### PR TITLE
KIN-251: Add EULA link to App Store metadata

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -24,6 +24,7 @@
         "NSLocationWhenInUseUsageDescription": "We use your location to look up nearby restaurants and addresses.",
         "ITSAppUsesNonExemptEncryption": false,
         "NSPrivacyPolicyURL": "https://beaker.notion.site/Kindred-Privacy-Policy-2afa5d52691580a7ac51d34b8e0f427a",
+        "NSTermsOfUseURL": "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/",
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": true,
           "NSExceptionDomains": {

--- a/frontend/store.config.json
+++ b/frontend/store.config.json
@@ -1,0 +1,39 @@
+{
+  "configVersion": 0,
+  "apple": {
+    "version": "0.0.1",
+    "copyright": "2025 Kindred",
+    "info": {
+      "en-US": {
+        "title": "Kindred Todo",
+        "subtitle": "Social Productivity",
+        "description": "Kindred is a to do list built on real intrinsic, sustainable motivation.\n\nTerms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/\nPrivacy Policy: https://beaker.notion.site/Kindred-Privacy-Policy-2afa5d52691580a7ac51d34b8e0f427a",
+        "keywords": [
+          "todo",
+          "to do list",
+          "tasks",
+          "productivity",
+          "motivation",
+          "habits",
+          "planner",
+          "organizer",
+          "reminders",
+          "goals"
+        ],
+        "supportUrl": "https://beaker.notion.site/Kindred-Privacy-Policy-2afa5d52691580a7ac51d34b8e0f427a",
+        "privacyPolicyUrl": "https://beaker.notion.site/Kindred-Privacy-Policy-2afa5d52691580a7ac51d34b8e0f427a",
+        "promoText": "A to-do list built on real motivation — not guilt, not streaks, just you."
+      }
+    },
+    "review": {
+      "firstName": "Abhik",
+      "lastName": "Ray",
+      "email": "bleubarryinc@gmail.com",
+      "phone": "6097751922",
+      "notes": "Terms of Use (EULA): https://www.apple.com/legal/internet-services/itunes/dev/stdeula/\nThis link is also included in the App Description.\n\nPrivacy Policy: https://beaker.notion.site/Kindred-Privacy-Policy-2afa5d52691580a7ac51d34b8e0f427a"
+    },
+    "release": {
+      "phasedRelease": true
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Added `NSTermsOfUseURL` to `ios.infoPlist` in `app.json`
- Created `store.config.json` (EAS Metadata) with app description, EULA/privacy links, subtitle, keywords, review notes, and reviewer contact info
- Addresses Apple's Guideline 3.1.2(c) rejection for missing Terms of Use link

## Manual Steps
- Run `eas metadata:push` to sync metadata to App Store Connect
- Add EULA link to subscription group in App Store Connect
- Reply to Apple Review confirming changes

## Test plan
- [ ] Verify `app.json` is valid JSON
- [ ] Verify `store.config.json` is valid JSON
- [ ] Run `eas metadata:push` successfully
- [ ] Confirm App Store description shows EULA link in App Store Connect