### PR TITLE
KIN-254: UGC content safeguards for Apple Guideline 1.2

### DIFF
--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -31,6 +31,7 @@ func newService(collections map[string]*mongo.Collection) *Service {
 		Categories:          collections["categories"],
 		Groups:              collections["groups"],
 		Connections:         collections["friend-requests"],
+		Reports:             collections["reports"],
 		NotificationService: notifications.NewNotificationService(collections),
 	}
 }
@@ -38,6 +39,68 @@ func newService(collections map[string]*mongo.Collection) *Service {
 // NewService is the exported version for testing
 func NewService(collections map[string]*mongo.Collection) *Service {
 	return newService(collections)
+}
+
+// GetReportedPostIDs returns IDs of all posts that have been reported by any user with pending or reviewed status
+func (s *Service) GetReportedPostIDs(ctx context.Context) ([]primitive.ObjectID, error) {
+	cursor, err := s.Reports.Find(ctx, bson.M{
+		"content_type": "post",
+		"status":       bson.M{"$in": []string{"pending", "reviewed"}},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query reported posts: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var reports []struct {
+		ContentID primitive.ObjectID `bson:"content_id"`
+	}
+	if err := cursor.All(ctx, &reports); err != nil {
+		return nil, fmt.Errorf("failed to decode reports: %w", err)
+	}
+
+	ids := make([]primitive.ObjectID, 0, len(reports))
+	for _, r := range reports {
+		ids = append(ids, r.ContentID)
+	}
+	return ids, nil
+}
+
+// GetUserReportedPostIDs returns IDs of posts reported by a specific user (any status)
+func (s *Service) GetUserReportedPostIDs(ctx context.Context, userID primitive.ObjectID) ([]primitive.ObjectID, error) {
+	cursor, err := s.Reports.Find(ctx, bson.M{
+		"reporter_id":  userID,
+		"content_type": "post",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query user reported posts: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var reports []struct {
+		ContentID primitive.ObjectID `bson:"content_id"`
+	}
+	if err := cursor.All(ctx, &reports); err != nil {
+		return nil, fmt.Errorf("failed to decode user reports: %w", err)
+	}
+
+	ids := make([]primitive.ObjectID, 0, len(reports))
+	for _, r := range reports {
+		ids = append(ids, r.ContentID)
+	}
+	return ids, nil
+}
+
+// GetUserSettings retrieves the display settings for a user
+func (s *Service) GetUserContentFilterEnabled(ctx context.Context, userID primitive.ObjectID) (bool, error) {
+	var user struct {
+		Settings types.UserSettings `bson:"settings"`
+	}
+	err := s.Users.FindOne(ctx, bson.M{"_id": userID}).Decode(&user)
+	if err != nil {
+		return false, err
+	}
+	return user.Settings.Display.ContentFilter, nil
 }
 
 // GetAllPosts fetches all Post documents from MongoDB with pagination
@@ -292,6 +355,45 @@ func (s *Service) GetFriendsPosts(userID primitive.ObjectID, limit, offset int) 
 		}
 	}
 
+	// Get post IDs that the current user has personally reported (always hidden)
+	userReportedIDs, err := s.GetUserReportedPostIDs(ctx, userID)
+	if err != nil {
+		slog.Warn("Failed to get user reported posts, continuing without filter", "error", err)
+		userReportedIDs = []primitive.ObjectID{}
+	}
+
+	// If content filter is enabled, also get all globally reported post IDs
+	contentFilterEnabled, err := s.GetUserContentFilterEnabled(ctx, userID)
+	if err != nil {
+		slog.Warn("Failed to get content filter setting, defaulting to enabled", "error", err)
+		contentFilterEnabled = true
+	}
+
+	var allReportedIDs []primitive.ObjectID
+	if contentFilterEnabled {
+		allReportedIDs, err = s.GetReportedPostIDs(ctx)
+		if err != nil {
+			slog.Warn("Failed to get reported posts, continuing without filter", "error", err)
+			allReportedIDs = []primitive.ObjectID{}
+		}
+	}
+
+	// Merge user-reported IDs and content-filter reported IDs into one exclusion set
+	excludedPostIDSet := make(map[primitive.ObjectID]struct{})
+	for _, id := range userReportedIDs {
+		excludedPostIDSet[id] = struct{}{}
+	}
+	for _, id := range allReportedIDs {
+		excludedPostIDSet[id] = struct{}{}
+	}
+	var excludedPostIDsArray bson.A
+	for id := range excludedPostIDSet {
+		excludedPostIDsArray = append(excludedPostIDsArray, id)
+	}
+	if excludedPostIDsArray == nil {
+		excludedPostIDsArray = bson.A{}
+	}
+
 	// Get user's groups to check group membership
 	userGroups, err := s.GetUserGroups(userID)
 	if err != nil {
@@ -355,6 +457,32 @@ func (s *Service) GetFriendsPosts(userID primitive.ObjectID, limit, offset int) 
 		},
 	})
 
+	// Build the common match conditions for both count and data pipelines
+	feedMatchConditions := []bson.M{
+		{"$eq": []interface{}{"$metadata.isDeleted", false}},
+		{
+			"$or": visibilityConditions,
+		},
+		// Filter out posts from blocked users
+		{
+			"$not": bson.M{
+				"$in": []interface{}{
+					bson.M{"$toObjectId": "$user._id"},
+					blockedUserIDsArray,
+				},
+			},
+		},
+	}
+
+	// Filter out reported posts (user's own reports + content filter)
+	if len(excludedPostIDsArray) > 0 {
+		feedMatchConditions = append(feedMatchConditions, bson.M{
+			"$not": bson.M{
+				"$in": []interface{}{"$_id", excludedPostIDsArray},
+			},
+		})
+	}
+
 	// First, get the total count of visible posts
 	countPipeline := mongo.Pipeline{
 		// Stage 1: Match the specific user
@@ -381,21 +509,7 @@ func (s *Service) GetFriendsPosts(userID primitive.ObjectID, limit, offset int) 
 				// Match posts that are not deleted and meet visibility criteria
 				{{Key: "$match", Value: bson.M{
 					"$expr": bson.M{
-						"$and": []bson.M{
-							{"$eq": []interface{}{"$metadata.isDeleted", false}},
-							{
-								"$or": visibilityConditions,
-							},
-							// Filter out posts from blocked users
-							{
-								"$not": bson.M{
-									"$in": []interface{}{
-										bson.M{"$toObjectId": "$user._id"},
-										blockedUserIDsArray,
-									},
-								},
-							},
-						},
+						"$and": feedMatchConditions,
 					},
 				}}},
 			},
@@ -454,21 +568,7 @@ func (s *Service) GetFriendsPosts(userID primitive.ObjectID, limit, offset int) 
 				// Match posts that are not deleted and meet visibility criteria
 				{{Key: "$match", Value: bson.M{
 					"$expr": bson.M{
-						"$and": []bson.M{
-							{"$eq": []interface{}{"$metadata.isDeleted", false}},
-							{
-								"$or": visibilityConditions,
-							},
-							// Filter out posts from blocked users
-							{
-								"$not": bson.M{
-									"$in": []interface{}{
-										bson.M{"$toObjectId": "$user._id"},
-										blockedUserIDsArray,
-									},
-								},
-							},
-						},
+						"$and": feedMatchConditions,
 					},
 				}}},
 				// Sort by creation date (newest first)

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -239,5 +239,6 @@ type Service struct {
 	Blueprints          *mongo.Collection
 	Groups              *mongo.Collection
 	Connections         *mongo.Collection
+	Reports             *mongo.Collection
 	NotificationService *notifications.Service
 }

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -308,6 +308,7 @@ type DisplaySettings struct {
 	RecentWorkspaces    bool `bson:"recent_workspaces" json:"recent_workspaces"`
 	FriendActivityFeed  bool `bson:"friend_activity_feed" json:"friend_activity_feed"`
 	NearDeadlinesWidget bool `bson:"near_deadlines_widget" json:"near_deadlines_widget"`
+	ContentFilter       bool `bson:"content_filter" json:"content_filter"`
 }
 
 // DefaultUserSettings returns default settings for new users
@@ -329,6 +330,7 @@ func DefaultUserSettings() UserSettings {
 			RecentWorkspaces:    true,
 			FriendActivityFeed:  true,
 			NearDeadlinesWidget: true,
+			ContentFilter:       true,
 		},
 	}
 }

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -4171,6 +4171,7 @@ export interface components {
             near_deadlines_widget: boolean;
             recent_workspaces: boolean;
             show_task_details: boolean;
+            content_filter: boolean;
         };
         EditResultResponse: {
             /**

--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -24,6 +24,9 @@ import { showToast } from "@/utils/showToast";
 import NotificationBadge from "@/components/NotificationBadge";
 import { PostCardSkeleton } from "@/components/ui/SkeletonLoader";
 import { HeartStraightIcon } from "phosphor-react-native";
+import TermsAcceptanceModal from "@/components/modals/TermsAcceptanceModal";
+import { useAuth } from "@/hooks/useAuth";
+import { acceptTerms } from "@/api/auth";
 const HORIZONTAL_PADDING = 16;
 
 type PostData = {
@@ -66,6 +69,8 @@ export default function Feed() {
     const insets = useSafeAreaInsets();
     const ThemedColor = useThemeColor();
     const styles = stylesheet(ThemedColor, insets);
+    const { user, updateUser } = useAuth();
+    const [showTermsModal, setShowTermsModal] = useState(false);
     const [showAnimatedHeader, setShowAnimatedHeader] = useState(false);
     const [refreshing, setRefreshing] = useState(false);
     const [posts, setPosts] = useState<PostData[]>([]);
@@ -299,6 +304,24 @@ export default function Feed() {
         initializeFeed();
         isInitialMount.current = false;
     }, []); // Only run once on mount
+
+    // Show terms modal if user hasn't accepted terms yet
+    useEffect(() => {
+        if (user && !user.terms_accepted_at) {
+            setShowTermsModal(true);
+        }
+    }, [user]);
+
+    const handleAcceptTerms = useCallback(async () => {
+        try {
+            await acceptTerms("1.0");
+            updateUser({ terms_accepted_at: new Date().toISOString() } as any);
+            setShowTermsModal(false);
+        } catch (error) {
+            console.error("Failed to accept terms:", error);
+            showToast("Failed to accept terms. Please try again.", "danger");
+        }
+    }, [updateUser]);
 
     // Load posts when feed changes (skip initial mount)
     useEffect(() => {
@@ -587,6 +610,10 @@ export default function Feed() {
 
     return (
         <View style={styles.container}>
+            <TermsAcceptanceModal
+                visible={showTermsModal}
+                onAccept={handleAcceptTerms}
+            />
             <Animated.View
                 style={[
                     styles.animatedHeader,

--- a/frontend/app/(logged-in)/(tabs)/(task)/settings.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/settings.tsx
@@ -44,6 +44,7 @@ export default function Settings() {
         nearDeadlines: true,
         showTaskDetails: true,
         recentWorkspaces: true,
+        contentFilter: true,
     });
 
     // Check-in frequency options
@@ -66,6 +67,7 @@ export default function Settings() {
                 nearDeadlines: userSettings.display?.near_deadlines_widget ?? true,
                 showTaskDetails: userSettings.display?.show_task_details ?? true,
                 recentWorkspaces: userSettings.display?.recent_workspaces ?? true,
+                contentFilter: userSettings.display?.content_filter ?? true,
             });
 
             // Map backend frequency to display format
@@ -113,6 +115,7 @@ export default function Settings() {
             nearDeadlines: 'near_deadlines_widget',
             showTaskDetails: 'show_task_details',
             recentWorkspaces: 'recent_workspaces',
+            contentFilter: 'content_filter',
         };
 
         updateSettings({
@@ -575,6 +578,14 @@ export default function Settings() {
                 </SettingsSection>
 
                 <SettingsSection title="PRIVACY & DATA">
+                    <SettingsCard>
+                        <SettingsToggleRow
+                            label="Content Filter"
+                            value={localSettings.contentFilter}
+                            onValueChange={() => handleToggle('contentFilter')}
+                            isLast
+                        />
+                    </SettingsCard>
                     <SettingsActionRow
                         label={`Phone Contacts${hasConsent === true ? ' — Enabled' : hasConsent === false ? ' — Disabled' : ''}`}
                         onPress={handleResetContactConsent}


### PR DESCRIPTION
## Summary
- Add `content_filter` toggle to `DisplaySettings` (on by default for new users)
- Filter reported posts from the feed: always hide posts the user personally reported, and hide all reported posts when content filter is enabled
- Wire the existing `TermsAcceptanceModal` into the feed — shown as a non-dismissible modal before users can access UGC if they haven't accepted terms
- Add Content Filter toggle to Settings UI under Privacy & Data section

## Test plan
- [ ] Enable content filter in settings → reported posts should not appear in feed
- [ ] Disable content filter → all posts appear (except from blocked users)
- [ ] Report a post → it disappears from reporter's feed immediately (regardless of content filter setting)
- [ ] Open app as new user → TermsAcceptanceModal shown before feed access
- [ ] Accept terms → modal dismissed, `terms_accepted_at` populated
- [ ] `cd backend && go build ./...` compiles cleanly