### PR TITLE
feat: enrich Sentry errors with request context

### DIFF
--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	Waitlist "github.com/abhikaboy/Kindred/internal/handlers/waitlist"
 	"github.com/abhikaboy/Kindred/internal/posthog"
 	"github.com/abhikaboy/Kindred/internal/xlog"
+	"github.com/abhikaboy/Kindred/internal/xsentry"
 
 	"log/slog"
 	"runtime/debug"
@@ -49,14 +50,9 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 		ErrorHandler: func(c *fiber.Ctx, err error) error {
 			slog.Error("FIBER ERROR", "error", err.Error(), "method", c.Method(), "path", c.Path())
 
-			if hub := sentry.CurrentHub(); hub.Client() != nil {
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetTag("method", c.Method())
-					scope.SetTag("path", c.Path())
-					scope.SetContext("request", map[string]interface{}{"ip": c.IP()})
-					hub.CaptureException(fmt.Errorf("fiber error on %s %s: %w", c.Method(), c.Path(), err))
-				})
-			}
+			// Use request-scoped hub from xsentry middleware (already has context)
+			hub := xsentry.GetHub(c)
+			hub.CaptureException(fmt.Errorf("fiber error on %s %s: %w", c.Method(), c.Path(), err))
 
 			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 		},
@@ -81,17 +77,19 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 				"stack", stack,
 			)
 
-			if hub := sentry.CurrentHub(); hub.Client() != nil {
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetTag("method", c.Method())
-					scope.SetTag("path", c.Path())
-					scope.SetContext("request", map[string]interface{}{"stack": stack, "ip": c.IP()})
-					scope.SetLevel(sentry.LevelFatal)
-					hub.RecoverWithContext(c.Context(), e)
-				})
-			}
+			// Use request-scoped hub — it already has request context
+			hub := xsentry.GetHub(c)
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("stack", stack)
+				scope.SetLevel(sentry.LevelFatal)
+				hub.RecoverWithContext(c.Context(), e)
+			})
 		},
 	}))
+
+	// Add Sentry request context middleware (after recovery, before auth)
+	app.Use(xsentry.FiberMiddleware())
+
 	app.Use(compress.New())
 
 	// Add CORS middleware

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -80,7 +80,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 			// Use request-scoped hub — it already has request context
 			hub := xsentry.GetHub(c)
 			hub.WithScope(func(scope *sentry.Scope) {
-				scope.SetExtra("stack", stack)
+				scope.SetContext("panic", map[string]interface{}{"stack": stack})
 				scope.SetLevel(sentry.LevelFatal)
 				hub.RecoverWithContext(c.Context(), e)
 			})

--- a/backend/internal/xsentry/middleware.go
+++ b/backend/internal/xsentry/middleware.go
@@ -57,7 +57,6 @@ func FiberMiddleware() fiber.Handler {
 
 		hub.ConfigureScope(func(scope *sentry.Scope) {
 			scope.SetTag("http.status_code", fmt.Sprintf("%d", statusCode))
-			scope.SetExtra("duration_ms", duration.Milliseconds())
 
 			// Enrich with user info if auth middleware set it
 			if userID, ok := c.Locals("user_id").(string); ok && userID != "" {
@@ -67,14 +66,19 @@ func FiberMiddleware() fiber.Handler {
 				scope.SetTag("user.timezone", timezone)
 			}
 
-			// Capture error response body for 4xx/5xx (truncated)
+			// Response context with duration and error body
+			responseCtx := map[string]interface{}{
+				"status_code": statusCode,
+				"duration_ms": duration.Milliseconds(),
+			}
 			if statusCode >= 400 {
 				body := string(c.Response().Body())
 				if len(body) > maxErrorBodyLen {
 					body = body[:maxErrorBodyLen] + "..."
 				}
-				scope.SetExtra("response_body", body)
+				responseCtx["body"] = body
 			}
+			scope.SetContext("response", responseCtx)
 		})
 
 		return err

--- a/backend/internal/xsentry/middleware.go
+++ b/backend/internal/xsentry/middleware.go
@@ -1,0 +1,92 @@
+package xsentry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	sentryHubContextKey = "sentry_hub"
+	maxErrorBodyLen     = 500
+)
+
+// FiberMiddleware returns Fiber middleware that creates a request-scoped
+// Sentry hub with rich context. Place it after panic recovery, before auth.
+//
+// Every slog.Error(ctx, ...) or sentry.GetHubFromContext(ctx).CaptureException()
+// during the request will automatically include the endpoint, user, and
+// request metadata set here.
+func FiberMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		hub := sentry.CurrentHub().Clone()
+		if hub.Client() == nil {
+			return c.Next()
+		}
+
+		startTime := time.Now()
+
+		// Set request context on the scope immediately (before handler runs)
+		hub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("http.method", c.Method())
+			scope.SetTag("http.route", c.Route().Path)
+			scope.SetContext("request", map[string]interface{}{
+				"ip":         c.IP(),
+				"user_agent": c.Get("User-Agent"),
+				"url":        c.OriginalURL(),
+				"method":     c.Method(),
+				"route":      c.Route().Path,
+			})
+		})
+
+		// Store hub in Go context so SentryHandler and handlers can use it
+		ctx := sentry.SetHubOnContext(c.UserContext(), hub)
+		c.SetUserContext(ctx)
+
+		// Also store in Fiber locals for the error handler / panic recovery
+		c.Locals(sentryHubContextKey, hub)
+
+		// Run the rest of the middleware chain + handler
+		err := c.Next()
+
+		// --- Post-handler enrichment ---
+		duration := time.Since(startTime)
+		statusCode := c.Response().StatusCode()
+
+		hub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("http.status_code", fmt.Sprintf("%d", statusCode))
+			scope.SetExtra("duration_ms", duration.Milliseconds())
+
+			// Enrich with user info if auth middleware set it
+			if userID, ok := c.Locals("user_id").(string); ok && userID != "" {
+				scope.SetUser(sentry.User{ID: userID})
+			}
+			if timezone, ok := c.Locals("timezone").(string); ok && timezone != "" {
+				scope.SetTag("user.timezone", timezone)
+			}
+
+			// Capture error response body for 4xx/5xx (truncated)
+			if statusCode >= 400 {
+				body := string(c.Response().Body())
+				if len(body) > maxErrorBodyLen {
+					body = body[:maxErrorBodyLen] + "..."
+				}
+				scope.SetExtra("response_body", body)
+			}
+		})
+
+		return err
+	}
+}
+
+// GetHub retrieves the request-scoped Sentry hub from Fiber locals.
+// Use this in Fiber error handlers or panic recovery where you have
+// the Fiber context but not the Go context.
+func GetHub(c *fiber.Ctx) *sentry.Hub {
+	if hub, ok := c.Locals(sentryHubContextKey).(*sentry.Hub); ok {
+		return hub
+	}
+	return sentry.CurrentHub()
+}

--- a/backend/internal/xslog/sentry.go
+++ b/backend/internal/xslog/sentry.go
@@ -34,7 +34,7 @@ func (h *SentryHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	// Only forward ERROR and above to Sentry.
 	if r.Level >= slog.LevelError {
-		h.reportToSentry(r)
+		h.reportToSentry(ctx, r)
 	}
 
 	return err
@@ -56,8 +56,12 @@ func (h *SentryHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-func (h *SentryHandler) reportToSentry(r slog.Record) {
-	hub := sentry.CurrentHub()
+func (h *SentryHandler) reportToSentry(ctx context.Context, r slog.Record) {
+	// Try request-scoped hub first, fall back to global hub
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
 	if hub.Client() == nil {
 		return
 	}


### PR DESCRIPTION
## Summary
- **New `xsentry.FiberMiddleware()`** creates request-scoped Sentry hubs with rich context on every request — endpoint, user, IP, duration, status code, error response body
- **Updated `SentryHandler`** to use request-scoped hub from `ctx` instead of global hub — every `slog.Error(ctx, ...)` now automatically inherits request context
- **Simplified** Fiber error handler and panic recovery — they now use `xsentry.GetHub(c)` instead of manually rebuilding scope context

### What Sentry events look like now
Every error automatically includes:
- **Tags**: `http.method`, `http.route` (pattern), `http.status_code`, `user.timezone`
- **User**: ID (when authenticated)
- **Request context**: URL, method, IP, user-agent, route pattern
- **Response context**: status code, duration (ms), error body (4xx/5xx only, truncated)

Works on all routes — authenticated, unauthenticated, and auth failures.

## Test plan
- [ ] Deploy to staging and trigger known errors
- [ ] Verify Sentry events show request context (method, route, IP, user-agent)
- [ ] Verify authenticated requests include user ID
- [ ] Verify unauthenticated routes still get request context (minus user)
- [ ] Verify 4xx/5xx responses include truncated response body
- [ ] Verify panic recovery still works with stack traces in Sentry