### PR TITLE
Add test phone bypass for Apple review

### DIFF
--- a/backend/internal/handlers/auth/service.go
+++ b/backend/internal/handlers/auth/service.go
@@ -19,6 +19,12 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+// Test account for Apple App Store review — bypasses Sinch SMS verification
+const (
+	testReviewPhone = "+15551234567"
+	testReviewOTP   = "1234"
+)
+
 /*
 Health Service to be used by Health Handler to interact with the
 Database layer of the application
@@ -528,6 +534,10 @@ func min(a, b int) int {
 */
 
 func (s *Service) SendOTP(ctx context.Context, phoneNumber string) (string, error) {
+	if phoneNumber == testReviewPhone {
+		slog.Info("Test review phone detected, skipping Sinch OTP send", "phone", phoneNumber)
+		return "test-verification-id", nil
+	}
 	return s.sendOTPAsync(ctx, phoneNumber)
 }
 
@@ -538,6 +548,10 @@ func (s *Service) SendOTP(ctx context.Context, phoneNumber string) (string, erro
 */
 
 func (s *Service) VerifyOTP(ctx context.Context, phoneNumber string, code string) (bool, string, error) {
+	if phoneNumber == testReviewPhone && code == testReviewOTP {
+		slog.Info("Test review phone OTP verified via bypass", "phone", phoneNumber)
+		return true, "SUCCESSFUL", nil
+	}
 	return s.verifyOTPAsync(ctx, phoneNumber, code)
 }
 


### PR DESCRIPTION
## Summary
- Adds a hardcoded test phone number (`+15551234567`) and OTP code (`1234`) that bypasses Sinch SMS verification
- When `SendOTP` is called with the test number, it returns a fake verification ID without hitting Sinch
- When `VerifyOTP` is called with the test number + code `1234`, it returns success without hitting Sinch
- All other phone numbers continue to use real Sinch verification

## Apple Review Credentials
- **Phone:** +1 (555) 123-4567
- **OTP Code:** 1234

## Setup after merge
1. Open app, register with phone `+15551234567`
2. Enter OTP `1234`
3. Complete onboarding

## Test plan
- [ ] Register with test phone number — should bypass SMS
- [ ] Login with test phone + OTP `1234` — should succeed
- [ ] Login with test phone + wrong OTP — should fail
- [ ] Login with real phone number — should still go through Sinch