### PR TITLE
feat: undoable task delete with rolling batch undo

### DIFF
--- a/backend/internal/handlers/auth/auth.go
+++ b/backend/internal/handlers/auth/auth.go
@@ -29,37 +29,15 @@ func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutpu
 		return nil, huma.Error401Unauthorized("Invalid email or password", err)
 	}
 
-	// Use user's timezone, default to UTC if not set
-	timezone := user.Timezone
-	if timezone == "" {
-		timezone = "UTC"
-	}
-
-	access, refresh, err := h.service.GenerateTokens(id.Hex(), *count, timezone)
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
-	resp.AccessToken = access
-	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
-
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
 	return resp, nil
 }
 
@@ -76,37 +54,15 @@ func (h *Handler) LoginWithPhoneHuma(ctx context.Context, input *LoginWithPhoneI
 		return nil, huma.Error401Unauthorized("Invalid phone number or password", err)
 	}
 
-	// Use user's timezone, default to UTC if not set
-	timezone := user.Timezone
-	if timezone == "" {
-		timezone = "UTC"
-	}
-
-	access, refresh, err := h.service.GenerateTokens(id.Hex(), *count, timezone)
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
-	resp.AccessToken = access
-	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
-
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
 	return resp, nil
 }
 
@@ -165,37 +121,15 @@ func (h *Handler) LoginWithGoogleHuma(ctx context.Context, input *LoginWithGoogl
 		return nil, huma.Error401Unauthorized("Unable to sign in with Google. Please try again.", err)
 	}
 
-	// Use user's timezone, default to UTC if not set
-	timezone := user.Timezone
-	if timezone == "" {
-		timezone = "UTC"
-	}
-
-	access, refresh, err := h.service.GenerateTokens(id.Hex(), *count, timezone)
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
-	resp.AccessToken = access
-	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
-
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
 	return resp, nil
 }
 
@@ -398,22 +332,7 @@ func (h *Handler) RegisterWithContext(ctx context.Context, input *RegisterInput)
 	resp := &RegisterOutput{}
 	resp.AccessToken = access
 	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
+	resp.Body = buildSafeUserResponse(&user)
 
 	return resp, nil
 }
@@ -431,37 +350,15 @@ func (h *Handler) LoginWithAppleHuma(ctx context.Context, input *LoginWithAppleI
 		return nil, huma.Error401Unauthorized("Unable to sign in with Apple. Please try again.", err)
 	}
 
-	// Use user's timezone, default to UTC if not set
-	timezone := user.Timezone
-	if timezone == "" {
-		timezone = "UTC"
-	}
-
-	access, refresh, err := h.service.GenerateTokens(id.Hex(), *count, timezone)
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
-	resp.AccessToken = access
-	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
-
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
 	return resp, nil
 }
 
@@ -648,39 +545,17 @@ func (h *Handler) LoginWithOTPHuma(ctx context.Context, input *LoginWithOTPInput
 		return nil, huma.Error404NotFound("No account found with this phone number. Please sign up first.", err)
 	}
 
-	// Step 3: Use user's timezone, default to UTC if not set
-	timezone := user.Timezone
-	if timezone == "" {
-		timezone = "UTC"
-	}
-
-	// Step 4: Generate tokens
-	access, refresh, err := h.service.GenerateTokens(id.Hex(), *count, timezone)
+	// Step 3: Generate tokens and build response
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		slog.Error("Token generation failed during OTP login", "error", err, "user_id", id.Hex())
 		return nil, huma.Error500InternalServerError("Token generation failed", err)
 	}
 
-	// Step 5: Build response
 	resp := &LoginWithOTPOutput{}
-	resp.AccessToken = access
-	resp.RefreshToken = refresh
-	resp.Body = types.SafeUser{
-		ID:              user.ID,
-		DisplayName:     user.DisplayName,
-		Handle:          user.Handle,
-		ProfilePicture:  user.ProfilePicture,
-		Categories:      user.Categories,
-		Friends:         user.Friends,
-		TasksComplete:   user.TasksComplete,
-		RecentActivity:  user.RecentActivity,
-		Encouragements:  user.Encouragements,
-		Congratulations: user.Congratulations,
-		Streak:          user.Streak,
-		StreakEligible:  user.StreakEligible,
-		Points:          user.Points,
-		PostsMade:       user.PostsMade,
-	}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
 
 	slog.Info("OTP login successful", "user_id", id.Hex(), "phone", input.Body.PhoneNumber)
 	return resp, nil

--- a/backend/internal/handlers/auth/helpers.go
+++ b/backend/internal/handlers/auth/helpers.go
@@ -1,0 +1,24 @@
+package auth
+
+import "github.com/abhikaboy/Kindred/internal/handlers/types"
+
+// buildSafeUserResponse converts a full User to a SafeUser for API responses.
+// This is the single source of truth for the user fields exposed in login/register responses.
+func buildSafeUserResponse(user *User) types.SafeUser {
+	return types.SafeUser{
+		ID:              user.ID,
+		DisplayName:     user.DisplayName,
+		Handle:          user.Handle,
+		ProfilePicture:  user.ProfilePicture,
+		Categories:      user.Categories,
+		Friends:         user.Friends,
+		TasksComplete:   user.TasksComplete,
+		RecentActivity:  user.RecentActivity,
+		Encouragements:  user.Encouragements,
+		Congratulations: user.Congratulations,
+		Streak:          user.Streak,
+		StreakEligible:  user.StreakEligible,
+		Points:          user.Points,
+		PostsMade:       user.PostsMade,
+	}
+}

--- a/backend/internal/handlers/auth/helpers.go
+++ b/backend/internal/handlers/auth/helpers.go
@@ -2,6 +2,31 @@ package auth
 
 import "github.com/abhikaboy/Kindred/internal/handlers/types"
 
+// timezoneOrDefault returns the timezone string, defaulting to "UTC" if empty.
+func timezoneOrDefault(tz string) string {
+	if tz == "" {
+		return "UTC"
+	}
+	return tz
+}
+
+// completeLogin generates tokens and builds the auth response for a successful login.
+// This is the shared tail for all LoginWith* handler methods.
+func completeLogin(service *Service, userID string, count float64, user *User) (*AuthResult, error) {
+	timezone := timezoneOrDefault(user.Timezone)
+
+	access, refresh, err := service.GenerateTokens(userID, count, timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthResult{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		User:         buildSafeUserResponse(user),
+	}, nil
+}
+
 // buildSafeUserResponse converts a full User to a SafeUser for API responses.
 // This is the single source of truth for the user fields exposed in login/register responses.
 func buildSafeUserResponse(user *User) types.SafeUser {

--- a/backend/internal/handlers/auth/helpers_test.go
+++ b/backend/internal/handlers/auth/helpers_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestBuildSafeUserResponse(t *testing.T) {
+	userID := primitive.NewObjectID()
+	user := &User{
+		ID:              userID,
+		DisplayName:     "Test User",
+		Handle:          "testuser",
+		ProfilePicture:  "https://example.com/pic.jpg",
+		Categories:      []types.CategoryDocument{{Name: "Work"}},
+		Friends:         []primitive.ObjectID{primitive.NewObjectID()},
+		TasksComplete:   5,
+		RecentActivity:  []types.ActivityDocument{},
+		Encouragements:  2,
+		Congratulations: 2,
+		Streak:          3,
+		StreakEligible:  true,
+		Points:          100,
+		PostsMade:       10,
+	}
+
+	result := buildSafeUserResponse(user)
+
+	assert.Equal(t, userID, result.ID)
+	assert.Equal(t, "Test User", result.DisplayName)
+	assert.Equal(t, "testuser", result.Handle)
+	assert.Equal(t, "https://example.com/pic.jpg", result.ProfilePicture)
+	assert.Equal(t, 1, len(result.Categories))
+	assert.Equal(t, 1, len(result.Friends))
+	assert.Equal(t, float64(5), result.TasksComplete)
+	assert.Equal(t, 2, result.Encouragements)
+	assert.Equal(t, 2, result.Congratulations)
+	assert.Equal(t, 3, result.Streak)
+	assert.True(t, result.StreakEligible)
+	assert.Equal(t, 100, result.Points)
+	assert.Equal(t, 10, result.PostsMade)
+}

--- a/backend/internal/handlers/auth/helpers_test.go
+++ b/backend/internal/handlers/auth/helpers_test.go
@@ -8,6 +8,14 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
+func TestTimezoneOrDefault_Empty(t *testing.T) {
+	assert.Equal(t, "UTC", timezoneOrDefault(""))
+}
+
+func TestTimezoneOrDefault_Set(t *testing.T) {
+	assert.Equal(t, "America/New_York", timezoneOrDefault("America/New_York"))
+}
+
 func TestBuildSafeUserResponse(t *testing.T) {
 	userID := primitive.NewObjectID()
 	user := &User{

--- a/backend/internal/handlers/auth/service.go
+++ b/backend/internal/handlers/auth/service.go
@@ -111,83 +111,67 @@ func (s *Service) ValidateToken(token string) (string, float64, string, error) {
 	return idString, tokenCount, timezone, nil
 }
 
-func (s *Service) LoginFromCredentials(email string, password string) (*primitive.ObjectID, *float64, *User, error) {
-
+// findByField is the private implementation detail for typed user lookups.
+func (s *Service) findByField(field string, value string) (*User, error) {
 	var user User
-	err := s.users.FindOne(context.Background(), bson.M{"email": email}).Decode(&user)
+	err := s.users.FindOne(context.Background(), bson.M{field: value}).Decode(&user)
 	if errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+		return nil, fiber.NewError(404, "Account does not exist")
 	}
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (s *Service) LoginFromCredentials(email string, password string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("email", email)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
 	// Compare the hashed password with the provided password
 	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
 	if err != nil {
 		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
 	}
-
-	return &user.ID, &user.Count, &user, nil
+	return &user.ID, &user.Count, user, nil
 }
 
 func (s *Service) LoginFromPhone(phoneNumber string, password string) (*primitive.ObjectID, *float64, *User, error) {
-
-	var user User
-	err := s.users.FindOne(context.Background(), bson.M{"phone": phoneNumber}).Decode(&user)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, nil, nil, fiber.NewError(404, "Account does not exist")
-	}
+	user, err := s.findByField("phone", phoneNumber)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-
 	// Compare the hashed password with the provided password
 	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
 	if err != nil {
 		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
 	}
-
-	return &user.ID, &user.Count, &user, nil
+	return &user.ID, &user.Count, user, nil
 }
 
 func (s *Service) LoginFromApple(apple_id string) (*primitive.ObjectID, *float64, *User, error) {
-
-	var user User
-	err := s.users.FindOne(context.Background(), bson.M{"apple_id": apple_id}).Decode(&user)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, nil, nil, fiber.NewError(404, "Account does not exist, Try to register")
-	}
+	user, err := s.findByField("apple_id", apple_id)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return &user.ID, &user.Count, &user, nil
+	return &user.ID, &user.Count, user, nil
 }
 
 func (s *Service) LoginFromGoogle(google_id string) (*primitive.ObjectID, *float64, *User, error) {
-
-	var user User
-	err := s.users.FindOne(context.Background(), bson.M{"google_id": google_id}).Decode(&user)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, nil, nil, fiber.NewError(404, "Account does not exist, Try to register")
-	}
+	user, err := s.findByField("google_id", google_id)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return &user.ID, &user.Count, &user, nil
+	return &user.ID, &user.Count, user, nil
 }
 
 func (s *Service) LoginFromPhoneOTP(phone_number string) (*primitive.ObjectID, *float64, *User, error) {
-
-	var user User
-	err := s.users.FindOne(context.Background(), bson.M{"phone": phone_number}).Decode(&user)
-	if errors.Is(err, mongo.ErrNoDocuments) {
-		return nil, nil, nil, fiber.NewError(404, "Account does not exist, Try to register")
-	}
+	user, err := s.findByField("phone", phone_number)
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	return &user.ID, &user.Count, &user, nil
+	return &user.ID, &user.Count, user, nil
 }
 
 func (s *Service) InvalidateTokens(user_id string) error {

--- a/backend/internal/handlers/auth/types.go
+++ b/backend/internal/handlers/auth/types.go
@@ -109,3 +109,16 @@ type LoginWithOTPRequest struct {
 	PhoneNumber string `validate:"required" json:"phone_number"`
 	Code        string `validate:"required" json:"code"`
 }
+
+// AuthResult is the unified return type for all login/register flows.
+type AuthResult struct {
+	AccessToken  string
+	RefreshToken string
+	User         types.SafeUser
+}
+
+// OAuthProvider identifies an OAuth provider for registration.
+type OAuthProvider struct {
+	Type string // "google" or "apple"
+	ID   string
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -29,6 +29,7 @@ import (
 	Waitlist "github.com/abhikaboy/Kindred/internal/handlers/waitlist"
 	"github.com/abhikaboy/Kindred/internal/posthog"
 	"github.com/abhikaboy/Kindred/internal/xlog"
+	"github.com/abhikaboy/Kindred/internal/xsentry"
 
 	"log/slog"
 	"runtime/debug"
@@ -49,14 +50,9 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 		ErrorHandler: func(c *fiber.Ctx, err error) error {
 			slog.Error("FIBER ERROR", "error", err.Error(), "method", c.Method(), "path", c.Path())
 
-			if hub := sentry.CurrentHub(); hub.Client() != nil {
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetTag("method", c.Method())
-					scope.SetTag("path", c.Path())
-					scope.SetContext("request", map[string]interface{}{"ip": c.IP()})
-					hub.CaptureException(fmt.Errorf("fiber error on %s %s: %w", c.Method(), c.Path(), err))
-				})
-			}
+			// Use request-scoped hub from xsentry middleware (already has context)
+			hub := xsentry.GetHub(c)
+			hub.CaptureException(fmt.Errorf("fiber error on %s %s: %w", c.Method(), c.Path(), err))
 
 			return c.Status(500).JSON(fiber.Map{"error": err.Error()})
 		},
@@ -81,17 +77,19 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 				"stack", stack,
 			)
 
-			if hub := sentry.CurrentHub(); hub.Client() != nil {
-				hub.WithScope(func(scope *sentry.Scope) {
-					scope.SetTag("method", c.Method())
-					scope.SetTag("path", c.Path())
-					scope.SetContext("request", map[string]interface{}{"stack": stack, "ip": c.IP()})
-					scope.SetLevel(sentry.LevelFatal)
-					hub.RecoverWithContext(c.Context(), e)
-				})
-			}
+			// Use request-scoped hub — it already has request context
+			hub := xsentry.GetHub(c)
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetExtra("stack", stack)
+				scope.SetLevel(sentry.LevelFatal)
+				hub.RecoverWithContext(c.Context(), e)
+			})
 		},
 	}))
+
+	// Add Sentry request context middleware (after recovery, before auth)
+	app.Use(xsentry.FiberMiddleware())
+
 	app.Use(compress.New())
 
 	// Add CORS middleware

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -80,7 +80,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 			// Use request-scoped hub — it already has request context
 			hub := xsentry.GetHub(c)
 			hub.WithScope(func(scope *sentry.Scope) {
-				scope.SetExtra("stack", stack)
+				scope.SetContext("panic", map[string]interface{}{"stack": stack})
 				scope.SetLevel(sentry.LevelFatal)
 				hub.RecoverWithContext(c.Context(), e)
 			})

--- a/backend/internal/xsentry/middleware.go
+++ b/backend/internal/xsentry/middleware.go
@@ -57,7 +57,6 @@ func FiberMiddleware() fiber.Handler {
 
 		hub.ConfigureScope(func(scope *sentry.Scope) {
 			scope.SetTag("http.status_code", fmt.Sprintf("%d", statusCode))
-			scope.SetExtra("duration_ms", duration.Milliseconds())
 
 			// Enrich with user info if auth middleware set it
 			if userID, ok := c.Locals("user_id").(string); ok && userID != "" {
@@ -67,14 +66,19 @@ func FiberMiddleware() fiber.Handler {
 				scope.SetTag("user.timezone", timezone)
 			}
 
-			// Capture error response body for 4xx/5xx (truncated)
+			// Response context with duration and error body
+			responseCtx := map[string]interface{}{
+				"status_code": statusCode,
+				"duration_ms": duration.Milliseconds(),
+			}
 			if statusCode >= 400 {
 				body := string(c.Response().Body())
 				if len(body) > maxErrorBodyLen {
 					body = body[:maxErrorBodyLen] + "..."
 				}
-				scope.SetExtra("response_body", body)
+				responseCtx["body"] = body
 			}
+			scope.SetContext("response", responseCtx)
 		})
 
 		return err

--- a/backend/internal/xsentry/middleware.go
+++ b/backend/internal/xsentry/middleware.go
@@ -1,0 +1,92 @@
+package xsentry
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gofiber/fiber/v2"
+)
+
+const (
+	sentryHubContextKey = "sentry_hub"
+	maxErrorBodyLen     = 500
+)
+
+// FiberMiddleware returns Fiber middleware that creates a request-scoped
+// Sentry hub with rich context. Place it after panic recovery, before auth.
+//
+// Every slog.Error(ctx, ...) or sentry.GetHubFromContext(ctx).CaptureException()
+// during the request will automatically include the endpoint, user, and
+// request metadata set here.
+func FiberMiddleware() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		hub := sentry.CurrentHub().Clone()
+		if hub.Client() == nil {
+			return c.Next()
+		}
+
+		startTime := time.Now()
+
+		// Set request context on the scope immediately (before handler runs)
+		hub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("http.method", c.Method())
+			scope.SetTag("http.route", c.Route().Path)
+			scope.SetContext("request", map[string]interface{}{
+				"ip":         c.IP(),
+				"user_agent": c.Get("User-Agent"),
+				"url":        c.OriginalURL(),
+				"method":     c.Method(),
+				"route":      c.Route().Path,
+			})
+		})
+
+		// Store hub in Go context so SentryHandler and handlers can use it
+		ctx := sentry.SetHubOnContext(c.UserContext(), hub)
+		c.SetUserContext(ctx)
+
+		// Also store in Fiber locals for the error handler / panic recovery
+		c.Locals(sentryHubContextKey, hub)
+
+		// Run the rest of the middleware chain + handler
+		err := c.Next()
+
+		// --- Post-handler enrichment ---
+		duration := time.Since(startTime)
+		statusCode := c.Response().StatusCode()
+
+		hub.ConfigureScope(func(scope *sentry.Scope) {
+			scope.SetTag("http.status_code", fmt.Sprintf("%d", statusCode))
+			scope.SetExtra("duration_ms", duration.Milliseconds())
+
+			// Enrich with user info if auth middleware set it
+			if userID, ok := c.Locals("user_id").(string); ok && userID != "" {
+				scope.SetUser(sentry.User{ID: userID})
+			}
+			if timezone, ok := c.Locals("timezone").(string); ok && timezone != "" {
+				scope.SetTag("user.timezone", timezone)
+			}
+
+			// Capture error response body for 4xx/5xx (truncated)
+			if statusCode >= 400 {
+				body := string(c.Response().Body())
+				if len(body) > maxErrorBodyLen {
+					body = body[:maxErrorBodyLen] + "..."
+				}
+				scope.SetExtra("response_body", body)
+			}
+		})
+
+		return err
+	}
+}
+
+// GetHub retrieves the request-scoped Sentry hub from Fiber locals.
+// Use this in Fiber error handlers or panic recovery where you have
+// the Fiber context but not the Go context.
+func GetHub(c *fiber.Ctx) *sentry.Hub {
+	if hub, ok := c.Locals(sentryHubContextKey).(*sentry.Hub); ok {
+		return hub
+	}
+	return sentry.CurrentHub()
+}

--- a/backend/internal/xslog/sentry.go
+++ b/backend/internal/xslog/sentry.go
@@ -34,7 +34,7 @@ func (h *SentryHandler) Handle(ctx context.Context, r slog.Record) error {
 
 	// Only forward ERROR and above to Sentry.
 	if r.Level >= slog.LevelError {
-		h.reportToSentry(r)
+		h.reportToSentry(ctx, r)
 	}
 
 	return err
@@ -56,8 +56,12 @@ func (h *SentryHandler) WithGroup(name string) slog.Handler {
 	}
 }
 
-func (h *SentryHandler) reportToSentry(r slog.Record) {
-	hub := sentry.CurrentHub()
+func (h *SentryHandler) reportToSentry(ctx context.Context, r slog.Record) {
+	// Try request-scoped hub first, fall back to global hub
+	hub := sentry.GetHubFromContext(ctx)
+	if hub == nil {
+		hub = sentry.CurrentHub()
+	}
 	if hub.Client() == nil {
 		return
 	}

--- a/docs/superpowers/plans/2026-05-06-backend-refactor.md
+++ b/docs/superpowers/plans/2026-05-06-backend-refactor.md
@@ -1,0 +1,1627 @@
+# Backend Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Consolidate auth duplication, split the oversized task service/handler, extract shared validation from bulk ops, and introduce repository interfaces with shared MongoDB helpers for the auth and task packages.
+
+**Architecture:** Four phases executed sequentially: (1) Auth consolidation behind an `AuthenticationService` interface with shared helpers, (2) File-level split of the task package into domain-focused files, (3) Shared helper extraction from bulk operations, (4) Repository interfaces in `internal/repository/` with MongoDB implementations and migration of auth + task services. Each phase is independently shippable and verified by the existing test suite.
+
+**Tech Stack:** Go 1.25, Huma v2, Fiber v2, MongoDB driver, testify, bcrypt, JWT
+
+**Module:** `github.com/abhikaboy/Kindred`
+
+**Spec:** `docs/superpowers/specs/2026-05-06-backend-refactor-design.md`
+
+---
+
+## Phase 1: Auth Consolidation
+
+### Task 1: Add `AuthResult` type and `buildSafeUserResponse` helper
+
+**Files:**
+- Modify: `internal/handlers/auth/types.go`
+- Create: `internal/handlers/auth/helpers.go`
+- Create: `internal/handlers/auth/helpers_test.go`
+
+- [ ] **Step 1: Write test for `buildSafeUserResponse`**
+
+Create `internal/handlers/auth/helpers_test.go`:
+
+```go
+package auth
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestBuildSafeUserResponse(t *testing.T) {
+	userID := primitive.NewObjectID()
+	user := &User{
+		ID:              userID,
+		DisplayName:     "Test User",
+		Handle:          "testuser",
+		ProfilePicture:  "https://example.com/pic.jpg",
+		Categories:      []types.CategoryDocument{{Name: "Work"}},
+		Friends:         []primitive.ObjectID{primitive.NewObjectID()},
+		TasksComplete:   5,
+		RecentActivity:  []types.ActivityDocument{},
+		Encouragements:  2,
+		Congratulations: 2,
+		Streak:          3,
+		StreakEligible:  true,
+		Points:          100,
+		PostsMade:       10,
+	}
+
+	result := buildSafeUserResponse(user)
+
+	assert.Equal(t, userID, result.ID)
+	assert.Equal(t, "Test User", result.DisplayName)
+	assert.Equal(t, "testuser", result.Handle)
+	assert.Equal(t, "https://example.com/pic.jpg", result.ProfilePicture)
+	assert.Equal(t, 1, len(result.Categories))
+	assert.Equal(t, 1, len(result.Friends))
+	assert.Equal(t, 5, result.TasksComplete)
+	assert.Equal(t, 2, result.Encouragements)
+	assert.Equal(t, 2, result.Congratulations)
+	assert.Equal(t, 3, result.Streak)
+	assert.True(t, result.StreakEligible)
+	assert.Equal(t, 100, result.Points)
+	assert.Equal(t, 10, result.PostsMade)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -run TestBuildSafeUserResponse -v`
+Expected: FAIL — `buildSafeUserResponse` not defined
+
+- [ ] **Step 3: Add `AuthResult` to types.go and create helpers.go**
+
+Add to `internal/handlers/auth/types.go` after the `LoginWithOTPRequest` struct (after line 111):
+
+```go
+// AuthResult is the unified return type for all login/register flows.
+type AuthResult struct {
+	AccessToken  string
+	RefreshToken string
+	User         types.SafeUser
+}
+
+// OAuthProvider identifies an OAuth provider for registration.
+type OAuthProvider struct {
+	Type string // "google" or "apple"
+	ID   string
+}
+```
+
+Create `internal/handlers/auth/helpers.go`:
+
+```go
+package auth
+
+import "github.com/abhikaboy/Kindred/internal/handlers/types"
+
+// buildSafeUserResponse converts a full User to a SafeUser for API responses.
+// This is the single source of truth for the user fields exposed in login/register responses.
+func buildSafeUserResponse(user *User) types.SafeUser {
+	return types.SafeUser{
+		ID:              user.ID,
+		DisplayName:     user.DisplayName,
+		Handle:          user.Handle,
+		ProfilePicture:  user.ProfilePicture,
+		Categories:      user.Categories,
+		Friends:         user.Friends,
+		TasksComplete:   user.TasksComplete,
+		RecentActivity:  user.RecentActivity,
+		Encouragements:  user.Encouragements,
+		Congratulations: user.Congratulations,
+		Streak:          user.Streak,
+		StreakEligible:  user.StreakEligible,
+		Points:          user.Points,
+		PostsMade:       user.PostsMade,
+	}
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -run TestBuildSafeUserResponse -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full auth test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/auth/helpers.go internal/handlers/auth/helpers_test.go internal/handlers/auth/types.go
+git commit -m "refactor(auth): extract buildSafeUserResponse helper and AuthResult type"
+```
+
+---
+
+### Task 2: Add `completeLogin` helper and wire into login handlers
+
+**Files:**
+- Modify: `internal/handlers/auth/helpers.go`
+- Modify: `internal/handlers/auth/helpers_test.go`
+- Modify: `internal/handlers/auth/auth.go`
+
+- [ ] **Step 1: Write test for `completeLogin`**
+
+Append to `internal/handlers/auth/helpers_test.go`:
+
+```go
+func TestCompleteLogin_DefaultsTimezoneToUTC(t *testing.T) {
+	user := &User{
+		ID:       primitive.NewObjectID(),
+		Timezone: "",
+	}
+	tz := timezoneOrDefault(user.Timezone)
+	assert.Equal(t, "UTC", tz)
+}
+
+func TestCompleteLogin_UsesUserTimezone(t *testing.T) {
+	user := &User{
+		ID:       primitive.NewObjectID(),
+		Timezone: "America/New_York",
+	}
+	tz := timezoneOrDefault(user.Timezone)
+	assert.Equal(t, "America/New_York", tz)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -run TestCompleteLogin -v`
+Expected: FAIL — `timezoneOrDefault` not defined
+
+- [ ] **Step 3: Add `completeLogin` and `timezoneOrDefault` to helpers.go**
+
+Add to `internal/handlers/auth/helpers.go`:
+
+```go
+// timezoneOrDefault returns the timezone string, defaulting to "UTC" if empty.
+func timezoneOrDefault(tz string) string {
+	if tz == "" {
+		return "UTC"
+	}
+	return tz
+}
+
+// completeLogin generates tokens and builds the auth response for a successful login.
+// This is the shared tail for all LoginWith* handler methods.
+func completeLogin(service *Service, userID string, count float64, user *User) (*AuthResult, error) {
+	timezone := timezoneOrDefault(user.Timezone)
+
+	access, refresh, err := service.GenerateTokens(userID, count, timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AuthResult{
+		AccessToken:  access,
+		RefreshToken: refresh,
+		User:         buildSafeUserResponse(user),
+	}, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -run TestCompleteLogin -v`
+Expected: PASS
+
+- [ ] **Step 5: Refactor `LoginHuma` to use helpers**
+
+Replace the body of `LoginHuma` in `auth.go` (lines 20-63) with:
+
+```go
+func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutput, error) {
+	errs := xvalidator.Validator.Validate(input.Body)
+	if len(errs) > 0 {
+		return nil, huma.Error400BadRequest("Please check your email and password", fmt.Errorf("validation errors: %v", errs))
+	}
+
+	id, count, user, err := h.service.LoginFromCredentials(input.Body.Email, input.Body.Password)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Invalid email or password", err)
+	}
+
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+	}
+
+	resp := &LoginOutput{}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
+	return resp, nil
+}
+```
+
+- [ ] **Step 6: Refactor `LoginWithPhoneHuma` (lines 67-111)**
+
+```go
+func (h *Handler) LoginWithPhoneHuma(ctx context.Context, input *LoginWithPhoneInput) (*LoginOutput, error) {
+	errs := xvalidator.Validator.Validate(input.Body)
+	if len(errs) > 0 {
+		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+	}
+
+	id, count, user, err := h.service.LoginFromPhone(input.Body.PhoneNumber, input.Body.Password)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Invalid phone number or password", err)
+	}
+
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+	}
+
+	resp := &LoginOutput{}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
+	return resp, nil
+}
+```
+
+- [ ] **Step 7: Refactor `LoginWithGoogleHuma` (lines 156-200)**
+
+```go
+func (h *Handler) LoginWithGoogleHuma(ctx context.Context, input *LoginWithGoogleInput) (*LoginOutput, error) {
+	errs := xvalidator.Validator.Validate(input.Body)
+	if len(errs) > 0 {
+		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+	}
+
+	id, count, user, err := h.service.LoginFromGoogle(input.Body.GoogleID)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Unable to sign in with Google. Please try again.", err)
+	}
+
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+	}
+
+	resp := &LoginOutput{}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
+	return resp, nil
+}
+```
+
+- [ ] **Step 8: Refactor `LoginWithAppleHuma` (lines 422-465)**
+
+```go
+func (h *Handler) LoginWithAppleHuma(ctx context.Context, input *LoginWithAppleInput) (*LoginOutput, error) {
+	errs := xvalidator.Validator.Validate(input.Body)
+	if len(errs) > 0 {
+		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+	}
+
+	id, count, user, err := h.service.LoginFromApple(input.Body.AppleID)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Unable to sign in with Apple. Please try again.", err)
+	}
+
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+	}
+
+	resp := &LoginOutput{}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
+	return resp, nil
+}
+```
+
+- [ ] **Step 9: Refactor `LoginWithOTPHuma` (lines 626-687)**
+
+```go
+func (h *Handler) LoginWithOTPHuma(ctx context.Context, input *LoginWithOTPInput) (*LoginWithOTPOutput, error) {
+	errs := xvalidator.Validator.Validate(input.Body)
+	if len(errs) > 0 {
+		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+	}
+
+	valid, status, err := h.service.VerifyOTP(ctx, input.Body.PhoneNumber, input.Body.Code)
+	if err != nil {
+		slog.Error("Failed to verify OTP during login", "error", err, "phone", input.Body.PhoneNumber)
+		return nil, huma.Error500InternalServerError("Unable to verify code. Please try again.", err)
+	}
+
+	if !valid {
+		slog.Warn("Invalid OTP code during login", "phone", input.Body.PhoneNumber, "status", status)
+		return nil, huma.Error401Unauthorized("Invalid or expired verification code. Please request a new one.", nil)
+	}
+
+	id, count, user, err := h.service.LoginFromPhoneOTP(input.Body.PhoneNumber)
+	if err != nil {
+		slog.Error("Failed to find user by phone", "error", err, "phone", input.Body.PhoneNumber)
+		return nil, huma.Error404NotFound("No account found with this phone number. Please sign up first.", err)
+	}
+
+	result, err := completeLogin(h.service, id.Hex(), *count, user)
+	if err != nil {
+		slog.Error("Token generation failed during OTP login", "error", err, "user_id", id.Hex())
+		return nil, huma.Error500InternalServerError("Token generation failed", err)
+	}
+
+	resp := &LoginWithOTPOutput{}
+	resp.AccessToken = result.AccessToken
+	resp.RefreshToken = result.RefreshToken
+	resp.Body = result.User
+
+	slog.Info("OTP login successful", "user_id", id.Hex(), "phone", input.Body.PhoneNumber)
+	return resp, nil
+}
+```
+
+- [ ] **Step 10: Refactor `RegisterWithContext` SafeUser block (lines 398-416)**
+
+Replace the SafeUser construction block at the end of `RegisterWithContext` with:
+
+```go
+	resp := &RegisterOutput{}
+	resp.AccessToken = access
+	resp.RefreshToken = refresh
+	resp.Body = buildSafeUserResponse(&user)
+
+	return resp, nil
+}
+```
+
+- [ ] **Step 11: Run full auth test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/auth/helpers.go internal/handlers/auth/helpers_test.go internal/handlers/auth/auth.go
+git commit -m "refactor(auth): consolidate login handlers with completeLogin helper"
+```
+
+---
+
+### Task 3: Extract `findByField` private helper in auth service
+
+**Files:**
+- Modify: `internal/handlers/auth/service.go`
+- Modify: `internal/handlers/auth/helpers_test.go`
+
+- [ ] **Step 1: Add `findByField` to service.go and refactor LoginFrom* methods**
+
+Add the private helper and refactor the 5 login methods in `service.go`. Replace lines 114-191 with:
+
+```go
+// findByField is the private implementation detail for typed user lookups.
+func (s *Service) findByField(field string, value string) (*User, error) {
+	var user User
+	err := s.users.FindOne(context.Background(), bson.M{field: value}).Decode(&user)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, fiber.NewError(404, "Account does not exist")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func (s *Service) LoginFromCredentials(email string, password string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("email", email)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
+	if err != nil {
+		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
+	}
+
+	return &user.ID, &user.Count, user, nil
+}
+
+func (s *Service) LoginFromPhone(phoneNumber string, password string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("phone", phoneNumber)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
+	if err != nil {
+		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
+	}
+
+	return &user.ID, &user.Count, user, nil
+}
+
+func (s *Service) LoginFromApple(apple_id string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("apple_id", apple_id)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return &user.ID, &user.Count, user, nil
+}
+
+func (s *Service) LoginFromGoogle(google_id string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("google_id", google_id)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return &user.ID, &user.Count, user, nil
+}
+
+func (s *Service) LoginFromPhoneOTP(phone_number string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.findByField("phone", phone_number)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return &user.ID, &user.Count, user, nil
+}
+```
+
+- [ ] **Step 2: Run full auth test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/auth/service.go
+git commit -m "refactor(auth): extract findByField private helper for user lookups"
+```
+
+---
+
+### Task 4: Consolidate middleware shared logic
+
+**Files:**
+- Modify: `internal/handlers/auth/middleware.go`
+- Modify: `internal/handlers/auth/fiber_middleware.go`
+- Create: `internal/handlers/auth/middleware_test.go`
+
+- [ ] **Step 1: Write test for `validateRefreshTokenCore`**
+
+Create `internal/handlers/auth/middleware_test.go`:
+
+```go
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateRefreshTokenCore_InvalidToken(t *testing.T) {
+	// Verify the function signature and error path exist
+	// Full integration testing requires a database connection, but we can test
+	// that the core function is callable and returns errors for nil service
+	assert.NotNil(t, validateRefreshTokenCore)
+}
+```
+
+- [ ] **Step 2: Extract shared `validateRefreshTokenCore` into middleware.go**
+
+The logic in `validateRefreshToken` (middleware.go:124-156) and `validateRefreshTokenFiber` (fiber_middleware.go:116-145) is identical. Extract the shared logic into `middleware.go`:
+
+```go
+// validateRefreshTokenCore contains the shared refresh token validation logic
+// used by both HTTP and Fiber middleware adapters.
+func validateRefreshTokenCore(service *Service, refreshToken string) (userID string, count float64, timezone string, err error) {
+	slog.Info("Refresh token: starting validation")
+
+	userID, count, timezone, err = service.ValidateToken(refreshToken)
+	if err != nil {
+		slog.Error("Refresh token: validation failed", "error", err.Error())
+		return "", 0, "", fmt.Errorf("refresh token invalid: %v", err)
+	}
+
+	id, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		slog.Error("Refresh token: invalid user ID format", "user_id", userID, "error", err.Error())
+		return "", 0, "", fmt.Errorf("invalid user ID in refresh token: %v", err)
+	}
+
+	used, err := service.CheckIfTokenUsed(id)
+	if err != nil {
+		slog.Error("Refresh token: error checking usage", "error", err.Error())
+		return "", 0, "", fmt.Errorf("error checking token usage: %v", err)
+	}
+
+	if used {
+		slog.Error("Refresh token: already used", "user_id", userID)
+		return "", 0, "", fmt.Errorf("refresh token has already been used")
+	}
+
+	return userID, count, timezone, nil
+}
+```
+
+Then update `validateRefreshToken` in middleware.go (lines 124-156) to delegate:
+
+```go
+func validateRefreshToken(service *Service, refreshToken string) (float64, string, error) {
+	_, count, timezone, err := validateRefreshTokenCore(service, refreshToken)
+	return count, timezone, err
+}
+```
+
+And update `validateRefreshTokenFiber` in fiber_middleware.go (lines 116-145) to delegate:
+
+```go
+func validateRefreshTokenFiber(service *Service, refreshToken string) (float64, string, error) {
+	_, count, timezone, err := validateRefreshTokenCore(service, refreshToken)
+	return count, timezone, err
+}
+```
+
+- [ ] **Step 3: Run full auth test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/auth/middleware.go internal/handlers/auth/fiber_middleware.go internal/handlers/auth/middleware_test.go
+git commit -m "refactor(auth): consolidate middleware refresh token validation logic"
+```
+
+---
+
+## Phase 2: Task Service File Split
+
+### Task 5: Split `service.go` into domain-focused files
+
+**Files:**
+- Delete: `internal/handlers/task/service.go`
+- Create: `internal/handlers/task/task_service.go`
+- Create: `internal/handlers/task/template_service.go`
+- Create: `internal/handlers/task/flex_service.go`
+- Create: `internal/handlers/task/query_service.go`
+
+All files stay in `package task`. The `Service` struct definition stays in `types.go`. This is a pure move — no logic changes.
+
+- [ ] **Step 1: Create `task_service.go` with CRUD + field update methods**
+
+Move these methods from `service.go` to `task_service.go`:
+- `getTasksByUserPipeline` (lines 59-74 — the helper used by multiple methods)
+- `GetAllTasks` (lines 76-90)
+- `GetTasksByUser` (lines 92-112)
+- `GetPublicTasks` (lines 113-136)
+- `GetTaskByID` (lines 139-161)
+- `CreateTask` (lines 164-181)
+- `UpdatePartialTask` (lines 195-276)
+- `CompleteTask` (lines 291-474)
+- `BulkCompleteTask` (lines 476-795)
+- `BulkDeleteTask` (lines 797-961)
+- `IncrementTaskCompletedAndDelete` (lines 963-1013)
+- `DeleteTask` (lines 1016-1034)
+- `DeleteTaskByID` (lines 1990-2020)
+- `ActivateTask` (lines 1052-1085)
+- `UpdateTaskNotes` (lines 2023-2050)
+- `UpdateTaskChecklist` (lines 2053-2100)
+- `verifyCategoryOwnership` (lines 2102-2110)
+- `UpdateTaskDeadline` (lines 2784-2804)
+- `UpdateTaskStart` (lines 2807-2835)
+- `UpdateTaskReminders` (lines 2838-2858)
+
+Include the necessary imports at the top.
+
+- [ ] **Step 2: Create `template_service.go` with recurring/template methods**
+
+Move these methods from `service.go` to `template_service.go`:
+- `CreateTemplateTask` (lines 183-192)
+- `CreateTaskFromTemplate` (lines 1111-1342)
+- `DeleteTemplateTask` (lines 1037-1049)
+- `DeleteTaskFromTemplateID` (lines 1344-1383)
+- `CreateTemplateForTask` (lines 1386-1505)
+- `ScheduleNextRecurrence` (lines 1572-1633)
+- `GetDueRecurringTasks` (lines 1803-1825)
+- `GetTasksWithStartTimesOlderThanOneDay` (lines 1827-1869)
+- `GetRecurringTasksWithPastDeadlines` (lines 1871-1905)
+- `GetTemplateByID` (lines 2338-2344)
+- `ResetTemplateMetrics` (lines 2347-2368)
+- `UndoMissedTask` (lines 2375-2428)
+- `UpdateTemplateTask` (lines 2431-2455)
+- `GetTemplatesByUserWithCategory` (lines 2458-2510)
+
+- [ ] **Step 3: Create `flex_service.go` with flex-specific methods**
+
+Move these methods from `service.go` to `flex_service.go`:
+- `createFlexTemplateForTask` (lines 1508-1567)
+- `createFlexTaskFromTemplate` (lines 1635-1724)
+- `handleFlexCompletion` (lines 1726-1798)
+
+- [ ] **Step 4: Create `query_service.go` with query/listing methods**
+
+Move these methods from `service.go` to `query_service.go`:
+- `GetActiveTasks` (lines 1087-1109)
+- `GetRandomTaskForToday` (lines 1912-1988)
+- `GetCompletedTasks` (lines 2512-2554)
+- `QueryTasksByUser` (lines 2557-2697)
+- `GetCompletedTasksByDate` (lines 2699-2779)
+
+- [ ] **Step 5: Move reminder methods to existing `reminder.go`**
+
+Move these from `service.go` to the existing `reminder.go` file (which already has `HandleReminder`, `AddReminderToTask`, `ParseReminder`):
+- `GetTasksWithPastReminders` (lines 2120-2145)
+- `SendReminder` (lines 2147-2172)
+- `generateReminderMessage` (lines 2175-2245)
+- `UpdateReminderSent` (lines 2293-2313)
+- `AddReminderToTask` service method (lines 2315-2336) — note: the handler method `AddReminderToTask` already lives in reminder.go, this is the *service* method
+
+- [ ] **Step 6: Move checkin methods to existing `checkin.go`**
+
+Move these from `service.go` to the existing `checkin.go` file (which already has `HandleCheckin`):
+- `GetUserTaskCountsForTodayWithTimezone` (currently in checkin.go already — verify)
+- `GetUserTaskCountsForToday` (currently in checkin.go already — verify)
+- `GetUsersWithPushTokens` (currently in checkin.go already — verify)
+
+Verify these are already in checkin.go and not duplicated in service.go.
+
+- [ ] **Step 7: Delete `service.go`**
+
+After all methods have been moved out, verify service.go is empty (except possibly the package declaration and imports), then delete it.
+
+- [ ] **Step 8: Run full task test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/task/
+git commit -m "refactor(task): split service.go into domain-focused files"
+```
+
+---
+
+### Task 6: Split `task.go` into domain-focused handler files
+
+**Files:**
+- Delete: `internal/handlers/task/task.go`
+- Create: `internal/handlers/task/task_handlers.go`
+- Create: `internal/handlers/task/template_handlers.go`
+- Create: `internal/handlers/task/query_handlers.go`
+- Create: `internal/handlers/task/nlp_handlers.go`
+
+All files stay in `package task`.
+
+- [ ] **Step 1: Create `task_handlers.go` with CRUD + field update + bulk handlers**
+
+Move from `task.go`:
+- `GetTasksByUser` (lines 45-76)
+- `CreateTask` (lines 78-210)
+- `GetTasks` (lines 212-218)
+- `GetTask` (lines 221-244)
+- `UpdateTask` (lines 265-367)
+- `CompleteTask` (lines 374-422)
+- `DeleteTask` (lines 429-485)
+- `BulkCompleteTask` (lines 488-519)
+- `BulkDeleteTask` (lines 521-548)
+- `ActivateTask` (lines 551-586)
+- `GetActiveTasks` (lines 588-600)
+- `UpdateTaskNotes` (lines 666-696)
+- `UpdateTaskChecklist` (lines 699-729)
+- `UpdateTaskDeadline` (lines 942-972)
+- `UpdateTaskStart` (lines 975-1005)
+- `UpdateTaskReminders` (lines 1008-1038)
+
+- [ ] **Step 2: Create `template_handlers.go` with template/recurring handlers**
+
+Move from `task.go`:
+- `CreateTaskFromTemplate` (lines 602-620)
+- `GetTasksWithStartTimesOlderThanOneDay` (lines 625-643)
+- `GetRecurringTasksWithPastDeadlines` (lines 645-663)
+- `GetTemplateByID` (lines 731-743)
+- `UpdateTemplate` (lines 745-765)
+- `ResetTemplateMetrics` (lines 767-786)
+- `UndoMissedTask` (lines 788-815)
+- `GetUserTemplates` (lines 817-844)
+
+- [ ] **Step 3: Create `query_handlers.go` with query handlers**
+
+Move from `task.go`:
+- `QueryTasksByUser` (lines 1041-1058)
+- `GetCompletedTasks` (lines 846-889)
+- `GetCompletedTasksByDate` (lines 891-937)
+
+- [ ] **Step 4: Create `nlp_handlers.go` with NLP/AI handlers**
+
+Move from `task.go`:
+- `QueryTasksNaturalLanguage` (lines 1061-1137)
+- `CreateTaskNaturalLanguage` (lines 1140-1263)
+- `EditTasksNaturalLanguage` (lines 1266-1540)
+- `applyEditInstructions` (lines 1545-1700)
+- `IntentTaskNaturalLanguage` (lines 1706-1824)
+- `PreviewTaskNaturalLanguage` (lines 1828-1883)
+- `ConfirmTaskNaturalLanguage` (lines 1886-1953)
+
+- [ ] **Step 5: Delete `task.go`**
+
+- [ ] **Step 6: Run full task test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/task/
+git commit -m "refactor(task): split task.go into domain-focused handler files"
+```
+
+---
+
+### Task 7: Split `operations.go` into domain-focused operation files
+
+**Files:**
+- Delete: `internal/handlers/task/operations.go`
+- Create: `internal/handlers/task/task_operations.go`
+- Create: `internal/handlers/task/template_operations.go`
+- Create: `internal/handlers/task/query_operations.go`
+- Create: `internal/handlers/task/nlp_operations.go`
+
+- [ ] **Step 1: Read operations.go to identify all type definitions and their line ranges**
+
+Read `internal/handlers/task/operations.go` fully and catalog each type definition.
+
+- [ ] **Step 2: Split types to match handler groupings**
+
+Move I/O types into files that match their handler file:
+- `task_operations.go`: CRUD, field update, bulk, activation types + their register functions
+- `template_operations.go`: Template/recurring types + their register functions
+- `query_operations.go`: Query, completed tasks types + their register functions
+- `nlp_operations.go`: NLP types, local Gemini mirror types + their register functions
+
+- [ ] **Step 3: Delete `operations.go`**
+
+- [ ] **Step 4: Run full task test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full project test suite to catch any import issues**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./... 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/task/
+git commit -m "refactor(task): split operations.go into domain-focused operation files"
+```
+
+---
+
+## Phase 3: Bulk Operation Shared Helpers
+
+### Task 8: Extract shared validation helpers from bulk operations
+
+**Files:**
+- Modify: `internal/handlers/task/task_service.go`
+- Create: `internal/handlers/task/bulk_helpers.go`
+- Create: `internal/handlers/task/bulk_helpers_test.go`
+
+The bulk operations (`BulkCompleteTask` and `BulkDeleteTask`) each use **genuine batch MongoDB operations** (`$in` queries, `$pull` with `$in`, `DeleteMany`), so we keep those optimizations. The duplication is in the **ID parsing/validation boilerplate**. We extract that.
+
+- [ ] **Step 1: Write test for `parseBulkTaskIDs`**
+
+Create `internal/handlers/task/bulk_helpers_test.go`:
+
+```go
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func TestParseBulkTaskIDs_ValidIDs(t *testing.T) {
+	taskID := primitive.NewObjectID()
+	catID := primitive.NewObjectID()
+
+	items := []bulkTaskItem{
+		{TaskID: taskID.Hex(), CategoryID: catID.Hex()},
+	}
+
+	valid, failed := parseBulkTaskIDs(items)
+	assert.Equal(t, 1, len(valid))
+	assert.Equal(t, 0, len(failed))
+	assert.Equal(t, taskID, valid[0].taskID)
+	assert.Equal(t, catID, valid[0].categoryID)
+}
+
+func TestParseBulkTaskIDs_InvalidTaskID(t *testing.T) {
+	catID := primitive.NewObjectID()
+
+	items := []bulkTaskItem{
+		{TaskID: "bad-id", CategoryID: catID.Hex()},
+	}
+
+	valid, failed := parseBulkTaskIDs(items)
+	assert.Equal(t, 0, len(valid))
+	assert.Equal(t, 1, len(failed))
+	assert.Equal(t, "bad-id", failed[0])
+}
+
+func TestParseBulkTaskIDs_InvalidCategoryID(t *testing.T) {
+	taskID := primitive.NewObjectID()
+
+	items := []bulkTaskItem{
+		{TaskID: taskID.Hex(), CategoryID: "bad-id"},
+	}
+
+	valid, failed := parseBulkTaskIDs(items)
+	assert.Equal(t, 0, len(valid))
+	assert.Equal(t, 1, len(failed))
+}
+
+func TestParseBulkTaskIDs_MixedValid(t *testing.T) {
+	taskID := primitive.NewObjectID()
+	catID := primitive.NewObjectID()
+
+	items := []bulkTaskItem{
+		{TaskID: taskID.Hex(), CategoryID: catID.Hex()},
+		{TaskID: "bad-id", CategoryID: catID.Hex()},
+	}
+
+	valid, failed := parseBulkTaskIDs(items)
+	assert.Equal(t, 1, len(valid))
+	assert.Equal(t, 1, len(failed))
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestParseBulkTaskIDs -v`
+Expected: FAIL — types not defined
+
+- [ ] **Step 3: Implement `bulk_helpers.go`**
+
+Create `internal/handlers/task/bulk_helpers.go`:
+
+```go
+package task
+
+import (
+	"log/slog"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// bulkTaskItem is the interface that both BulkCompleteTaskItem and BulkDeleteTaskItem satisfy.
+type bulkTaskItem interface {
+	GetTaskID() string
+	GetCategoryID() string
+}
+
+// parsedBulkTask holds the parsed ObjectIDs from a bulk task item.
+type parsedBulkTask struct {
+	taskID     primitive.ObjectID
+	categoryID primitive.ObjectID
+	index      int
+}
+
+// parseBulkTaskIDs validates and parses hex string IDs into ObjectIDs.
+// Returns the valid parsed tasks and a list of failed task ID strings.
+func parseBulkTaskIDs(items []bulkTaskItem) ([]parsedBulkTask, []string) {
+	valid := make([]parsedBulkTask, 0, len(items))
+	failed := make([]string, 0)
+
+	for i, item := range items {
+		taskID, err := primitive.ObjectIDFromHex(item.GetTaskID())
+		if err != nil {
+			failed = append(failed, item.GetTaskID())
+			slog.Warn("Invalid task ID in bulk operation", "taskID", item.GetTaskID(), "error", err)
+			continue
+		}
+
+		categoryID, err := primitive.ObjectIDFromHex(item.GetCategoryID())
+		if err != nil {
+			failed = append(failed, item.GetTaskID())
+			slog.Warn("Invalid category ID in bulk operation", "categoryID", item.GetCategoryID(), "error", err)
+			continue
+		}
+
+		valid = append(valid, parsedBulkTask{
+			taskID:     taskID,
+			categoryID: categoryID,
+			index:      i,
+		})
+	}
+
+	return valid, failed
+}
+
+// fetchAndValidateBulkTasks fetches tasks by IDs via aggregation and validates ownership.
+// Returns a map of found tasks and a list of failed task ID strings.
+func fetchAndValidateBulkTasks(
+	s *Service,
+	userID primitive.ObjectID,
+	taskIDs []primitive.ObjectID,
+	validTasks []parsedBulkTask,
+) (map[primitive.ObjectID]TaskDocument, []string) {
+	ctx := context.Background()
+	failed := make([]string, 0)
+
+	taskPipeline := getTasksByUserPipeline(userID)
+	taskPipeline = append(taskPipeline, bson.D{
+		{Key: "$match", Value: bson.M{"_id": bson.M{"$in": taskIDs}}},
+	})
+
+	taskCursor, err := s.Tasks.Aggregate(ctx, taskPipeline)
+	if err != nil {
+		// If we can't fetch at all, mark everything as failed
+		for _, vt := range validTasks {
+			failed = append(failed, vt.taskID.Hex())
+		}
+		return nil, failed
+	}
+	defer taskCursor.Close(ctx)
+
+	var fetchedTasks []TaskDocument
+	if err := taskCursor.All(ctx, &fetchedTasks); err != nil {
+		for _, vt := range validTasks {
+			failed = append(failed, vt.taskID.Hex())
+		}
+		return nil, failed
+	}
+
+	fetchedMap := make(map[primitive.ObjectID]TaskDocument)
+	for _, task := range fetchedTasks {
+		fetchedMap[task.ID] = task
+	}
+
+	return fetchedMap, failed
+}
+```
+
+Wait — I realize `fetchAndValidateBulkTasks` needs `context` and `bson` imports. Add those to the import block:
+
+```go
+import (
+	"context"
+	"log/slog"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+```
+
+Also add the `GetTaskID` and `GetCategoryID` methods to `BulkCompleteTaskItem` and `BulkDeleteTaskItem` in the operations file where they are defined. These are simple accessor methods:
+
+```go
+func (b BulkCompleteTaskItem) GetTaskID() string    { return b.TaskID }
+func (b BulkCompleteTaskItem) GetCategoryID() string { return b.CategoryID }
+
+func (b BulkDeleteTaskItem) GetTaskID() string    { return b.TaskID }
+func (b BulkDeleteTaskItem) GetCategoryID() string { return b.CategoryID }
+```
+
+- [ ] **Step 4: Update `BulkCompleteTask` and `BulkDeleteTask` to use the shared helpers**
+
+Replace the ID parsing loops in both methods with calls to `parseBulkTaskIDs` and `fetchAndValidateBulkTasks`. Keep the MongoDB batch operations (`$pull`, `DeleteMany`, etc.) exactly as they are.
+
+- [ ] **Step 5: Run test to verify helpers pass**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestParseBulkTaskIDs -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full task test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/task/
+git commit -m "refactor(task): extract shared validation helpers from bulk operations"
+```
+
+---
+
+## Phase 4: Repository Interfaces + Shared Helpers
+
+### Task 9: Create repository package with interfaces and error types
+
+**Files:**
+- Create: `internal/repository/interfaces.go`
+- Create: `internal/repository/errors.go`
+
+- [ ] **Step 1: Create `internal/repository/errors.go`**
+
+```go
+package repository
+
+import "errors"
+
+var (
+	ErrNotFound  = errors.New("document not found")
+	ErrDuplicate = errors.New("duplicate document")
+)
+```
+
+- [ ] **Step 2: Create `internal/repository/interfaces.go`**
+
+```go
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type UserRepository interface {
+	GetUserByID(ctx context.Context, id primitive.ObjectID) (*types.User, error)
+	GetUserByEmail(ctx context.Context, email string) (*types.User, error)
+	GetUserByPhone(ctx context.Context, phone string) (*types.User, error)
+	GetUserByGoogleID(ctx context.Context, googleID string) (*types.User, error)
+	GetUserByAppleID(ctx context.Context, appleID string) (*types.User, error)
+	CreateUser(ctx context.Context, user *types.User) error
+	UpdateUser(ctx context.Context, id primitive.ObjectID, update bson.M) error
+	DeleteUser(ctx context.Context, id primitive.ObjectID) error
+	GetUsersWithPushTokens(ctx context.Context) ([]types.User, error)
+	IncrementUserCount(ctx context.Context, id primitive.ObjectID) error
+	UpdatePushToken(ctx context.Context, id primitive.ObjectID, token string) error
+	CheckTokenCount(ctx context.Context, id primitive.ObjectID) (float64, error)
+	MarkTokenUsed(ctx context.Context, id primitive.ObjectID) error
+	CheckIfTokenUsed(ctx context.Context, id primitive.ObjectID) (bool, error)
+	AcceptTerms(ctx context.Context, id primitive.ObjectID, version string) (*time.Time, error)
+	RemoveFromFriendsLists(ctx context.Context, id primitive.ObjectID) error
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./internal/repository/...`
+Expected: Success (no errors)
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/repository/
+git commit -m "refactor: add repository interfaces and error types"
+```
+
+---
+
+### Task 10: Create MongoDB user repository implementation
+
+**Files:**
+- Create: `internal/repository/mongo/helpers.go`
+- Create: `internal/repository/mongo/user_repo.go`
+- Create: `internal/repository/mongo/user_repo_test.go`
+
+- [ ] **Step 1: Create shared MongoDB helpers**
+
+Create `internal/repository/mongo/helpers.go`:
+
+```go
+package mongo
+
+import (
+	"context"
+	"errors"
+
+	"github.com/abhikaboy/Kindred/internal/repository"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// findOneByField is the private generic helper for single-document lookups.
+func findOneByField[T any](ctx context.Context, coll *mongo.Collection, field string, value any) (*T, error) {
+	var result T
+	err := coll.FindOne(ctx, bson.M{field: value}).Decode(&result)
+	if errors.Is(err, mongo.ErrNoDocuments) {
+		return nil, repository.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// findMany is the private generic helper for multi-document queries.
+func findMany[T any](ctx context.Context, coll *mongo.Collection, filter bson.M) ([]T, error) {
+	cursor, err := coll.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []T
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// updateOneByID updates a single document by its _id field.
+func updateOneByID(ctx context.Context, coll *mongo.Collection, id any, update bson.M) error {
+	_, err := coll.UpdateOne(ctx, bson.M{"_id": id}, update)
+	return err
+}
+```
+
+- [ ] **Step 2: Create `internal/repository/mongo/user_repo.go`**
+
+```go
+package mongo
+
+import (
+	"context"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/abhikaboy/Kindred/internal/repository"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+type userRepo struct {
+	collection *mongo.Collection
+}
+
+func NewUserRepository(coll *mongo.Collection) repository.UserRepository {
+	return &userRepo{collection: coll}
+}
+
+func (r *userRepo) GetUserByID(ctx context.Context, id primitive.ObjectID) (*types.User, error) {
+	return findOneByField[types.User](ctx, r.collection, "_id", id)
+}
+
+func (r *userRepo) GetUserByEmail(ctx context.Context, email string) (*types.User, error) {
+	return findOneByField[types.User](ctx, r.collection, "email", email)
+}
+
+func (r *userRepo) GetUserByPhone(ctx context.Context, phone string) (*types.User, error) {
+	return findOneByField[types.User](ctx, r.collection, "phone", phone)
+}
+
+func (r *userRepo) GetUserByGoogleID(ctx context.Context, googleID string) (*types.User, error) {
+	return findOneByField[types.User](ctx, r.collection, "google_id", googleID)
+}
+
+func (r *userRepo) GetUserByAppleID(ctx context.Context, appleID string) (*types.User, error) {
+	return findOneByField[types.User](ctx, r.collection, "apple_id", appleID)
+}
+
+func (r *userRepo) CreateUser(ctx context.Context, user *types.User) error {
+	_, err := r.collection.InsertOne(ctx, user)
+	return err
+}
+
+func (r *userRepo) UpdateUser(ctx context.Context, id primitive.ObjectID, update bson.M) error {
+	return updateOneByID(ctx, r.collection, id, bson.M{"$set": update})
+}
+
+func (r *userRepo) DeleteUser(ctx context.Context, id primitive.ObjectID) error {
+	_, err := r.collection.DeleteOne(ctx, bson.M{"_id": id})
+	return err
+}
+
+func (r *userRepo) GetUsersWithPushTokens(ctx context.Context) ([]types.User, error) {
+	return findMany[types.User](ctx, r.collection, bson.M{
+		"push_token": bson.M{"$ne": ""},
+	})
+}
+
+func (r *userRepo) IncrementUserCount(ctx context.Context, id primitive.ObjectID) error {
+	return updateOneByID(ctx, r.collection, id, bson.M{"$inc": bson.M{"count": 1}})
+}
+
+func (r *userRepo) UpdatePushToken(ctx context.Context, id primitive.ObjectID, token string) error {
+	return updateOneByID(ctx, r.collection, id, bson.M{"$set": bson.M{"push_token": token}})
+}
+
+func (r *userRepo) CheckTokenCount(ctx context.Context, id primitive.ObjectID) (float64, error) {
+	user, err := r.GetUserByID(ctx, id)
+	if err != nil {
+		return 0, err
+	}
+	return user.Count, nil
+}
+
+func (r *userRepo) MarkTokenUsed(ctx context.Context, id primitive.ObjectID) error {
+	return updateOneByID(ctx, r.collection, id, bson.M{"$set": bson.M{"token_used": true}})
+}
+
+func (r *userRepo) CheckIfTokenUsed(ctx context.Context, id primitive.ObjectID) (bool, error) {
+	user, err := r.GetUserByID(ctx, id)
+	if err != nil {
+		return false, err
+	}
+	return user.TokenUsed, nil
+}
+
+func (r *userRepo) AcceptTerms(ctx context.Context, id primitive.ObjectID, version string) (*time.Time, error) {
+	now := time.Now()
+	err := updateOneByID(ctx, r.collection, id, bson.M{
+		"$set": bson.M{
+			"terms_accepted_at":      now,
+			"terms_accepted_version": version,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &now, nil
+}
+
+func (r *userRepo) RemoveFromFriendsLists(ctx context.Context, id primitive.ObjectID) error {
+	_, err := r.collection.UpdateMany(ctx,
+		bson.M{"friends": id},
+		bson.M{"$pull": bson.M{"friends": id}},
+	)
+	return err
+}
+```
+
+- [ ] **Step 3: Write integration test for user repository**
+
+Create `internal/repository/mongo/user_repo_test.go`:
+
+```go
+package mongo
+
+import (
+	"context"
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/abhikaboy/Kindred/internal/repository"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// These tests require a running MongoDB instance.
+// They are skipped in CI unless MONGO_TEST_URI is set.
+func setupTestRepo(t *testing.T) (repository.UserRepository, func()) {
+	t.Helper()
+	uri := "mongodb://localhost:27017"
+	// Use test environment helper if available
+	ctx := context.Background()
+
+	client, err := mongoDriver.Connect(ctx, options.Client().ApplyURI(uri))
+	if err != nil {
+		t.Skip("MongoDB not available, skipping integration test")
+	}
+
+	dbName := "kindred_test_repo_" + primitive.NewObjectID().Hex()[:8]
+	coll := client.Database(dbName).Collection("users")
+	repo := NewUserRepository(coll)
+
+	cleanup := func() {
+		client.Database(dbName).Drop(ctx)
+		client.Disconnect(ctx)
+	}
+
+	return repo, cleanup
+}
+
+func TestUserRepo_CreateAndGetByID(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := &types.User{
+		ID:          primitive.NewObjectID(),
+		Email:       "test@example.com",
+		DisplayName: "Test",
+		Handle:      "test",
+	}
+
+	err := repo.CreateUser(ctx, user)
+	require.NoError(t, err)
+
+	found, err := repo.GetUserByID(ctx, user.ID)
+	require.NoError(t, err)
+	assert.Equal(t, user.Email, found.Email)
+}
+
+func TestUserRepo_GetByEmail(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	user := &types.User{
+		ID:    primitive.NewObjectID(),
+		Email: "lookup@example.com",
+	}
+
+	err := repo.CreateUser(ctx, user)
+	require.NoError(t, err)
+
+	found, err := repo.GetUserByEmail(ctx, "lookup@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, user.ID, found.ID)
+}
+
+func TestUserRepo_NotFound(t *testing.T) {
+	repo, cleanup := setupTestRepo(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	_, err := repo.GetUserByID(ctx, primitive.NewObjectID())
+	assert.ErrorIs(t, err, repository.ErrNotFound)
+}
+```
+
+Note: The test setup uses a direct MongoDB connection. Adjust the import for `mongo.Connect` — it needs:
+```go
+import (
+	mongoDriver "go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./internal/repository/...`
+Expected: Success
+
+- [ ] **Step 5: Run repository tests (if MongoDB available)**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/repository/... -v`
+Expected: PASS (or SKIP if no local MongoDB)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/repository/
+git commit -m "feat: add MongoDB user repository implementation with shared helpers"
+```
+
+---
+
+### Task 11: Migrate auth service to use UserRepository
+
+**Files:**
+- Modify: `internal/handlers/auth/types.go`
+- Modify: `internal/handlers/auth/service.go`
+- Modify: `internal/handlers/auth/routes.go`
+- Modify: `internal/handlers/auth/middleware.go`
+- Modify: `internal/handlers/auth/fiber_middleware.go`
+
+- [ ] **Step 1: Update `Service` struct in types.go to accept `UserRepository`**
+
+Replace the `Service` struct in `types.go` (lines 17-22):
+
+```go
+type Service struct {
+	users      repository.UserRepository
+	categories *mongo.Collection
+	referrals  *mongo.Collection
+	config     config.Config
+}
+```
+
+Add import: `"github.com/abhikaboy/Kindred/internal/repository"`
+
+Update `newService` (lines 24-31):
+
+```go
+func newService(users repository.UserRepository, categories *mongo.Collection, referrals *mongo.Collection, config config.Config) *Service {
+	return &Service{
+		users:      users,
+		categories: categories,
+		referrals:  referrals,
+		config:     config,
+	}
+}
+
+func NewServiceWithConfig(collections map[string]*mongo.Collection, cfg config.Config) *Service {
+	users := mongorepo.NewUserRepository(collections["users"])
+	return newService(users, collections["categories"], collections["referrals"], cfg)
+}
+```
+
+Add import: `mongorepo "github.com/abhikaboy/Kindred/internal/repository/mongo"`
+
+- [ ] **Step 2: Update routes.go to create repository**
+
+Update `Routes` in `routes.go` (line 15) and any other constructor calls to use `NewServiceWithConfig` pattern which now creates the repo internally.
+
+- [ ] **Step 3: Migrate service.go methods from `s.users.FindOne(...)` to repository calls**
+
+Go through each method in `service.go` that accesses `s.users` and replace with repository method calls. Key changes:
+
+- `GetUserCount` (line 53): Replace `s.users.FindOne(context.Background(), bson.M{"_id": id}).Decode(&user)` with `user, err := s.users.GetUserByID(context.Background(), id)` then return `user.Count`
+- `LoginFromCredentials`: Replace `s.findByField("email", email)` with `s.users.GetUserByEmail(ctx, email)` — handle `repository.ErrNotFound` → `fiber.NewError(404, ...)`
+- `LoginFromPhone`: Replace with `s.users.GetUserByPhone(ctx, phone)`
+- `LoginFromApple`: Replace with `s.users.GetUserByAppleID(ctx, apple_id)`
+- `LoginFromGoogle`: Replace with `s.users.GetUserByGoogleID(ctx, google_id)`
+- `LoginFromPhoneOTP`: Replace with `s.users.GetUserByPhone(ctx, phone)`
+- `InvalidateTokens`: Replace with `s.users.IncrementUserCount(ctx, id)`
+- `UseToken`: Replace with `s.users.MarkTokenUsed(ctx, id)`
+- `CheckIfTokenUsed`: Replace with `s.users.CheckIfTokenUsed(ctx, id)`
+- `CreateUser`: Replace with `s.users.CreateUser(ctx, &user)`
+- `GetUser`: Replace with `s.users.GetUserByID(ctx, id)` and build SafeUser
+- `UpdatePushToken`: Replace with `s.users.UpdatePushToken(ctx, id, token)`
+- `DeleteAccount`: Replace user operations with repo calls
+- `AcceptTerms`: Replace with `s.users.AcceptTerms(ctx, id, version)`
+
+For each replacement, map `repository.ErrNotFound` to the appropriate HTTP error to preserve existing behavior.
+
+- [ ] **Step 4: Update middleware.go constructor**
+
+Update `AuthMiddleware` (line 22) to create the user repository:
+
+```go
+func AuthMiddleware(collections map[string]*mongo.Collection, cfg config.Config) func(http.Handler) http.Handler {
+	service := NewServiceWithConfig(collections, cfg)
+	// ... rest stays the same
+```
+
+- [ ] **Step 5: Update fiber_middleware.go constructor**
+
+Same change for `FiberAuthMiddleware` (line 17).
+
+- [ ] **Step 6: Remove the `findByField` method from service.go**
+
+It's no longer needed — the repository has typed lookup methods.
+
+- [ ] **Step 7: Run full auth test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/auth/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 8: Run full project test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./... 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/auth/ internal/repository/
+git commit -m "refactor(auth): migrate auth service to use UserRepository interface"
+```
+
+---
+
+### Task 12: Migrate task service checkin/reminder to use UserRepository
+
+**Files:**
+- Modify: `internal/handlers/task/types.go`
+- Modify: `internal/handlers/task/routes.go`
+- Modify: `internal/handlers/task/checkin.go`
+
+The task service also accesses the `Users` collection directly for checkin/push notification operations. Migrate those to the repository.
+
+- [ ] **Step 1: Add `UserRepository` to task Service struct**
+
+In `internal/handlers/task/types.go`, add a `Users` field as `repository.UserRepository` alongside the existing `*mongo.Collection` fields. The task service's core operations use the `Tasks` (categories) collection via complex aggregation pipelines that are hard to abstract — we migrate only the user lookups.
+
+```go
+type Service struct {
+	Users               repository.UserRepository
+	Tasks               *mongo.Collection // categories — complex aggregation pipelines
+	CompletedTasks      *mongo.Collection
+	TemplateTasks       *mongo.Collection
+	EncouragementHelper EncouragementServiceInterface
+}
+```
+
+- [ ] **Step 2: Update task `newService` in routes.go**
+
+```go
+func Routes(api huma.API, collections map[string]*mongo.Collection, geminiService any) {
+	users := mongorepo.NewUserRepository(collections["users"])
+	service := newService(users, collections)
+	// ...
+}
+```
+
+Update `newService` to accept the user repo:
+
+```go
+func newService(users repository.UserRepository, collections map[string]*mongo.Collection) *Service {
+	return &Service{
+		Users:               users,
+		Tasks:               collections["categories"],
+		CompletedTasks:      collections["completed-tasks"],
+		TemplateTasks:       collections["template-tasks"],
+		EncouragementHelper: encouragement.NewEncouragementService(collections),
+	}
+}
+```
+
+- [ ] **Step 3: Update checkin.go to use repository**
+
+Replace `s.Users.FindOne(...)` and `s.Users.Find(...)` calls in `GetUsersWithPushTokens` and any other user-accessing methods with repository calls.
+
+- [ ] **Step 4: Run full task test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -v`
+Expected: All tests PASS
+
+- [ ] **Step 5: Run full project test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./... 2>&1 | tail -30`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add internal/handlers/task/ internal/repository/
+git commit -m "refactor(task): migrate user operations to UserRepository interface"
+```
+
+---
+
+### Task 13: Final verification and cleanup
+
+**Files:**
+- All modified files
+
+- [ ] **Step 1: Run full project build**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: No compile errors
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./... -v 2>&1 | tail -50`
+Expected: All tests PASS
+
+- [ ] **Step 3: Run vet and check for issues**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go vet ./...`
+Expected: No issues
+
+- [ ] **Step 4: Verify no unused imports or dead code**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... 2>&1`
+Expected: Clean build
+
+- [ ] **Step 5: Commit any cleanup**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend
+git add -A
+git commit -m "refactor: final cleanup after backend refactor"
+```

--- a/docs/superpowers/plans/2026-05-06-undoable-delete.md
+++ b/docs/superpowers/plans/2026-05-06-undoable-delete.md
@@ -1,0 +1,806 @@
+# Undoable Task Delete Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a 5-second undo window to task deletion across all swipeable surfaces, with rolling batch support for rapid consecutive deletes.
+
+**Architecture:** A new `useUndoableDelete` hook manages a pending-deletes map and a single rolling timer. Components call `deleteWithUndo()` instead of the API directly. A new `UndoToast` component renders the "N task(s) deleted · Undo" toast. On timer expiry the hook fires the real API calls; on undo it restores all pending tasks to the context.
+
+**Tech Stack:** React Native, Expo, react-native-toastable, react-native-reanimated, expo-haptics
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `frontend/components/ui/UndoToast.tsx` | Toast with "Undo" button |
+| Create | `frontend/hooks/useUndoableDelete.tsx` | Delayed-delete lifecycle hook |
+| Modify | `frontend/components/cards/SwipableTaskCard.tsx` | Replace inline delete with hook |
+| Modify | `frontend/components/cards/SchedulableTaskCard.tsx` | Replace inline delete with hook |
+| Modify | `frontend/components/daily/CalendarView.tsx` | Replace inline delete with hook |
+| Modify | `frontend/app/(logged-in)/(tabs)/(task)/review.tsx` | Replace inline delete with hook |
+
+---
+
+### Task 1: Create UndoToast component
+
+**Files:**
+- Create: `frontend/components/ui/UndoToast.tsx`
+
+- [ ] **Step 1: Create UndoToast.tsx**
+
+This follows the same pattern as `DefaultToast.tsx` — pan-gesture dismiss, themed colors, animated opacity. The key addition is an "Undo" pressable on the right side.
+
+```tsx
+import React from "react";
+import { View, Dimensions, StyleSheet, TouchableOpacity } from "react-native";
+import { ToastableBodyParams, hideToastable } from "react-native-toastable";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Reanimated, {
+    useSharedValue,
+    useAnimatedStyle,
+    runOnJS,
+    withSpring,
+    withTiming,
+} from "react-native-reanimated";
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
+
+interface UndoToastProps extends ToastableBodyParams {
+    onUndo: () => void;
+    count: number;
+}
+
+export default function UndoToast({ message, onUndo, count }: UndoToastProps) {
+    const ThemedColor = useThemeColor();
+    const translateX = useSharedValue(0);
+    const translateY = useSharedValue(0);
+    const opacity = useSharedValue(1);
+    const startX = useSharedValue(0);
+    const startY = useSharedValue(0);
+
+    React.useEffect(() => {
+        translateX.value = 0;
+        translateY.value = 0;
+        opacity.value = 1;
+    }, []);
+
+    const panGesture = Gesture.Pan()
+        .onBegin(() => {
+            startX.value = translateX.value;
+            startY.value = translateY.value;
+        })
+        .onUpdate((event) => {
+            translateX.value = startX.value + event.translationX;
+            translateY.value = startY.value + event.translationY;
+            const horizontalProgress = Math.abs(translateX.value) / (screenWidth * 0.3);
+            const verticalProgress = Math.abs(translateY.value) / (screenHeight * 0.2);
+            const maxProgress = Math.max(horizontalProgress, verticalProgress);
+            opacity.value = Math.max(0.3, 1 - maxProgress);
+        })
+        .onEnd((event) => {
+            const horizontalThreshold = screenWidth * 0.25;
+            const verticalThreshold = screenHeight * 0.15;
+            const shouldDismissHorizontal =
+                Math.abs(translateX.value) > horizontalThreshold || Math.abs(event.velocityX) > 500;
+            const shouldDismissVertical =
+                translateY.value < -verticalThreshold || event.velocityY < -500;
+
+            if (shouldDismissHorizontal || shouldDismissVertical) {
+                if (shouldDismissVertical) {
+                    translateY.value = withTiming(-screenHeight, { duration: 200 });
+                } else {
+                    const direction = translateX.value > 0 ? 1 : -1;
+                    translateX.value = withTiming(direction * screenWidth, { duration: 200 });
+                }
+                opacity.value = withTiming(0, { duration: 200 });
+                runOnJS(hideToastable)();
+            } else {
+                translateX.value = withSpring(0, { damping: 20, stiffness: 300 });
+                translateY.value = withSpring(0, { damping: 20, stiffness: 300 });
+                opacity.value = withSpring(1, { damping: 20, stiffness: 300 });
+            }
+        });
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [
+            { translateX: translateX.value },
+            { translateY: translateY.value },
+        ],
+        opacity: opacity.value,
+    }));
+
+    const label = count === 1 ? "1 task deleted" : `${count} tasks deleted`;
+
+    return (
+        <GestureDetector gesture={panGesture}>
+            <Reanimated.View style={animatedStyle as any}>
+                <View style={styles.container}>
+                    <View style={[styles.toastBody, {
+                        borderColor: ThemedColor.warning,
+                        backgroundColor: ThemedColor.lightened,
+                    }]}>
+                        <ThemedText type="defaultSemiBold" style={styles.messageText}>
+                            {label}
+                        </ThemedText>
+                        <TouchableOpacity onPress={onUndo} hitSlop={8} style={styles.undoButton}>
+                            <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                                Undo
+                            </ThemedText>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </Reanimated.View>
+        </GestureDetector>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 20,
+    },
+    toastBody: {
+        minWidth: screenWidth * 0.8,
+        maxWidth: screenWidth * 0.9,
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderRadius: 12,
+        borderBottomWidth: 3,
+        paddingVertical: 16,
+        paddingHorizontal: 20,
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+        elevation: 8,
+    },
+    messageText: {
+        fontSize: 16,
+        flexShrink: 1,
+    },
+    undoButton: {
+        marginLeft: 16,
+        paddingVertical: 4,
+        paddingHorizontal: 8,
+    },
+});
+```
+
+- [ ] **Step 2: Verify it renders**
+
+Open the app, temporarily show this toast from any screen to confirm layout. Or just verify no TypeScript errors:
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+Expected: No errors in UndoToast.tsx.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/ui/UndoToast.tsx
+git commit -m "feat: add UndoToast component for delayed-delete undo"
+```
+
+---
+
+### Task 2: Create useUndoableDelete hook
+
+**Files:**
+- Create: `frontend/hooks/useUndoableDelete.tsx`
+
+- [ ] **Step 1: Create the hook file**
+
+```tsx
+import React, { useRef, useEffect, useCallback, useState } from "react";
+import { Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+import { showToastable, hideToastable } from "react-native-toastable";
+import { useTasks } from "@/contexts/tasksContext";
+import { removeFromCategoryAPI, bulkDeleteTasksAPI } from "@/api/task";
+import { Task } from "@/api/types";
+import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
+import UndoToast from "@/components/ui/UndoToast";
+import DefaultToast from "@/components/ui/DefaultToast";
+
+const UNDO_DELAY_MS = 5000;
+
+interface PendingDelete {
+    task: Task;
+    categoryId: string;
+    deleteRecurring: boolean;
+}
+
+export function useUndoableDelete() {
+    const { removeFromCategory, addToCategory } = useTasks();
+    const pendingRef = useRef<Map<string, PendingDelete>>(new Map());
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    // Alert state for recurring task dialog
+    const [alertVisible, setAlertVisible] = useState(false);
+    const [alertTitle, setAlertTitle] = useState("");
+    const [alertMessage, setAlertMessage] = useState("");
+    const [alertButtons, setAlertButtons] = useState<AlertButton[]>([]);
+
+    const flushPending = useCallback(async () => {
+        const entries = Array.from(pendingRef.current.values());
+        pendingRef.current.clear();
+        if (entries.length === 0) return;
+
+        // Partition: recurring-template deletes need individual calls
+        const individual: PendingDelete[] = [];
+        const bulkable: PendingDelete[] = [];
+
+        for (const entry of entries) {
+            if (entry.deleteRecurring) {
+                individual.push(entry);
+            } else {
+                bulkable.push(entry);
+            }
+        }
+
+        // Fire bulk delete for non-recurring
+        if (bulkable.length > 0) {
+            try {
+                if (bulkable.length === 1) {
+                    const { categoryId, task } = bulkable[0];
+                    await removeFromCategoryAPI(categoryId, task.id, false);
+                } else {
+                    await bulkDeleteTasksAPI(
+                        bulkable.map(({ categoryId, task }) => ({
+                            categoryId,
+                            taskId: task.id,
+                            deleteRecurring: false,
+                        }))
+                    );
+                }
+            } catch (error) {
+                // Restore failed tasks to UI
+                for (const { categoryId, task } of bulkable) {
+                    addToCategory(categoryId, task);
+                }
+                showToastable({
+                    title: "Error",
+                    status: "danger",
+                    position: "top",
+                    message: "Failed to delete task(s)",
+                    swipeDirection: "up",
+                    renderContent: (props) => <DefaultToast {...props} />,
+                });
+            }
+        }
+
+        // Fire individual calls for recurring-template deletes
+        for (const entry of individual) {
+            try {
+                await removeFromCategoryAPI(entry.categoryId, entry.task.id, true);
+            } catch (error) {
+                addToCategory(entry.categoryId, entry.task);
+                showToastable({
+                    title: "Error",
+                    status: "danger",
+                    position: "top",
+                    message: `Failed to delete "${entry.task.content}"`,
+                    swipeDirection: "up",
+                    renderContent: (props) => <DefaultToast {...props} />,
+                });
+            }
+        }
+    }, [addToCategory]);
+
+    // On unmount: flush immediately (no more undo possible)
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+                timerRef.current = undefined;
+            }
+            flushPending();
+        };
+    }, [flushPending]);
+
+    const undoAll = useCallback(() => {
+        // Clear the timer
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = undefined;
+        }
+
+        // Restore all pending tasks
+        for (const { categoryId, task } of pendingRef.current.values()) {
+            addToCategory(categoryId, task);
+        }
+        pendingRef.current.clear();
+        hideToastable();
+    }, [addToCategory]);
+
+    const scheduleFlush = useCallback(() => {
+        // Clear existing timer
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+        }
+
+        const count = pendingRef.current.size;
+
+        // Show/update the undo toast
+        showToastable({
+            title: "Deleted",
+            message: count === 1 ? "1 task deleted" : `${count} tasks deleted`,
+            status: "warning",
+            position: "top",
+            duration: UNDO_DELAY_MS,
+            swipeDirection: "up",
+            renderContent: (props) => (
+                <UndoToast {...props} onUndo={undoAll} count={count} />
+            ),
+        });
+
+        // Start new timer
+        timerRef.current = setTimeout(() => {
+            timerRef.current = undefined;
+            flushPending();
+        }, UNDO_DELAY_MS);
+    }, [undoAll, flushPending]);
+
+    const enqueuePendingDelete = useCallback(
+        (task: Task, categoryId: string, deleteRecurring: boolean) => {
+            // Snapshot the task into the pending map
+            pendingRef.current.set(task.id, {
+                task: { ...task },
+                categoryId,
+                deleteRecurring,
+            });
+
+            // Optimistic UI removal
+            removeFromCategory(categoryId, task.id);
+
+            // Haptic feedback
+            if (Platform.OS === "ios") {
+                Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+            }
+
+            // Schedule (or reschedule) the flush
+            scheduleFlush();
+        },
+        [removeFromCategory, scheduleFlush]
+    );
+
+    const deleteWithUndo = useCallback(
+        (task: Task, categoryId: string) => {
+            if (task.templateID) {
+                // Show recurring task dialog
+                setAlertTitle("Delete Recurring Task");
+                setAlertMessage(
+                    "Do you want to delete only this task or all future tasks?"
+                );
+                setAlertButtons([
+                    {
+                        text: "Cancel",
+                        style: "cancel",
+                    },
+                    {
+                        text: "Only This Task",
+                        onPress: () => enqueuePendingDelete(task, categoryId, false),
+                    },
+                    {
+                        text: "All Future Tasks",
+                        onPress: () => enqueuePendingDelete(task, categoryId, true),
+                        style: "destructive",
+                    },
+                ]);
+                setAlertVisible(true);
+            } else {
+                enqueuePendingDelete(task, categoryId, false);
+            }
+        },
+        [enqueuePendingDelete]
+    );
+
+    const alertElement = alertVisible ? (
+        <CustomAlert
+            visible={alertVisible}
+            setVisible={setAlertVisible}
+            title={alertTitle}
+            message={alertMessage}
+            buttons={alertButtons}
+        />
+    ) : null;
+
+    return { deleteWithUndo, alertElement };
+}
+```
+
+- [ ] **Step 2: Verify no TypeScript errors**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+Expected: No errors in useUndoableDelete.tsx.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useUndoableDelete.tsx
+git commit -m "feat: add useUndoableDelete hook with rolling batch undo"
+```
+
+---
+
+### Task 3: Integrate into SwipableTaskCard
+
+**Files:**
+- Modify: `frontend/components/cards/SwipableTaskCard.tsx`
+
+- [ ] **Step 1: Replace the inline delete with the hook**
+
+In `SwipableTaskCard.tsx`, make these changes:
+
+**a) Update imports** — remove `removeFromCategoryAPI` from the task import (line 12), remove `CustomAlert` and `AlertButton` imports (line 19). Add `useUndoableDelete`:
+
+Replace:
+```tsx
+import { markAsCompletedAPI, activateTaskAPI, removeFromCategoryAPI } from "@/api/task";
+```
+With:
+```tsx
+import { markAsCompletedAPI, activateTaskAPI } from "@/api/task";
+```
+
+Replace:
+```tsx
+import CustomAlert, { AlertButton } from "../modals/CustomAlert";
+```
+With:
+```tsx
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
+```
+
+**b) Inside the component**, remove alert state (lines 41-44) and the `deleteTask` function (lines 58-103). Add the hook call after the existing `useTasks()` line:
+
+Remove these lines:
+```tsx
+    // Alert state
+    const [alertVisible, setAlertVisible] = React.useState(false);
+    const [alertTitle, setAlertTitle] = React.useState("");
+    const [alertMessage, setAlertMessage] = React.useState("");
+    const [alertButtons, setAlertButtons] = React.useState<AlertButton[]>([]);
+```
+
+And remove the entire `deleteTask` function (lines 58-103).
+
+Add after the `useThemeColor()` call:
+```tsx
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
+```
+
+**c) Update the trash button callback** (line 268) — replace `() => deleteTask(categoryId, task.id)` with:
+```tsx
+() => deleteWithUndo(task, categoryId)
+```
+
+**d) Replace CustomAlert render blocks** — in both the phantom card return (lines 220-228) and the main return (lines 284-292), replace:
+```tsx
+                {alertVisible && (
+                    <CustomAlert
+                        visible={alertVisible}
+                        setVisible={setAlertVisible}
+                        title={alertTitle}
+                        message={alertMessage}
+                        buttons={alertButtons}
+                    />
+                )}
+```
+With:
+```tsx
+                {alertElement}
+```
+
+- [ ] **Step 2: Verify no TypeScript errors**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/cards/SwipableTaskCard.tsx
+git commit -m "refactor: use useUndoableDelete in SwipableTaskCard"
+```
+
+---
+
+### Task 4: Integrate into SchedulableTaskCard
+
+**Files:**
+- Modify: `frontend/components/cards/SchedulableTaskCard.tsx`
+
+- [ ] **Step 1: Replace the inline delete with the hook**
+
+**a) Update imports** — remove `removeFromCategoryAPI` (line 13), remove `CustomAlert` and `AlertButton` (line 19). Add hook:
+
+Replace:
+```tsx
+import { markAsCompletedAPI, activateTaskAPI, removeFromCategoryAPI } from "@/api/task";
+```
+With:
+```tsx
+import { markAsCompletedAPI, activateTaskAPI } from "@/api/task";
+```
+
+Replace:
+```tsx
+import CustomAlert, { AlertButton } from "../modals/CustomAlert";
+```
+With:
+```tsx
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
+```
+
+**b) Inside the component**, remove alert state (lines 40-43) and `deleteTask` function (lines 49-90). Add the hook:
+
+Remove:
+```tsx
+    // Alert state
+    const [alertVisible, setAlertVisible] = React.useState(false);
+    const [alertTitle, setAlertTitle] = React.useState("");
+    const [alertMessage, setAlertMessage] = React.useState("");
+    const [alertButtons, setAlertButtons] = React.useState<AlertButton[]>([]);
+```
+
+Remove the entire `deleteTask` function (lines 49-90).
+
+Add after the `useThemeColor()` call:
+```tsx
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
+```
+
+**c) Update `handleRightSwipe`** (lines 93-99) — replace the fallback:
+
+Replace:
+```tsx
+    const handleRightSwipe = () => {
+        if (onRightSwipe) {
+            onRightSwipe();
+        } else {
+            deleteTask(categoryId, task.id);
+        }
+    };
+```
+With:
+```tsx
+    const handleRightSwipe = () => {
+        if (onRightSwipe) {
+            onRightSwipe();
+        } else {
+            deleteWithUndo(task, categoryId);
+        }
+    };
+```
+
+**d) Replace the CustomAlert render** (lines 131-139):
+
+Replace:
+```tsx
+            {alertVisible && (
+                <CustomAlert
+                    visible={alertVisible}
+                    setVisible={setAlertVisible}
+                    title={alertTitle}
+                    message={alertMessage}
+                    buttons={alertButtons}
+                />
+            )}
+```
+With:
+```tsx
+            {alertElement}
+```
+
+- [ ] **Step 2: Verify no TypeScript errors**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/cards/SchedulableTaskCard.tsx
+git commit -m "refactor: use useUndoableDelete in SchedulableTaskCard"
+```
+
+---
+
+### Task 5: Integrate into CalendarView
+
+**Files:**
+- Modify: `frontend/components/daily/CalendarView.tsx`
+
+- [ ] **Step 1: Replace the inline delete with the hook**
+
+**a) Update imports** (line 24) — remove `removeFromCategoryAPI` from the import:
+
+Replace:
+```tsx
+import { updateTaskAPI, removeFromCategoryAPI, markAsCompletedAPI } from "@/api/task";
+```
+With:
+```tsx
+import { updateTaskAPI, markAsCompletedAPI } from "@/api/task";
+```
+
+Remove the `Alert` import from react-native (line 2) if no other uses of `Alert` remain in the file. Check first — if `Alert` is used elsewhere in CalendarView, keep it.
+
+Add:
+```tsx
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
+```
+
+**b) Inside the component**, add the hook near the other hooks (after line 62):
+
+```tsx
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
+```
+
+**c) Replace `handleDeleteTask`** (lines 429-459) with:
+
+```tsx
+    const handleDeleteTask = () => {
+        if (!selectedTask?.id || !selectedTask?.categoryID) return;
+        setContextMenuVisible(false);
+        deleteWithUndo(selectedTask as Task, selectedTask.categoryID);
+    };
+```
+
+Note: The `isDeleting` state (line 72) and its usage on the delete button can be removed since the delete is now deferred. Remove `const [isDeleting, setIsDeleting] = useState(false);` and any references to `isDeleting` in the delete button's disabled prop or label.
+
+**d) Render `{alertElement}`** — add it right before the closing tag of the component's return, next to the other modals.
+
+- [ ] **Step 2: Verify no TypeScript errors and check `Alert` usage**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && grep -n "Alert\." frontend/components/daily/CalendarView.tsx
+```
+
+If `Alert.alert` is only used in the deleted `handleDeleteTask`, remove the `Alert` import. If used elsewhere, keep it.
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/daily/CalendarView.tsx
+git commit -m "refactor: use useUndoableDelete in CalendarView"
+```
+
+---
+
+### Task 6: Integrate into Review screen
+
+**Files:**
+- Modify: `frontend/app/(logged-in)/(tabs)/(task)/review.tsx`
+
+- [ ] **Step 1: Replace the inline delete with the hook**
+
+**a) Update imports** (line 14) — remove `removeFromCategoryAPI`:
+
+Replace:
+```tsx
+import { markAsCompletedAPI, removeFromCategoryAPI } from "@/api/task";
+```
+With:
+```tsx
+import { markAsCompletedAPI } from "@/api/task";
+```
+
+Add:
+```tsx
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
+```
+
+**b) Inside the `Review` component**, add the hook after the existing hooks (around line 23):
+
+```tsx
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
+```
+
+**c) Replace `handleDelete`** (lines 193-202) with:
+
+```tsx
+    const handleDelete = async (task: Task): Promise<void> => {
+        if (!task.categoryID) {
+            throw new Error("Task category ID is missing");
+        }
+        deleteWithUndo(task, task.categoryID);
+    };
+```
+
+Note: Remove `debouncedFetchWorkspaces()` from the delete path — the hook's `flushPending` handles the API call. The debounced fetch for completion (`handleComplete`) stays as-is.
+
+**d) Render `{alertElement}`** — add it inside the component's return JSX, near the bottom (before the closing `</ThemedView>` or equivalent wrapper).
+
+- [ ] **Step 2: Verify no TypeScript errors**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/app/\(logged-in\)/\(tabs\)/\(task\)/review.tsx
+git commit -m "refactor: use useUndoableDelete in review screen"
+```
+
+---
+
+### Task 7: Manual smoke test
+
+- [ ] **Step 1: Test single delete + undo on home screen**
+
+1. Open the app, navigate to a workspace with tasks
+2. Swipe right on a task card → tap trash icon
+3. Verify: task disappears immediately, "1 task deleted · Undo" toast appears
+4. Tap "Undo" within 5 seconds
+5. Verify: task reappears in its original position
+
+- [ ] **Step 2: Test single delete + timer expiry**
+
+1. Swipe to delete a non-recurring task
+2. Wait 5 seconds without tapping undo
+3. Verify: toast disappears, task stays gone
+4. Pull to refresh or navigate away and back
+5. Verify: task is still gone (API was called)
+
+- [ ] **Step 3: Test batch delete + undo**
+
+1. Delete task A
+2. Within 5 seconds, delete task B
+3. Verify: toast updates to "2 tasks deleted · Undo"
+4. Tap Undo
+5. Verify: both tasks A and B reappear
+
+- [ ] **Step 4: Test recurring task delete**
+
+1. Find a recurring task (has template)
+2. Swipe to delete → verify "Delete Recurring Task" dialog appears
+3. Choose "Only This Task"
+4. Verify: undo toast appears, task is removed
+5. Tap Undo → verify task reappears
+
+- [ ] **Step 5: Test CalendarView delete**
+
+1. Navigate to Daily view
+2. Long-press a task → tap "Delete Task" in context menu
+3. Verify: context menu closes, undo toast appears
+4. Let timer expire
+5. Verify: task is deleted
+
+- [ ] **Step 6: Test Review screen delete**
+
+1. Navigate to Review screen
+2. Swipe a task down (delete direction)
+3. Verify: undo toast appears
+4. For a recurring task, verify dialog appears first
+
+- [ ] **Step 7: Commit final state**
+
+If any TypeScript issues were found and fixed during smoke testing:
+
+```bash
+git add -A
+git commit -m "fix: address issues found during undoable delete smoke test"
+```

--- a/docs/superpowers/specs/2026-05-06-backend-refactor-design.md
+++ b/docs/superpowers/specs/2026-05-06-backend-refactor-design.md
@@ -1,0 +1,316 @@
+# Backend Refactor: Auth Consolidation, Task Split, Bulk Dedup, Repository Pattern
+
+**Date:** 2026-05-06
+**Scope:** 5 refactors executed in 4 phases via Approach C (interleaved, safe-to-ship increments)
+**Constraint:** Purely structural — zero functional changes. Tests run after every meaningful change.
+
+---
+
+## Phase 1: Auth Consolidation
+
+### Problem
+
+The auth package has ~400-500 lines of duplicated code:
+- 4 login handlers build identical `SafeUser` responses and token pairs
+- 3 registration handlers funnel through `RegisterWithContext` but duplicate OAuth setup
+- `middleware.go` and `fiber_middleware.go` contain ~100 lines of identical validation/refresh logic
+- 5 `LoginFrom*` service methods each do the same `FindOne` + decode + error check
+
+### Solution: `AuthenticationService` Interface
+
+```go
+type AuthenticationService interface {
+    // Login flows — all return unified AuthResult
+    LoginWithCredentials(ctx context.Context, email, password string) (*AuthResult, error)
+    LoginWithPhone(ctx context.Context, phone, password string) (*AuthResult, error)
+    LoginWithGoogle(ctx context.Context, googleID string) (*AuthResult, error)
+    LoginWithApple(ctx context.Context, appleID string) (*AuthResult, error)
+    LoginWithOTP(ctx context.Context, phone string) (*AuthResult, error)
+
+    // Token management
+    GenerateTokens(ctx context.Context, userID string, count float64, timezone string) (access string, refresh string, err error)
+    ValidateToken(ctx context.Context, token string) (userID string, count float64, timezone string, err error)
+    InvalidateTokens(ctx context.Context, userID string) error
+
+    // Registration — single method, optional OAuth provider
+    Register(ctx context.Context, req RegisterRequest, provider *OAuthProvider) (*AuthResult, error)
+
+    // OTP
+    SendOTP(ctx context.Context, phone string) (string, error)
+    VerifyOTP(ctx context.Context, phone, code string) (bool, string, error)
+
+    // Account management
+    DeleteAccount(ctx context.Context, userID primitive.ObjectID) error
+    AcceptTerms(ctx context.Context, userID primitive.ObjectID, version string) (*time.Time, error)
+    UpdatePushToken(ctx context.Context, userID primitive.ObjectID, token string) error
+}
+
+// AuthResult — unified return type for all login/register flows
+type AuthResult struct {
+    AccessToken  string
+    RefreshToken string
+    User         types.SafeUser
+}
+
+// OAuthProvider — optional, passed for Google/Apple registration
+type OAuthProvider struct {
+    Type string // "google" or "apple"
+    ID   string
+}
+```
+
+### Extraction Details
+
+**1a. `buildSafeUserResponse(user *User) types.SafeUser`**
+- New file: `auth/helpers.go`
+- Replaces 6 identical 14-field SafeUser construction blocks
+
+**1b. `completeLogin(service, userID, count, user, timezone) (*AuthResult, error)`**
+- Shared tail for all `LoginWith*` methods
+- Handles: timezone defaulting to UTC, token generation, SafeUser building, AuthResult assembly
+
+**1c. Private `findByField(ctx, field, value) (*User, error)`**
+- Internal implementation detail composing the typed public lookups
+- Public API stays explicit: `GetUserByEmail`, `GetUserByAppleID`, etc.
+- Password-based flows add bcrypt check after the lookup
+
+**1d. Middleware consolidation**
+- Extract shared validation + token-refresh logic into a common function
+- Thin adapters for HTTP (`middleware.go`) and Fiber (`fiber_middleware.go`)
+- Both adapters consume `AuthenticationService` interface
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `auth/helpers.go` | New — `buildSafeUserResponse`, `completeLogin` |
+| `auth/service.go` | Refactor to implement `AuthenticationService`, extract `findByField` |
+| `auth/auth.go` | Slim down handlers to: validate input, call service, return result |
+| `auth/types.go` | Add `AuthResult`, `OAuthProvider`, `AuthenticationService` interface |
+| `auth/middleware.go` | Extract shared logic, use thin adapter |
+| `auth/fiber_middleware.go` | Extract shared logic, use thin adapter |
+| `auth/operations.go` | No changes (Huma operation types stay) |
+| `auth/routes.go` | No changes |
+
+---
+
+## Phase 2: Task Service Split
+
+### Problem
+
+`task/service.go` is 2858 lines with 44 methods spanning CRUD, templates, flex tasks, queries, and reminders. `task/task.go` is 1953 lines with 30+ handlers. Both are too large to navigate or reason about.
+
+### Solution: File-Level Split (Same Package)
+
+Split by domain into separate files. The `Service` struct remains the single entry point — this is a **file-only reorganization**, no new structs or constructor changes.
+
+### Service Split
+
+| New file | Methods moved | ~Lines |
+|----------|--------------|--------|
+| `task_service.go` | Core CRUD: `CreateTask`, `UpdatePartialTask`, `DeleteTask`, `DeleteTaskByID`, `GetTaskByID`, `GetTasksByUser`, `CompleteTask`, `BulkCompleteTask`, `BulkDeleteTask`, `ActivateTask`, `IncrementTaskCompletedAndDelete` + field updates: `UpdateTaskDeadline`, `UpdateTaskStart`, `UpdateTaskReminders`, `UpdateTaskNotes`, `UpdateTaskChecklist` + `verifyCategoryOwnership` | ~800 |
+| `template_service.go` | `CreateTemplateTask`, `CreateTemplateForTask`, `CreateTaskFromTemplate`, `DeleteTemplateTask`, `DeleteTaskFromTemplateID`, `UpdateTemplateTask`, `GetTemplateByID`, `GetTemplatesByUserWithCategory`, `GetDueRecurringTasks`, `GetTasksWithStartTimesOlderThanOneDay`, `GetRecurringTasksWithPastDeadlines`, `ScheduleNextRecurrence`, `ResetTemplateMetrics`, `UndoMissedTask` | ~900 |
+| `flex_service.go` | `createFlexTemplateForTask`, `createFlexTaskFromTemplate`, `handleFlexCompletion` | ~300 |
+| `query_service.go` | `QueryTasksByUser`, `GetCompletedTasks`, `GetCompletedTasksByDate`, `GetActiveTasks`, `GetPublicTasks`, `GetRandomTaskForToday` | ~350 |
+
+**Existing files that stay as-is:** `util.go`, `flex_period*.go`, `checkin.go`, `reminder.go`, `cron.go`, `task_helpers.go`
+
+**Deleted file:** `service.go` (all methods moved to the 4 new files above)
+
+### Handler Split
+
+| New file | Handlers moved |
+|----------|---------------|
+| `task_handlers.go` | CRUD + field update + completion + status + bulk handlers |
+| `template_handlers.go` | All template/recurring handlers |
+| `query_handlers.go` | Query + completed tasks handlers |
+| `nlp_handlers.go` | All 6 natural language AI handlers |
+
+**Deleted file:** `task.go` (all handlers moved to the 4 new files above)
+
+### Operations Split
+
+| New file | Types moved |
+|----------|-------------|
+| `task_operations.go` | CRUD + field update + bulk I/O types |
+| `template_operations.go` | Template/recurring I/O types |
+| `query_operations.go` | Query + completed tasks I/O types |
+| `nlp_operations.go` | All NLP I/O types + local Gemini mirror types |
+
+**Deleted file:** `operations.go` (all types moved to the 4 new files above)
+
+---
+
+## Phase 3: Bulk Operation Deduplication
+
+### Problem
+
+`BulkCompleteTask` and `BulkDeleteTask` duplicate ~95% of their single-item counterparts with loop wrappers.
+
+### Solution
+
+Make the single-op the primitive. Bulk becomes a thin iterator + result aggregator:
+
+```go
+func (s *Service) BulkCompleteTask(ctx context.Context, userID primitive.ObjectID, tasks []BulkCompleteTaskItem) (*BulkCompleteTaskOutput, error) {
+    var results []CompleteTaskResult
+    var errs []BulkTaskError
+    for _, t := range tasks {
+        result, err := s.CompleteTask(ctx, userID, t.ID, t.CategoryID, t.Data)
+        if err != nil {
+            errs = append(errs, BulkTaskError{ID: t.ID, Err: err})
+            continue
+        }
+        results = append(results, *result)
+    }
+    return &BulkCompleteTaskOutput{Results: results, Errors: errs}, nil
+}
+```
+
+Same pattern for `BulkDeleteTask`.
+
+**Caveat:** If current bulk implementations use MongoDB batch operations (`UpdateMany`, `BulkWrite`) for performance, those optimizations stay. Only consolidate where the logic is truly duplicated single-item calls in a loop.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `task_service.go` | Refactor bulk methods to delegate to single-op methods |
+
+---
+
+## Phase 4: Repository Interfaces + Shared Helpers
+
+### Problem
+
+All services directly use `*mongo.Collection` with string-based lookups. No interfaces, no testability, duplicated query patterns across services.
+
+### Solution
+
+New package `internal/repository/` with typed interfaces and a `mongo/` sub-package for implementation.
+
+### Package Structure
+
+```
+internal/repository/
+├── interfaces.go         # All repository interfaces
+├── errors.go             # Shared errors (ErrNotFound, ErrDuplicate)
+└── mongo/
+    ├── user_repo.go      # UserRepository implementation
+    ├── task_repo.go       # TaskRepository implementation
+    ├── template_repo.go   # TemplateTaskRepository implementation
+    ├── helpers.go         # Shared private MongoDB helpers
+    └── completed_task_repo.go
+```
+
+### Interfaces
+
+```go
+// interfaces.go
+
+type UserRepository interface {
+    GetUserByID(ctx context.Context, id primitive.ObjectID) (*types.User, error)
+    GetUserByEmail(ctx context.Context, email string) (*types.User, error)
+    GetUserByPhone(ctx context.Context, phone string) (*types.User, error)
+    GetUserByGoogleID(ctx context.Context, googleID string) (*types.User, error)
+    GetUserByAppleID(ctx context.Context, appleID string) (*types.User, error)
+    CreateUser(ctx context.Context, user *types.User) error
+    UpdateUser(ctx context.Context, id primitive.ObjectID, update bson.M) error
+    DeleteUser(ctx context.Context, id primitive.ObjectID) error
+    GetUsersWithPushTokens(ctx context.Context) ([]types.User, error)
+    IncrementUserCount(ctx context.Context, id primitive.ObjectID) error
+    UpdatePushToken(ctx context.Context, id primitive.ObjectID, token string) error
+    CheckTokenCount(ctx context.Context, id primitive.ObjectID) (float64, error)
+    MarkTokenUsed(ctx context.Context, id primitive.ObjectID) error
+    CheckIfTokenUsed(ctx context.Context, id primitive.ObjectID) (bool, error)
+    AcceptTerms(ctx context.Context, id primitive.ObjectID, version string) (*time.Time, error)
+}
+
+type TaskRepository interface {
+    GetTaskByID(ctx context.Context, taskID, userID primitive.ObjectID) (*types.TaskDocument, error)
+    GetTasksByUser(ctx context.Context, userID primitive.ObjectID, sort bson.D) ([]types.TaskDocument, error)
+    GetPublicTasks(ctx context.Context, userID primitive.ObjectID, sort bson.D) ([]types.TaskDocument, error)
+    CreateTask(ctx context.Context, categoryID primitive.ObjectID, task *types.TaskDocument) (*types.TaskDocument, error)
+    UpdateTask(ctx context.Context, taskID, categoryID primitive.ObjectID, update interface{}) error
+    DeleteTask(ctx context.Context, categoryID, taskID primitive.ObjectID) error
+    UpdateTaskField(ctx context.Context, taskID, categoryID, userID primitive.ObjectID, field string, value interface{}) error
+    CompleteTask(ctx context.Context, categoryID, taskID primitive.ObjectID, update bson.M) error
+    QueryTasks(ctx context.Context, userID primitive.ObjectID, filters interface{}) ([]types.TaskDocument, error)
+    GetCompletedTasks(ctx context.Context, userID primitive.ObjectID, page, limit int) ([]types.TaskDocument, int64, error)
+    GetCompletedTasksByDate(ctx context.Context, userID primitive.ObjectID, date time.Time) ([]types.TaskDocument, error)
+    GetActiveTasks(ctx context.Context, userID primitive.ObjectID) ([]types.TaskDocument, error)
+}
+
+type TemplateTaskRepository interface {
+    GetTemplateByID(ctx context.Context, id primitive.ObjectID) (*types.TemplateTaskDocument, error)
+    CreateTemplate(ctx context.Context, template *types.TemplateTaskDocument) (*types.TemplateTaskDocument, error)
+    UpdateTemplate(ctx context.Context, id primitive.ObjectID, update interface{}) error
+    DeleteTemplate(ctx context.Context, id primitive.ObjectID) error
+    GetDueRecurringTasks(ctx context.Context) ([]types.TemplateTaskDocument, error)
+    GetTemplatesByUser(ctx context.Context, userID primitive.ObjectID) ([]types.TemplateTaskDocument, error)
+    GetTasksWithOldStartTimes(ctx context.Context, userIDs ...primitive.ObjectID) ([]types.TemplateTaskDocument, error)
+    GetRecurringWithPastDeadlines(ctx context.Context, userIDs ...primitive.ObjectID) ([]types.TemplateTaskDocument, error)
+    ResetMetrics(ctx context.Context, id primitive.ObjectID) error
+}
+```
+
+### Shared Private Helpers (`mongo/helpers.go`)
+
+```go
+func findOneByField[T any](ctx context.Context, coll *mongo.Collection, field string, value any) (*T, error)
+func findMany[T any](ctx context.Context, coll *mongo.Collection, filter bson.M, opts ...*options.FindOptions) ([]T, error)
+func updateOneByID(ctx context.Context, coll *mongo.Collection, id primitive.ObjectID, update bson.M) error
+func pushToArray(ctx context.Context, coll *mongo.Collection, docID primitive.ObjectID, arrayField string, element any) error
+```
+
+These are private to the `mongo` sub-package. Public API is always the typed repository methods (e.g. `GetUserByEmail`, not `findOneByField`).
+
+### Migration Scope
+
+- **Phase 4 migrates:** auth service + task service only
+- **Out of scope:** post, connection, profile, category, and other services stay on raw collections
+- Services receive repository interfaces via constructor injection
+- Existing `newService(collections)` pattern changes to `newService(repos)` for migrated services
+
+### Service Constructor Changes
+
+```go
+// Before (auth)
+func newService(collections map[string]*mongo.Collection, config config.Config) *Service
+
+// After (auth)
+func newService(users repository.UserRepository, config config.Config) *Service
+
+// Before (task)
+func newService(collections map[string]*mongo.Collection) *Service
+
+// After (task)
+func newService(tasks repository.TaskRepository, templates repository.TemplateTaskRepository, users repository.UserRepository) *Service
+```
+
+Routes functions create the concrete MongoDB repos and pass them in.
+
+---
+
+## Execution Order & Test Strategy
+
+| Phase | Scope | Test checkpoint |
+|-------|-------|-----------------|
+| 1 | Auth consolidation | Run `go test ./internal/handlers/auth/...` after each extraction |
+| 2 | Task file split | Run `go test ./internal/handlers/task/...` after each file move |
+| 3 | Bulk dedup | Run `go test ./internal/handlers/task/...` after refactoring each bulk method |
+| 4 | Repository interfaces | Run `go test ./...` after migrating each service |
+
+Each phase is independently shippable as its own PR/commit.
+
+---
+
+## Out of Scope
+
+- Query builders
+- Caching layer
+- Migrating services other than auth and task to repositories
+- Changing any API behavior, request/response shapes, or route paths
+- Adding new tests (existing tests must continue to pass)
+- Refactoring the Gemini/AI integration
+- Completing the Huma migration for sockets

--- a/docs/superpowers/specs/2026-05-06-undoable-delete-design.md
+++ b/docs/superpowers/specs/2026-05-06-undoable-delete-design.md
@@ -1,0 +1,174 @@
+# Undoable Task Delete - Frontend-Delayed Delete with Rolling Batch Undo
+
+## Summary
+
+When a user swipes to delete a task, remove it from the UI immediately but delay the API call for 5 seconds. Show an undo toast that accumulates multiple deletes into a single batch. Tapping "Undo" restores all pending tasks; letting the timer expire fires all delete API calls.
+
+## Motivation
+
+Currently, task deletion is instant and irreversible from the frontend. Accidental swipes cause data loss with no recovery path. This is especially dangerous on the review screen where swipe-to-delete has no confirmation dialog (for non-recurring tasks).
+
+## Architecture
+
+### New Files
+
+#### 1. `frontend/hooks/useUndoableDelete.tsx`
+
+A hook that manages the entire delayed-delete lifecycle.
+
+**Returns:**
+- `deleteWithUndo(task: Task, categoryId: string)` - main function called by components
+- `alertElement: JSX.Element | null` - CustomAlert for recurring task dialog, rendered by consuming component
+
+**Internal state:**
+- `pendingDeletesRef = useRef<Map<string, PendingDelete>>()` - map of taskId to snapshot
+- `timerRef = useRef<ReturnType<typeof setTimeout>>()` - single rolling timer
+- Alert state for recurring task dialog (`alertVisible`, `alertTitle`, `alertMessage`, `alertButtons`)
+
+**PendingDelete type:**
+```typescript
+interface PendingDelete {
+  task: Task;
+  categoryId: string;
+  deleteRecurring: boolean;
+}
+```
+
+**Flow:**
+
+```
+deleteWithUndo(task, categoryId):
+  1. If task.templateID exists:
+     → Show CustomAlert: "Cancel" / "Only This Task" / "All Future Tasks"
+     → On cancel: abort
+     → On choice: set deleteRecurring flag, continue to step 2
+  2. If no templateID: deleteRecurring = false, continue to step 2
+
+  3. Snapshot task + categoryId + deleteRecurring into pendingDeletesRef Map
+  4. removeFromCategory(categoryId, taskId)  // optimistic UI removal
+  5. Haptic feedback (warning, iOS only)
+  6. Clear existing timer (if any)
+  7. Show UndoToast via showToastable:
+     - message: "N task(s) deleted"
+     - duration: 5000ms
+     - renderContent: UndoToast with onUndo callback
+  8. Start new 5-second setTimeout
+
+  On Undo (user taps button):
+    - clearTimeout
+    - For each entry in pendingDeletesRef: addToCategory(categoryId, task)
+    - Clear the Map
+    - hideToastable()
+
+  On timer expiry:
+    - Partition pending deletes:
+      - Non-recurring (deleteRecurring=false): use bulkDeleteTasksAPI if multiple, removeFromCategoryAPI if single
+      - Recurring with deleteRecurring=true: individual removeFromCategoryAPI calls
+    - On error for any task: addToCategory to restore that task + show error toast
+    - Clear the Map
+```
+
+**Dependencies used from context/hooks:**
+- `useTasks()` → `removeFromCategory`, `addToCategory`
+- `removeFromCategoryAPI`, `bulkDeleteTasksAPI` from `@/api/task`
+- `showToastable`, `hideToastable` from `react-native-toastable`
+- `Haptics` from `expo-haptics`
+
+#### 2. `frontend/components/ui/UndoToast.tsx`
+
+Custom toast component following the same pattern as `DefaultToast`.
+
+**Props:** Extends `ToastableBodyParams` with:
+- `onUndo: () => void` - callback when undo button pressed
+- `count: number` - number of tasks pending deletion
+
+**Layout:**
+- Left side: message text ("N task(s) deleted")
+- Right side: "Undo" text button (themed primary color)
+- Bottom border: warning color
+- Same pan-gesture dismiss behavior as DefaultToast
+
+**Styling:**
+- Matches DefaultToast dimensions (80-90% screen width)
+- Same shadow, border radius, background
+- "Undo" button: bold text, primary color, tappable area with padding
+
+### Changes to Existing Files
+
+#### 3. `frontend/components/cards/SwipableTaskCard.tsx`
+
+**Remove:**
+- `deleteTask` function (lines 58-103)
+- Alert state variables (lines 41-44)
+- `CustomAlert` import and render (lines 19, 284-292)
+- `removeFromCategoryAPI` import (line 12, partially - still used elsewhere? No, completion is separate)
+
+**Add:**
+- Import and call `useUndoableDelete`
+- `const { deleteWithUndo, alertElement } = useUndoableDelete();`
+- Trash button callback: `() => deleteWithUndo(task, categoryId)`
+- Render `{alertElement}` where `<CustomAlert>` was
+
+#### 4. `frontend/components/cards/SchedulableTaskCard.tsx`
+
+**Same pattern as SwipableTaskCard:**
+- Remove `deleteTask` function (lines 49-90), alert state (lines 40-43), `CustomAlert` render
+- Add `useUndoableDelete` hook
+- `handleRightSwipe` falls through to `deleteWithUndo` when no `onRightSwipe` prop
+
+#### 5. `frontend/components/daily/CalendarView.tsx`
+
+**Remove:**
+- `handleDeleteTask` function (lines 429-459)
+- The `Alert.alert` call for recurring tasks
+
+**Add:**
+- `useUndoableDelete` hook
+- Replace delete handler: `() => deleteWithUndo(selectedTask, selectedTask.categoryID)`
+- Context menu close still happens immediately (before the timer)
+
+#### 6. `frontend/app/(logged-in)/(tabs)/(task)/review.tsx`
+
+**Change in `handleDelete`:**
+- Currently calls `removeFromCategoryAPI` directly (line 198)
+- Replace with `deleteWithUndo(task, task.categoryID)`
+- The review screen's `removeTaskFromUI` (local card removal from the swipe stack) still fires immediately - this is separate from the context-level `removeFromCategory` that the hook calls
+- Note: review screen doesn't show recurring dialogs currently (always passes `false`). With the hook, recurring tasks swiped down will now show the dialog, which is an improvement.
+
+## Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Multiple rapid deletes | Each adds to pending Map, timer resets, toast updates count |
+| Undo after multiple deletes | All pending tasks restored at once |
+| Toast swiped away by user | Timer continues; API fires when it expires |
+| App backgrounded during timer | setTimeout pauses on iOS/Android, resumes on foreground |
+| API error on delayed call | Failed task restored via addToCategory, error toast shown |
+| Recurring "All Future Tasks" | deleteRecurring=true captured in snapshot, passed to API on timer |
+| Delete then undo then delete same task | Works - task re-enters Map on second delete |
+| Component unmounts during timer | useEffect cleanup clears timer, fires all pending API calls immediately |
+
+## Component Unmount Handling
+
+The hook registers a cleanup in `useEffect` that, on unmount:
+1. Clears the timer
+2. Fires all pending API calls immediately (no undo possible after navigating away)
+
+This prevents tasks from being removed from UI but never deleted on the backend.
+
+## What Does NOT Change
+
+- Task completion flow (useTaskCompletion hook)
+- tasksContext.tsx (addToCategory and removeFromCategory already exist)
+- Backend (no changes)
+- bulkDeleteTasksAPI already exists in api/task.ts
+
+## Testing Considerations
+
+- Verify single delete → undo restores task
+- Verify single delete → timer fires → API called
+- Verify 3 rapid deletes → undo restores all 3
+- Verify recurring task shows dialog before adding to pending
+- Verify "All Future Tasks" flag is preserved through timer
+- Verify component unmount fires pending deletes
+- Verify API error restores task to UI

--- a/frontend/app/(logged-in)/(tabs)/(task)/review.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/review.tsx
@@ -11,7 +11,8 @@ import PrimaryButton from "@/components/inputs/PrimaryButton";
 import { useTasks } from "@/contexts/tasksContext";
 import { Task } from "@/api/types";
 import ConditionalView from "@/components/ui/ConditionalView";
-import { markAsCompletedAPI, removeFromCategoryAPI } from "@/api/task";
+import { markAsCompletedAPI } from "@/api/task";
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
 import { useDebounce } from "@/hooks/useDebounce";
 import ReviewSkeletonCard from "@/components/cards/ReviewSkeletonCard";
 import ReviewTaskCard from "@/components/cards/ReviewTaskCard";
@@ -21,6 +22,7 @@ const Review = (props: Props) => {
     const ThemedColor = useThemeColor();
     const router = useRouter();
     const { fetchWorkspaces, unnestedTasks, addToCategory } = useTasks();
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
     const [isLoading, setIsLoading] = useState(false);
     const childRefs = useRef<{ [key: number]: any }>({});
     const [removedTasks, setRemovedTasks] = useState<string[]>([]);
@@ -194,11 +196,7 @@ const Review = (props: Props) => {
         if (!task.categoryID) {
             throw new Error("Task category ID is missing");
         }
-
-        await removeFromCategoryAPI(task.categoryID, task.id, false);
-
-        // Debounced refresh tasks after deletion
-        debouncedFetchWorkspaces();
+        deleteWithUndo(task, task.categoryID);
     };
 
     const resetAnimationAndProcessing = (taskId: string) => {
@@ -361,6 +359,7 @@ const Review = (props: Props) => {
                     />
                 </View> */}
             </View>
+            {alertElement}
         </ThemedView>
     );
 };

--- a/frontend/components/cards/SchedulableTaskCard.tsx
+++ b/frontend/components/cards/SchedulableTaskCard.tsx
@@ -10,13 +10,13 @@ import Reanimated, { SharedValue, useAnimatedStyle, useAnimatedReaction, runOnJS
 import { Dimensions, Platform, StyleSheet, TouchableOpacity } from "react-native";
 import Entypo from "@expo/vector-icons/Entypo";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { markAsCompletedAPI, activateTaskAPI, removeFromCategoryAPI } from "@/api/task";
+import { markAsCompletedAPI, activateTaskAPI } from "@/api/task";
 import { useTasks } from "@/contexts/tasksContext";
 import { hideToastable, showToastable } from "react-native-toastable";
 import TaskToast from "../ui/TaskToast";
 import DefaultToast from "../ui/DefaultToast";
 import * as Haptics from "expo-haptics";
-import CustomAlert, { AlertButton } from "../modals/CustomAlert";
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
 
 type Props = {
     redirect?: boolean;
@@ -35,66 +35,14 @@ const SchedulableTaskCard = ({
 }: Props) => {
     const { removeFromCategory, setShowConfetti } = useTasks();
     const ThemedColor = useThemeColor();
-
-    // Alert state
-    const [alertVisible, setAlertVisible] = React.useState(false);
-    const [alertTitle, setAlertTitle] = React.useState("");
-    const [alertMessage, setAlertMessage] = React.useState("");
-    const [alertButtons, setAlertButtons] = React.useState<AlertButton[]>([]);
-
-    /*
-  Mark as completed function
-*/
-
-    const deleteTask = async (categoryId: string, taskId: string) => {
-        const performDelete = async (deleteRecurring: boolean) => {
-            try {
-                const res = await removeFromCategoryAPI(categoryId, taskId, deleteRecurring);
-                removeFromCategory(categoryId, taskId);
-                console.log(res);
-            } catch (error) {
-                console.log(error);
-                showToastable({
-                    title: "Error",
-                    status: "danger",
-                    position: "top",
-                    message: "Error deleting task",
-                    swipeDirection: "up",
-                    renderContent: (props) => <DefaultToast {...props} />,
-                });
-            }
-        };
-
-        if (task.templateID) {
-            setAlertTitle("Delete Recurring Task");
-            setAlertMessage("Do you want to delete only this task or all future tasks?");
-            setAlertButtons([
-                {
-                    text: "Cancel",
-                    style: "cancel",
-                },
-                {
-                    text: "Only This Task",
-                    onPress: () => performDelete(false),
-                },
-                {
-                    text: "All Future Tasks",
-                    onPress: () => performDelete(true),
-                    style: "destructive",
-                },
-            ]);
-            setAlertVisible(true);
-        } else {
-            performDelete(false);
-        }
-    };
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
 
     // Custom right swipe action - either use provided callback or default delete
     const handleRightSwipe = () => {
         if (onRightSwipe) {
             onRightSwipe();
         } else {
-            deleteTask(categoryId, task.id);
+            deleteWithUndo(task, categoryId);
         }
     };
 
@@ -128,15 +76,7 @@ const SchedulableTaskCard = ({
                 />
             </ReanimatedSwipeable>
 
-            {alertVisible && (
-                <CustomAlert
-                    visible={alertVisible}
-                    setVisible={setAlertVisible}
-                    title={alertTitle}
-                    message={alertMessage}
-                    buttons={alertButtons}
-                />
-            )}
+            {alertElement}
         </>
     );
 }

--- a/frontend/components/cards/SwipableTaskCard.tsx
+++ b/frontend/components/cards/SwipableTaskCard.tsx
@@ -9,14 +9,14 @@ import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeabl
 import Reanimated, { SharedValue, useAnimatedStyle, useAnimatedReaction, runOnJS } from "react-native-reanimated";
 import { Dimensions, Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { markAsCompletedAPI, activateTaskAPI, removeFromCategoryAPI } from "@/api/task";
+import { markAsCompletedAPI, activateTaskAPI } from "@/api/task";
 import { useTasks } from "@/contexts/tasksContext";
 import { hideToastable, showToastable } from "react-native-toastable";
 import TaskToast from "../ui/TaskToast";
 import DefaultToast from "../ui/DefaultToast";
 import * as Haptics from "expo-haptics";
 import { Bell, Flag, Trash } from "phosphor-react-native";
-import CustomAlert, { AlertButton } from "../modals/CustomAlert";
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
 import { AttachStep } from "react-native-spotlight-tour";
 
 type Props = {
@@ -36,12 +36,7 @@ const SwipableTaskCard = ({
 }: Props) => {
     const { removeFromCategory, addToCategory, setShowConfetti, categories } = useTasks();
     const ThemedColor = useThemeColor();
-
-    // Alert state
-    const [alertVisible, setAlertVisible] = React.useState(false);
-    const [alertTitle, setAlertTitle] = React.useState("");
-    const [alertMessage, setAlertMessage] = React.useState("");
-    const [alertButtons, setAlertButtons] = React.useState<AlertButton[]>([]);
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
 
     const finalCategoryName =
         categoryName ||
@@ -54,53 +49,6 @@ const SwipableTaskCard = ({
   Mark as completed function
 
 */
-
-    const deleteTask = async (categoryId: string, taskId: string) => {
-        if (Platform.OS === "ios") {
-            await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
-        }
-
-        const performDelete = async (deleteRecurring: boolean) => {
-            try {
-                const res = await removeFromCategoryAPI(categoryId, taskId, deleteRecurring);
-                removeFromCategory(categoryId, taskId);
-                console.log(res);
-            } catch (error) {
-                console.log(error);
-                showToastable({
-                    title: "Error",
-                    status: "danger",
-                    position: "top",
-                    message: "Error deleting task",
-                    swipeDirection: "up",
-                    renderContent: (props) => <DefaultToast {...props} />,
-                });
-            }
-        };
-
-        if (task.templateID) {
-             setAlertTitle("Delete Recurring Task");
-             setAlertMessage("Do you want to delete only this task or all future tasks?");
-             setAlertButtons([
-                 {
-                     text: "Cancel",
-                     style: "cancel",
-                 },
-                 {
-                     text: "Only This Task",
-                     onPress: () => performDelete(false),
-                 },
-                 {
-                     text: "All Future Tasks",
-                     onPress: () => performDelete(true),
-                     style: "destructive",
-                 },
-             ]);
-             setAlertVisible(true);
-        } else {
-            performDelete(false);
-        }
-    };
 
     const markAsCompleted = async (categoryId: string, taskId: string) => {
         try {
@@ -217,15 +165,7 @@ const SwipableTaskCard = ({
                 ) : (
                     phantomCard
                 )}
-                {alertVisible && (
-                    <CustomAlert
-                        visible={alertVisible}
-                        setVisible={setAlertVisible}
-                        title={alertTitle}
-                        message={alertMessage}
-                        buttons={alertButtons}
-                    />
-                )}
+                {alertElement}
             </>
         );
     }
@@ -265,7 +205,7 @@ const SwipableTaskCard = ({
                         {RightAction(
                             prog,
                             drag,
-                            () => deleteTask(categoryId, task.id),
+                            () => deleteWithUndo(task, categoryId),
                             3,
                             <Trash size={24} color="white" weight="regular" />,
                             ThemedColor.error
@@ -281,15 +221,7 @@ const SwipableTaskCard = ({
                 )}
             </ReanimatedSwipeable>
 
-            {alertVisible && (
-                <CustomAlert
-                    visible={alertVisible}
-                    setVisible={setAlertVisible}
-                    title={alertTitle}
-                    message={alertMessage}
-                    buttons={alertButtons}
-                />
-            )}
+            {alertElement}
         </>
     );
 }

--- a/frontend/components/daily/CalendarView.tsx
+++ b/frontend/components/daily/CalendarView.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from "react";
-import { View, TouchableOpacity, StyleSheet, Alert, Platform } from "react-native";
+import { View, TouchableOpacity, StyleSheet, Platform } from "react-native";
 import { GestureDetector, Gesture } from "react-native-gesture-handler";
 import Animated, {
     useSharedValue,
@@ -21,7 +21,9 @@ import UnscheduledTasksSection from "@/components/task/UnscheduledTasksSection";
 import DefaultModal from "@/components/modals/DefaultModal";
 import { Ionicons } from "@expo/vector-icons";
 import { useTasks } from "@/contexts/tasksContext";
-import { updateTaskAPI, removeFromCategoryAPI, markAsCompletedAPI } from "@/api/task";
+import { updateTaskAPI, markAsCompletedAPI } from "@/api/task";
+import { Task } from "@/api/types";
+import { useUndoableDelete } from "@/hooks/useUndoableDelete";
 import { CalendarEventCard } from "./CalendarEventCard";
 import { TimeRangeGhostBlock } from "./TimeRangeGhostBlock";
 import { useDailyTasks } from "@/hooks/useDailyTasks";
@@ -62,6 +64,7 @@ const CalendarViewComponent: React.FC<CalendarViewProps> = ({
     const { setSelected, updateTask, removeFromCategory, addToCategory } = useTasks();
     const { tasksWithSpecificTime, tasksForTodayNoTime, tasksUnscheduled } =
         useDailyTasks(selectedDate);
+    const { deleteWithUndo, alertElement } = useUndoableDelete();
     const currentTimeLineRef = useRef<View>(null);
     const hasScrolledToFirstEvent = useRef(false);
 
@@ -69,7 +72,6 @@ const CalendarViewComponent: React.FC<CalendarViewProps> = ({
     const [contextMenuVisible, setContextMenuVisible] = useState(false);
     const [selectedTask, setSelectedTask] = useState<any>(null);
     const [isHiding, setIsHiding] = useState(false);
-    const [isDeleting, setIsDeleting] = useState(false);
     const [isCompleting, setIsCompleting] = useState(false);
 
     // Ghost block state
@@ -426,36 +428,10 @@ const CalendarViewComponent: React.FC<CalendarViewProps> = ({
         }
     };
 
-    const handleDeleteTask = async () => {
+    const handleDeleteTask = () => {
         if (!selectedTask?.id || !selectedTask?.categoryID) return;
-
-        const performDelete = async (deleteRecurring: boolean) => {
-            setIsDeleting(true);
-            try {
-                await removeFromCategoryAPI(selectedTask.categoryID, selectedTask.id, deleteRecurring);
-                removeFromCategory(selectedTask.categoryID, selectedTask.id);
-                setContextMenuVisible(false);
-            } catch (error) {
-                logger.error("Failed to delete task", error);
-            } finally {
-                setIsDeleting(false);
-            }
-        };
-
-        if (selectedTask.templateID) {
-            setContextMenuVisible(false);
-            Alert.alert(
-                "Delete Recurring Task",
-                "Do you want to delete only this task or all future tasks?",
-                [
-                    { text: "Cancel", style: "cancel" },
-                    { text: "Only This Task", onPress: () => performDelete(false) },
-                    { text: "All Future Tasks", onPress: () => performDelete(true), style: "destructive" },
-                ]
-            );
-        } else {
-            await performDelete(false);
-        }
+        setContextMenuVisible(false);
+        deleteWithUndo(selectedTask as Task, selectedTask.categoryID);
     };
 
     const handleCompleteTask = async () => {
@@ -884,32 +860,26 @@ const CalendarViewComponent: React.FC<CalendarViewProps> = ({
                     <TouchableOpacity
                         style={styles.menuOption}
                         onPress={handleDeleteTask}
-                        disabled={isDeleting}
                     >
                         <Ionicons
                             name="trash-outline"
                             size={24}
-                            color={
-                                isDeleting
-                                    ? ThemedColor.caption
-                                    : ThemedColor.error
-                            }
+                            color={ThemedColor.error}
                         />
                         <ThemedText
                             type="default"
                             style={{
                                 marginLeft: 12,
                                 flex: 1,
-                                color: isDeleting
-                                    ? ThemedColor.caption
-                                    : ThemedColor.error,
+                                color: ThemedColor.error,
                             }}
                         >
-                            {isDeleting ? "Deleting..." : "Delete Task"}
+                            Delete Task
                         </ThemedText>
                     </TouchableOpacity>
                 </View>
             </DefaultModal>
+            {alertElement}
         </View>
     );
 };

--- a/frontend/components/ui/UndoToast.tsx
+++ b/frontend/components/ui/UndoToast.tsx
@@ -19,7 +19,7 @@ interface UndoToastProps extends ToastableBodyParams {
     count: number;
 }
 
-export default function UndoToast({ message, onUndo, count }: UndoToastProps) {
+export default function UndoToast({ onUndo, count }: UndoToastProps) {
     const ThemedColor = useThemeColor();
     const translateX = useSharedValue(0);
     const translateY = useSharedValue(0);
@@ -70,13 +70,15 @@ export default function UndoToast({ message, onUndo, count }: UndoToastProps) {
             }
         });
 
-    const animatedStyle = useAnimatedStyle(() => ({
-        transform: [
-            { translateX: translateX.value },
-            { translateY: translateY.value },
-        ],
-        opacity: opacity.value,
-    }));
+    const animatedStyle = useAnimatedStyle(() => {
+        return {
+            transform: [
+                { translateX: translateX.value },
+                { translateY: translateY.value },
+            ] as any,
+            opacity: opacity.value,
+        };
+    });
 
     const label = count === 1 ? "1 task deleted" : `${count} tasks deleted`;
 

--- a/frontend/components/ui/UndoToast.tsx
+++ b/frontend/components/ui/UndoToast.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { View, Dimensions, StyleSheet, TouchableOpacity } from "react-native";
+import { ToastableBodyParams, hideToastable } from "react-native-toastable";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Reanimated, {
+    useSharedValue,
+    useAnimatedStyle,
+    runOnJS,
+    withSpring,
+    withTiming,
+} from "react-native-reanimated";
+
+const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
+
+interface UndoToastProps extends ToastableBodyParams {
+    onUndo: () => void;
+    count: number;
+}
+
+export default function UndoToast({ message, onUndo, count }: UndoToastProps) {
+    const ThemedColor = useThemeColor();
+    const translateX = useSharedValue(0);
+    const translateY = useSharedValue(0);
+    const opacity = useSharedValue(1);
+    const startX = useSharedValue(0);
+    const startY = useSharedValue(0);
+
+    React.useEffect(() => {
+        translateX.value = 0;
+        translateY.value = 0;
+        opacity.value = 1;
+    }, []);
+
+    const panGesture = Gesture.Pan()
+        .onBegin(() => {
+            startX.value = translateX.value;
+            startY.value = translateY.value;
+        })
+        .onUpdate((event) => {
+            translateX.value = startX.value + event.translationX;
+            translateY.value = startY.value + event.translationY;
+            const horizontalProgress = Math.abs(translateX.value) / (screenWidth * 0.3);
+            const verticalProgress = Math.abs(translateY.value) / (screenHeight * 0.2);
+            const maxProgress = Math.max(horizontalProgress, verticalProgress);
+            opacity.value = Math.max(0.3, 1 - maxProgress);
+        })
+        .onEnd((event) => {
+            const horizontalThreshold = screenWidth * 0.25;
+            const verticalThreshold = screenHeight * 0.15;
+            const shouldDismissHorizontal =
+                Math.abs(translateX.value) > horizontalThreshold || Math.abs(event.velocityX) > 500;
+            const shouldDismissVertical =
+                translateY.value < -verticalThreshold || event.velocityY < -500;
+
+            if (shouldDismissHorizontal || shouldDismissVertical) {
+                if (shouldDismissVertical) {
+                    translateY.value = withTiming(-screenHeight, { duration: 200 });
+                } else {
+                    const direction = translateX.value > 0 ? 1 : -1;
+                    translateX.value = withTiming(direction * screenWidth, { duration: 200 });
+                }
+                opacity.value = withTiming(0, { duration: 200 });
+                runOnJS(hideToastable)();
+            } else {
+                translateX.value = withSpring(0, { damping: 20, stiffness: 300 });
+                translateY.value = withSpring(0, { damping: 20, stiffness: 300 });
+                opacity.value = withSpring(1, { damping: 20, stiffness: 300 });
+            }
+        });
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [
+            { translateX: translateX.value },
+            { translateY: translateY.value },
+        ],
+        opacity: opacity.value,
+    }));
+
+    const label = count === 1 ? "1 task deleted" : `${count} tasks deleted`;
+
+    return (
+        <GestureDetector gesture={panGesture}>
+            <Reanimated.View style={animatedStyle as any}>
+                <View style={styles.container}>
+                    <View style={[styles.toastBody, {
+                        borderColor: ThemedColor.warning,
+                        backgroundColor: ThemedColor.lightened,
+                    }]}>
+                        <ThemedText type="defaultSemiBold" style={styles.messageText}>
+                            {label}
+                        </ThemedText>
+                        <TouchableOpacity onPress={onUndo} hitSlop={8} style={styles.undoButton}>
+                            <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                                Undo
+                            </ThemedText>
+                        </TouchableOpacity>
+                    </View>
+                </View>
+            </Reanimated.View>
+        </GestureDetector>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 20,
+    },
+    toastBody: {
+        minWidth: screenWidth * 0.8,
+        maxWidth: screenWidth * 0.9,
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        borderRadius: 12,
+        borderBottomWidth: 3,
+        paddingVertical: 16,
+        paddingHorizontal: 20,
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 3 },
+        shadowOpacity: 0.3,
+        shadowRadius: 6,
+        elevation: 8,
+    },
+    messageText: {
+        fontSize: 16,
+        flexShrink: 1,
+    },
+    undoButton: {
+        marginLeft: 16,
+        paddingVertical: 4,
+        paddingHorizontal: 8,
+    },
+});

--- a/frontend/hooks/useUndoableDelete.tsx
+++ b/frontend/hooks/useUndoableDelete.tsx
@@ -19,7 +19,7 @@ interface PendingDelete {
 
 export function useUndoableDelete() {
     const { removeFromCategory, addToCategory } = useTasks();
-    const pendingRef = useRef<Map<string, PendingDelete>>(new Map());
+    const pendingRef = useRef<Map<string, PendingDelete>>(new Map<string, PendingDelete>());
     const timerRef = useRef<ReturnType<typeof setTimeout>>();
 
     // Alert state for recurring task dialog

--- a/frontend/hooks/useUndoableDelete.tsx
+++ b/frontend/hooks/useUndoableDelete.tsx
@@ -1,0 +1,216 @@
+import React, { useRef, useEffect, useCallback, useState } from "react";
+import { Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+import { showToastable, hideToastable } from "react-native-toastable";
+import { useTasks } from "@/contexts/tasksContext";
+import { removeFromCategoryAPI, bulkDeleteTasksAPI } from "@/api/task";
+import { Task } from "@/api/types";
+import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
+import UndoToast from "@/components/ui/UndoToast";
+import DefaultToast from "@/components/ui/DefaultToast";
+
+const UNDO_DELAY_MS = 5000;
+
+interface PendingDelete {
+    task: Task;
+    categoryId: string;
+    deleteRecurring: boolean;
+}
+
+export function useUndoableDelete() {
+    const { removeFromCategory, addToCategory } = useTasks();
+    const pendingRef = useRef<Map<string, PendingDelete>>(new Map());
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+    // Alert state for recurring task dialog
+    const [alertVisible, setAlertVisible] = useState(false);
+    const [alertTitle, setAlertTitle] = useState("");
+    const [alertMessage, setAlertMessage] = useState("");
+    const [alertButtons, setAlertButtons] = useState<AlertButton[]>([]);
+
+    const flushPending = useCallback(async () => {
+        const entries = Array.from(pendingRef.current.values());
+        pendingRef.current.clear();
+        if (entries.length === 0) return;
+
+        // Partition: recurring-template deletes need individual calls
+        const individual: PendingDelete[] = [];
+        const bulkable: PendingDelete[] = [];
+
+        for (const entry of entries) {
+            if (entry.deleteRecurring) {
+                individual.push(entry);
+            } else {
+                bulkable.push(entry);
+            }
+        }
+
+        // Fire bulk delete for non-recurring
+        if (bulkable.length > 0) {
+            try {
+                if (bulkable.length === 1) {
+                    const { categoryId, task } = bulkable[0];
+                    await removeFromCategoryAPI(categoryId, task.id, false);
+                } else {
+                    await bulkDeleteTasksAPI(
+                        bulkable.map(({ categoryId, task }) => ({
+                            categoryId,
+                            taskId: task.id,
+                            deleteRecurring: false,
+                        }))
+                    );
+                }
+            } catch (error) {
+                // Restore failed tasks to UI
+                for (const { categoryId, task } of bulkable) {
+                    addToCategory(categoryId, task);
+                }
+                showToastable({
+                    title: "Error",
+                    status: "danger",
+                    position: "top",
+                    message: "Failed to delete task(s)",
+                    swipeDirection: "up",
+                    renderContent: (props) => <DefaultToast {...props} />,
+                });
+            }
+        }
+
+        // Fire individual calls for recurring-template deletes
+        for (const entry of individual) {
+            try {
+                await removeFromCategoryAPI(entry.categoryId, entry.task.id, true);
+            } catch (error) {
+                addToCategory(entry.categoryId, entry.task);
+                showToastable({
+                    title: "Error",
+                    status: "danger",
+                    position: "top",
+                    message: `Failed to delete "${entry.task.content}"`,
+                    swipeDirection: "up",
+                    renderContent: (props) => <DefaultToast {...props} />,
+                });
+            }
+        }
+    }, [addToCategory]);
+
+    // On unmount: flush immediately (no more undo possible)
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) {
+                clearTimeout(timerRef.current);
+                timerRef.current = undefined;
+            }
+            flushPending();
+        };
+    }, [flushPending]);
+
+    const undoAll = useCallback(() => {
+        // Clear the timer
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+            timerRef.current = undefined;
+        }
+
+        // Restore all pending tasks
+        for (const { categoryId, task } of pendingRef.current.values()) {
+            addToCategory(categoryId, task);
+        }
+        pendingRef.current.clear();
+        hideToastable();
+    }, [addToCategory]);
+
+    const scheduleFlush = useCallback(() => {
+        // Clear existing timer
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+        }
+
+        const count = pendingRef.current.size;
+
+        // Show/update the undo toast
+        showToastable({
+            title: "Deleted",
+            message: count === 1 ? "1 task deleted" : `${count} tasks deleted`,
+            status: "warning",
+            position: "top",
+            duration: UNDO_DELAY_MS,
+            swipeDirection: "up",
+            renderContent: (props) => (
+                <UndoToast {...props} onUndo={undoAll} count={count} />
+            ),
+        });
+
+        // Start new timer
+        timerRef.current = setTimeout(() => {
+            timerRef.current = undefined;
+            flushPending();
+        }, UNDO_DELAY_MS);
+    }, [undoAll, flushPending]);
+
+    const enqueuePendingDelete = useCallback(
+        (task: Task, categoryId: string, deleteRecurring: boolean) => {
+            // Snapshot the task into the pending map
+            pendingRef.current.set(task.id, {
+                task: { ...task },
+                categoryId,
+                deleteRecurring,
+            });
+
+            // Optimistic UI removal
+            removeFromCategory(categoryId, task.id);
+
+            // Haptic feedback
+            if (Platform.OS === "ios") {
+                Haptics.notificationAsync(Haptics.NotificationFeedbackType.Warning);
+            }
+
+            // Schedule (or reschedule) the flush
+            scheduleFlush();
+        },
+        [removeFromCategory, scheduleFlush]
+    );
+
+    const deleteWithUndo = useCallback(
+        (task: Task, categoryId: string) => {
+            if (task.templateID) {
+                // Show recurring task dialog
+                setAlertTitle("Delete Recurring Task");
+                setAlertMessage(
+                    "Do you want to delete only this task or all future tasks?"
+                );
+                setAlertButtons([
+                    {
+                        text: "Cancel",
+                        style: "cancel",
+                    },
+                    {
+                        text: "Only This Task",
+                        onPress: () => enqueuePendingDelete(task, categoryId, false),
+                    },
+                    {
+                        text: "All Future Tasks",
+                        onPress: () => enqueuePendingDelete(task, categoryId, true),
+                        style: "destructive",
+                    },
+                ]);
+                setAlertVisible(true);
+            } else {
+                enqueuePendingDelete(task, categoryId, false);
+            }
+        },
+        [enqueuePendingDelete]
+    );
+
+    const alertElement = alertVisible ? (
+        <CustomAlert
+            visible={alertVisible}
+            setVisible={setAlertVisible}
+            title={alertTitle}
+            message={alertMessage}
+            buttons={alertButtons}
+        />
+    ) : null;
+
+    return { deleteWithUndo, alertElement };
+}


### PR DESCRIPTION
## Summary
- **Undoable task delete**: Swipe-to-delete now removes the task from UI immediately but delays the API call for 5 seconds, showing an "Undo" toast. Tapping undo restores all pending tasks.
- **Rolling batch support**: Rapid consecutive deletes accumulate into a single batch — toast updates to "N tasks deleted" and the timer resets. Undo restores all at once.
- **Recurring task support**: Recurring tasks still show the "Only This Task / All Future Tasks" dialog before entering the undo queue.
- **Backend auth refactors**: Extracted helpers (`buildSafeUserResponse`, `completeLogin`, `findByField`) to reduce duplication across auth handlers.
- **Sentry middleware**: Added request-scoped Sentry context middleware for better error tracking.

## New files
- `frontend/components/ui/UndoToast.tsx` — Toast component with "Undo" button
- `frontend/hooks/useUndoableDelete.tsx` — Hook managing pending deletes map, rolling timer, and flush logic

## Modified files
- `SwipableTaskCard.tsx` — Replaced inline delete with `useUndoableDelete` hook
- `SchedulableTaskCard.tsx` — Same
- `CalendarView.tsx` — Same (also removed `isDeleting` state and `Alert.alert`)
- `review.tsx` — Same (also removed direct `removeFromCategoryAPI` call)

## Test plan
- [ ] Swipe to delete a non-recurring task → toast appears → tap Undo → task reappears
- [ ] Swipe to delete → wait 5s → task stays deleted after refresh
- [ ] Delete 3 tasks rapidly → toast shows "3 tasks deleted" → Undo restores all 3
- [ ] Delete a recurring task → dialog appears → choose option → undo toast appears
- [ ] Delete from CalendarView long-press menu → undo toast appears
- [ ] Delete from Review screen swipe-down → undo toast appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)