### PR TITLE
refactor: extract lightweight widget updater handles

### DIFF
--- a/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
@@ -46,7 +46,8 @@ import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
 import { showToastable } from "react-native-toastable";
 import DefaultToast from "@/components/ui/DefaultToast";
 import { logger } from "@/utils/logger";
-import DeadlineCountdownActivity, { DeadlineCountdownProps } from "@/widgets/DeadlineCountdownActivity";
+import { DeadlineCountdownActivityFactory as DeadlineCountdownActivity } from "@/widgets/widgetUpdaters";
+import type { DeadlineCountdownProps } from "@/widgets/DeadlineCountdownActivity";
 import type { LiveActivity } from "expo-widgets";
 
 type TemplateTaskDocument = components["schemas"]["TemplateTaskDocument"];

--- a/frontend/contexts/kudosContext.tsx
+++ b/frontend/contexts/kudosContext.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useState, useEffect, useRef, ReactNod
 import { getEncouragementsAPI, markEncouragementsReadAPI } from "@/api/encouragement";
 import { getCongratulationsAPI, markCongratulationsReadAPI } from "@/api/congratulation";
 import { createLogger } from "@/utils/logger";
-import EncouragementActivity from "@/widgets/EncouragementActivity";
+import { EncouragementActivityFactory as EncouragementActivity } from "@/widgets/widgetUpdaters";
 
 const logger = createLogger('KudosContext');
 

--- a/frontend/contexts/tasksContext.tsx
+++ b/frontend/contexts/tasksContext.tsx
@@ -9,9 +9,12 @@ import { isFuture, isPast, isToday, isWithinInterval } from "date-fns";
 import { getUserSubscribedBlueprints } from "@/api/blueprint";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createLogger } from "@/utils/logger";
-import TodayTasksWidget from "@/widgets/TodayTasksWidget";
-import WorkspaceSnapshotWidget from "@/widgets/WorkspaceSnapshotWidget";
-import { LockScreenCircularWidget, LockScreenRectangularWidget } from "@/widgets/LockScreenWidgets";
+import {
+    TodayTasksWidgetUpdater as TodayTasksWidget,
+    WorkspaceSnapshotWidgetUpdater as WorkspaceSnapshotWidget,
+    LockScreenCircularWidgetUpdater as LockScreenCircularWidget,
+    LockScreenRectangularWidgetUpdater as LockScreenRectangularWidget,
+} from "@/widgets/widgetUpdaters";
 
 const logger = createLogger('TasksContext');
 

--- a/frontend/widgets/updateStreakWidget.ts
+++ b/frontend/widgets/updateStreakWidget.ts
@@ -1,5 +1,4 @@
-import ActivityStreakWidget from './ActivityStreakWidget';
-import { LockScreenInlineWidget } from './LockScreenWidgets';
+import { ActivityStreakWidgetUpdater, LockScreenInlineWidgetUpdater } from './widgetUpdaters';
 import { activityAPI, convertToWeeklyActivityLevels } from '@/api/activity';
 import { createLogger } from '@/utils/logger';
 
@@ -16,15 +15,15 @@ export async function updateStreakWidget(
         // convertToWeeklyActivityLevels returns 8 values; take the last 7
         const weeklyLevels = allLevels.slice(-7);
 
-        ActivityStreakWidget.updateSnapshot({ streak, tasksCompletedToday, weeklyLevels });
-        LockScreenInlineWidget.updateSnapshot({ streak });
+        ActivityStreakWidgetUpdater.updateSnapshot({ streak, tasksCompletedToday, weeklyLevels });
+        LockScreenInlineWidgetUpdater.updateSnapshot({ streak });
     } catch (error) {
         logger.error('Failed to update streak widget', error);
-        ActivityStreakWidget.updateSnapshot({
+        ActivityStreakWidgetUpdater.updateSnapshot({
             streak,
             tasksCompletedToday,
             weeklyLevels: new Array(7).fill(0),
         });
-        LockScreenInlineWidget.updateSnapshot({ streak });
+        LockScreenInlineWidgetUpdater.updateSnapshot({ streak });
     }
 }

--- a/frontend/widgets/widgetUpdaters.ts
+++ b/frontend/widgets/widgetUpdaters.ts
@@ -1,0 +1,23 @@
+import { Widget, LiveActivityFactory } from 'expo-widgets';
+import type { TodayTasksWidgetProps } from './TodayTasksWidget';
+import type { WorkspaceSnapshotWidgetProps } from './WorkspaceSnapshotWidget';
+import type { LockScreenCircularProps, LockScreenRectangularProps } from './LockScreenWidgets';
+import type { ActivityStreakWidgetProps } from './ActivityStreakWidget';
+import type { EncouragementActivityProps } from './EncouragementActivity';
+import type { DeadlineCountdownProps } from './DeadlineCountdownActivity';
+
+// Lightweight widget/activity handles for use in the main app bundle.
+// These only call updateSnapshot/updateTimeline/start — they never render SwiftUI
+// components, so they are safe to import outside of the widget extension target.
+
+const noop = () => null as any;
+
+export const TodayTasksWidgetUpdater = new Widget<TodayTasksWidgetProps>('TodayTasksWidget', noop);
+export const WorkspaceSnapshotWidgetUpdater = new Widget<WorkspaceSnapshotWidgetProps>('WorkspaceSnapshotWidget', noop);
+export const LockScreenCircularWidgetUpdater = new Widget<LockScreenCircularProps>('LockScreenCircularWidget', noop);
+export const LockScreenRectangularWidgetUpdater = new Widget<LockScreenRectangularProps>('LockScreenRectangularWidget', noop);
+export const ActivityStreakWidgetUpdater = new Widget<ActivityStreakWidgetProps>('ActivityStreakWidget', noop);
+export const LockScreenInlineWidgetUpdater = new Widget<{ streak: number }>('LockScreenInlineWidget', noop);
+
+export const EncouragementActivityFactory = new LiveActivityFactory<EncouragementActivityProps>('EncouragementActivity', noop);
+export const DeadlineCountdownActivityFactory = new LiveActivityFactory<DeadlineCountdownProps>('DeadlineCountdownActivity', noop);


### PR DESCRIPTION
## Summary
- Extracts widget/activity update handles into `widgetUpdaters.ts`
- Main app bundle now imports lightweight update proxies instead of full SwiftUI rendering components
- Affects TodayTasksWidget, WorkspaceSnapshotWidget, LockScreen widgets, ActivityStreak, and Live Activities

🤖 Generated with [Claude Code](https://claude.com/claude-code)