### PR TITLE
fix: improve auth error messages and Google account linking

### DIFF
--- a/backend/internal/handlers/auth/auth.go
+++ b/backend/internal/handlers/auth/auth.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -23,14 +24,30 @@ func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutpu
 		return nil, huma.Error400BadRequest("Please check your email and password", fmt.Errorf("validation errors: %v", errs))
 	}
 
+	slog.LogAttrs(ctx, slog.LevelInfo, "Email login attempt",
+		slog.String("email", input.Body.Email),
+	)
+
 	// database call to find the user and verify credentials and get count
 	id, count, user, err := h.service.LoginFromCredentials(input.Body.Email, input.Body.Password)
 	if err != nil {
-		return nil, huma.Error401Unauthorized("Invalid email or password", err)
+		// Propagate the specific error message from the service (e.g., "No account found..." or "Incorrect password...")
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) {
+			if fiberErr.Code == 404 {
+				return nil, huma.Error404NotFound(fiberErr.Message, err)
+			}
+			return nil, huma.Error401Unauthorized(fiberErr.Message, err)
+		}
+		return nil, huma.Error500InternalServerError("Unable to sign in. Please try again.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Token generation failed during email login",
+			slog.String("userId", id.Hex()),
+			slog.String("error", err.Error()),
+		)
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
@@ -45,17 +62,30 @@ func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutpu
 func (h *Handler) LoginWithPhoneHuma(ctx context.Context, input *LoginWithPhoneInput) (*LoginOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your phone number and password", fmt.Errorf("validation errors: %v", errs))
 	}
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "Phone login attempt")
 
 	// database call to find the user and verify credentials and get count
 	id, count, user, err := h.service.LoginFromPhone(input.Body.PhoneNumber, input.Body.Password)
 	if err != nil {
-		return nil, huma.Error401Unauthorized("Invalid phone number or password", err)
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) {
+			if fiberErr.Code == 404 {
+				return nil, huma.Error404NotFound(fiberErr.Message, err)
+			}
+			return nil, huma.Error401Unauthorized(fiberErr.Message, err)
+		}
+		return nil, huma.Error500InternalServerError("Unable to sign in. Please try again.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Token generation failed during phone login",
+			slog.String("userId", id.Hex()),
+			slog.String("error", err.Error()),
+		)
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
@@ -112,17 +142,34 @@ func (h *Handler) RegisterWithAppleHuma(ctx context.Context, input *RegisterWith
 func (h *Handler) LoginWithGoogleHuma(ctx context.Context, input *LoginWithGoogleInput) (*LoginOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid Google account", fmt.Errorf("validation errors: %v", errs))
 	}
 
+	slog.LogAttrs(ctx, slog.LevelInfo, "Google login attempt",
+		slog.Bool("hasEmail", input.Body.Email != ""),
+	)
+
 	// database call to find the user and verify credentials and get count
-	id, count, user, err := h.service.LoginFromGoogle(input.Body.GoogleID)
+	id, count, user, err := h.service.LoginFromGoogle(input.Body.GoogleID, input.Body.Email)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "Google login failed",
+			slog.String("error", err.Error()),
+			slog.Bool("hasEmail", input.Body.Email != ""),
+		)
+		// Check for 404 (account not found) vs other errors
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) && fiberErr.Code == 404 {
+			return nil, huma.Error404NotFound(fiberErr.Message, err)
+		}
 		return nil, huma.Error401Unauthorized("Unable to sign in with Google. Please try again.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Token generation failed during Google login",
+			slog.String("userId", id.Hex()),
+			slog.String("error", err.Error()),
+		)
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 
@@ -341,17 +388,30 @@ func (h *Handler) RegisterWithContext(ctx context.Context, input *RegisterInput)
 func (h *Handler) LoginWithAppleHuma(ctx context.Context, input *LoginWithAppleInput) (*LoginOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid Apple ID", fmt.Errorf("validation errors: %v", errs))
 	}
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "Apple login attempt")
 
 	// database call to find the user and verify credentials and get count
 	id, count, user, err := h.service.LoginFromApple(input.Body.AppleID)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "Apple login failed",
+			slog.String("error", err.Error()),
+		)
+		var fiberErr *fiber.Error
+		if errors.As(err, &fiberErr) && fiberErr.Code == 404 {
+			return nil, huma.Error404NotFound(fiberErr.Message, err)
+		}
 		return nil, huma.Error401Unauthorized("Unable to sign in with Apple. Please try again.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Token generation failed during Apple login",
+			slog.String("userId", id.Hex()),
+			slog.String("error", err.Error()),
+		)
 		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
 	}
 

--- a/backend/internal/handlers/auth/service.go
+++ b/backend/internal/handlers/auth/service.go
@@ -109,14 +109,27 @@ func (s *Service) LoginFromCredentials(email string, password string) (*primitiv
 	user, err := s.users.GetUserByEmail(context.Background(), email)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+			slog.Warn("Login attempt for non-existent email",
+				"email", email,
+				"provider", "email",
+			)
+			return nil, nil, nil, fiber.NewError(404, "No account found with this email address. Please sign up first.")
 		}
-		return nil, nil, nil, err
+		slog.Error("Database error during email login",
+			"email", email,
+			"error", err.Error(),
+		)
+		return nil, nil, nil, fmt.Errorf("unable to look up account: %w", err)
 	}
 	// Compare the hashed password with the provided password
 	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
 	if err != nil {
-		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
+		slog.Warn("Invalid password attempt",
+			"email", email,
+			"userId", user.ID.Hex(),
+			"provider", "email",
+		)
+		return nil, nil, nil, fiber.NewError(401, "Incorrect password. Please try again.")
 	}
 	return &user.ID, &user.Count, user, nil
 }
@@ -125,14 +138,24 @@ func (s *Service) LoginFromPhone(phoneNumber string, password string) (*primitiv
 	user, err := s.users.GetUserByPhone(context.Background(), phoneNumber)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+			slog.Warn("Login attempt for non-existent phone",
+				"provider", "phone",
+			)
+			return nil, nil, nil, fiber.NewError(404, "No account found with this phone number. Please sign up first.")
 		}
-		return nil, nil, nil, err
+		slog.Error("Database error during phone login",
+			"error", err.Error(),
+		)
+		return nil, nil, nil, fmt.Errorf("unable to look up account: %w", err)
 	}
 	// Compare the hashed password with the provided password
 	err = bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password))
 	if err != nil {
-		return nil, nil, nil, fiber.NewError(400, "Not Authorized, Invalid Credentials")
+		slog.Warn("Invalid password attempt",
+			"userId", user.ID.Hex(),
+			"provider", "phone",
+		)
+		return nil, nil, nil, fiber.NewError(401, "Incorrect password. Please try again.")
 	}
 	return &user.ID, &user.Count, user, nil
 }
@@ -141,20 +164,51 @@ func (s *Service) LoginFromApple(apple_id string) (*primitive.ObjectID, *float64
 	user, err := s.users.GetUserByAppleID(context.Background(), apple_id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+			slog.Warn("Login attempt for non-existent Apple ID",
+				"provider", "apple",
+			)
+			return nil, nil, nil, fiber.NewError(404, "No account found with this Apple ID. Please sign up first.")
 		}
-		return nil, nil, nil, err
+		slog.Error("Database error during Apple login",
+			"error", err.Error(),
+		)
+		return nil, nil, nil, fmt.Errorf("unable to look up account: %w", err)
 	}
 	return &user.ID, &user.Count, user, nil
 }
 
-func (s *Service) LoginFromGoogle(google_id string) (*primitive.ObjectID, *float64, *User, error) {
-	user, err := s.users.GetUserByGoogleID(context.Background(), google_id)
+func (s *Service) LoginFromGoogle(googleID string, email string) (*primitive.ObjectID, *float64, *User, error) {
+	user, err := s.users.GetUserByGoogleID(context.Background(), googleID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+			// No account with this Google ID — try to find by email and link
+			if email != "" {
+				emailUser, emailErr := s.users.GetUserByEmail(context.Background(), email)
+				if emailErr == nil && emailUser != nil {
+					// Found an existing account with this email — link Google ID
+					linkErr := s.users.LinkGoogleID(context.Background(), emailUser.ID, googleID)
+					if linkErr != nil {
+						slog.Error("Failed to link Google ID to existing account",
+							"email", email,
+							"userId", emailUser.ID.Hex(),
+							"error", linkErr.Error(),
+						)
+						return nil, nil, nil, fmt.Errorf("failed to link Google account: %w", linkErr)
+					}
+					slog.Info("Linked Google ID to existing account",
+						"email", email,
+						"userId", emailUser.ID.Hex(),
+					)
+					return &emailUser.ID, &emailUser.Count, emailUser, nil
+				}
+			}
+			return nil, nil, nil, fiber.NewError(404, "No account found. Please sign up first.")
 		}
-		return nil, nil, nil, err
+		slog.Error("Database error during Google login",
+			"googleID", googleID,
+			"error", err.Error(),
+		)
+		return nil, nil, nil, fmt.Errorf("unable to look up account: %w", err)
 	}
 	return &user.ID, &user.Count, user, nil
 }
@@ -163,9 +217,15 @@ func (s *Service) LoginFromPhoneOTP(phone_number string) (*primitive.ObjectID, *
 	user, err := s.users.GetUserByPhone(context.Background(), phone_number)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
-			return nil, nil, nil, fiber.NewError(404, "Account does not exist")
+			slog.Warn("OTP login attempt for non-existent phone",
+				"provider", "phone_otp",
+			)
+			return nil, nil, nil, fiber.NewError(404, "No account found with this phone number. Please sign up first.")
 		}
-		return nil, nil, nil, err
+		slog.Error("Database error during OTP login",
+			"error", err.Error(),
+		)
+		return nil, nil, nil, fmt.Errorf("unable to look up account: %w", err)
 	}
 	return &user.ID, &user.Count, user, nil
 }

--- a/backend/internal/handlers/auth/types.go
+++ b/backend/internal/handlers/auth/types.go
@@ -67,6 +67,7 @@ type LoginRequestApple struct {
 
 type LoginRequestGoogle struct {
 	GoogleID string `validate:"required" json:"google_id"`
+	Email    string `json:"email,omitempty"` // Optional: used to link Google account to existing email-based account
 }
 
 type RegisterRequestApple struct {

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -29,4 +29,5 @@ type UserRepository interface {
 	ConsumeCredit(ctx context.Context, id primitive.ObjectID, creditType types.CreditType) error
 	AddCredits(ctx context.Context, id primitive.ObjectID, creditType types.CreditType, amount int) error
 	CheckCredits(ctx context.Context, id primitive.ObjectID, creditType types.CreditType) (bool, error)
+	LinkGoogleID(ctx context.Context, id primitive.ObjectID, googleID string) error
 }

--- a/backend/internal/repository/mongo/user_repo.go
+++ b/backend/internal/repository/mongo/user_repo.go
@@ -120,3 +120,7 @@ func (r *userRepo) AddCredits(ctx context.Context, id primitive.ObjectID, credit
 func (r *userRepo) CheckCredits(ctx context.Context, id primitive.ObjectID, creditType types.CreditType) (bool, error) {
 	return types.CheckCredits(ctx, r.collection, id, creditType)
 }
+
+func (r *userRepo) LinkGoogleID(ctx context.Context, id primitive.ObjectID, googleID string) error {
+	return updateOneByID(ctx, r.collection, id, bson.M{"$set": bson.M{"google_id": googleID}})
+}

--- a/frontend/app/login-phone.tsx
+++ b/frontend/app/login-phone.tsx
@@ -91,7 +91,11 @@ const LoginPhone = () => {
             } else if (err?.message === "ACCOUNT_NOT_FOUND") {
                 setError("No account found with this phone number. Please sign up first!");
             } else {
-                setError("Login failed. Please try again.");
+                // Surface the API error message if it's descriptive, otherwise use fallback
+                const msg = err?.message;
+                setError(msg && msg !== "INVALID_OTP" && msg !== "ACCOUNT_NOT_FOUND"
+                    ? msg
+                    : "Login failed. Please try again.");
             }
         } finally {
             setLoading(false);
@@ -111,7 +115,15 @@ const LoginPhone = () => {
             router.push("/(logged-in)/(tabs)/(task)");
         } catch (err: any) {
             console.error("Login failed:", err);
-            setError("Invalid phone number or password. Please try again.");
+            if (err?.message === "ACCOUNT_NOT_FOUND") {
+                setError("No account found with this phone number. Please sign up first!");
+            } else {
+                // Surface the API error message if descriptive
+                const msg = err?.message;
+                setError(msg && msg !== "ACCOUNT_NOT_FOUND"
+                    ? msg
+                    : "Invalid phone number or password. Please try again.");
+            }
         } finally {
             setLoading(false);
         }

--- a/frontend/components/modals/OnboardModal.tsx
+++ b/frontend/components/modals/OnboardModal.tsx
@@ -60,7 +60,7 @@ export const OnboardModal = (props: Props) => {
                         router.replace("/(onboarding)/name");
                         setVisible(false);
                     } else {
-                        await loginWithGoogle(result.user.id);
+                        await loginWithGoogle(result.user.id, result.user.email);
                         router.push("/(logged-in)/(tabs)/(task)");
                         setVisible(false);
                     }
@@ -75,7 +75,12 @@ export const OnboardModal = (props: Props) => {
                             showToast(ERROR_MESSAGES.ACCOUNT_NOT_FOUND_GOOGLE, "warning", "No Account Found");
                         }
                     } else {
-                        showToast(ERROR_MESSAGES.GOOGLE_AUTH_FAILED, "danger", "Sign-In Failed");
+                        // Surface the API error message if descriptive, otherwise use fallback
+                        const msg = error?.message;
+                        const displayMsg = msg && msg !== "ACCOUNT_NOT_FOUND"
+                            ? msg
+                            : ERROR_MESSAGES.GOOGLE_AUTH_FAILED;
+                        showToast(displayMsg, "danger", "Sign-In Failed");
                     }
                 }
             }

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -55,7 +55,7 @@ interface AuthContextType {
     loginWithOTP: (phoneNumber: string, code: string) => Promise<SafeUser | void>;
     register: (email: string, appleAccountID: string) => Promise<any>;
     registerWithGoogle: (email: string, googleID: string) => Promise<any>;
-    loginWithGoogle: (googleID: string) => Promise<SafeUser | void>;
+    loginWithGoogle: (googleID: string, email?: string) => Promise<SafeUser | void>;
     logout: () => void;
     refresh: () => void;
     fetchAuthData: () => Promise<SafeUser | null>;
@@ -149,48 +149,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     async function login(appleAccountID: string): Promise<SafeUser | void> {
-        logger.debug("Logging in with Apple", {
-            appleAccountID,
-            apiUrl: process.env.EXPO_PUBLIC_URL + "/api"
-        });
+        logger.debug("Apple login attempt");
 
         try {
-            logger.debug("About to make POST request");
-            console.log("Request body:", { apple_id: appleAccountID });
-
             const result = await client.POST("/v1/auth/login/apple", {
                 body: {
                     apple_id: appleAccountID,
                 }
             });
 
-            logger.debug("Raw result from client.POST", result);
-            logger.debug("Result data", result.data);
-            logger.debug("Result error", result.error);
-            logger.debug("Result response", result.response);
-
             if (result.error) {
-                logger.error("Error details", JSON.stringify(result.error, null, 2));
-
-                // Check if this is a "account doesn't exist" error (404)
-                const errorDetail = result.error?.detail || '';
+                const errorDetail = (result.error as any)?.detail || '';
                 const errorStatus = result.response?.status;
 
-                if (errorStatus === 404 || errorDetail.includes('Account does not exist')) {
-                    // User-friendly error for account not found
+                logger.error("Apple login error", { status: errorStatus, detail: errorDetail });
+
+                if (errorStatus === 404) {
                     throw new Error("ACCOUNT_NOT_FOUND");
                 }
 
-                // For other errors, provide a generic message
-                throw new Error(`Login failed: ${errorDetail || 'An unexpected error occurred'}`);
+                // Surface the API's descriptive error message
+                throw new Error(errorDetail || 'Apple sign-in failed. Please try again.');
             }
 
             if (result.data) {
                 const userData = result.data as SafeUser;
                 setUser(userData);
 
-                // Save tokens if they exist in response headers
-                logger.debug("Response headers", result.response?.headers);
                 if (result.response?.headers) {
                     const accessToken = result.response.headers.get('access_token');
                     const refreshToken = result.response.headers.get('refresh_token');
@@ -208,7 +193,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
             logger.error("No data or error in response - this is unexpected");
         } catch (error) {
-            console.error("Login failed with exception:", error);
+            console.error("Apple login failed with exception:", error);
             Sentry.captureException(error, {
                 tags: { "auth.method": "apple", "auth.flow": "login" },
             });
@@ -216,38 +201,33 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
     }
 
-    async function loginWithGoogle(googleID: string): Promise<SafeUser | void> {
+    async function loginWithGoogle(googleID: string, email?: string): Promise<SafeUser | void> {
         logger.debug("Google login with ID", googleID);
 
         try {
             logger.debug("About to make POST request to Google login endpoint...");
-            logger.debug("Request body", { google_id: googleID });
+
+            const body: Record<string, string> = { google_id: googleID };
+            if (email) {
+                body.email = email;
+            }
 
             const result = await client.POST("/v1/auth/login/google" as any, {
-                body: {
-                    google_id: googleID,
-                } as any
+                body: body as any
             });
 
-            logger.debug("Raw result from client.POST", result);
-            logger.debug("Result data", result.data);
-            logger.debug("Result error", result.error);
-            logger.debug("Result response", result.response);
-
             if (result.error) {
-                logger.error("Error details", JSON.stringify(result.error, null, 2));
-
-                // Check if this is a "account doesn't exist" error (404)
-                const errorDetail = result.error?.detail || '';
+                const errorDetail = (result.error as any)?.detail || '';
                 const errorStatus = result.response?.status;
 
-                if (errorStatus === 404 || errorDetail.includes('Account does not exist')) {
-                    // User-friendly error for account not found
+                logger.error("Google login error", { status: errorStatus, detail: errorDetail });
+
+                if (errorStatus === 404) {
                     throw new Error("ACCOUNT_NOT_FOUND");
                 }
 
-                // For other errors, provide a generic message
-                throw new Error(`Google login failed: ${errorDetail || 'An unexpected error occurred'}`);
+                // Surface the API's descriptive error message
+                throw new Error(errorDetail || 'Google sign-in failed. Please try again.');
             }
 
             if (result.data) {
@@ -255,7 +235,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 setUser(userData);
 
                 // Save tokens if they exist in response headers
-                logger.debug("Response headers", result.response?.headers);
                 if (result.response?.headers) {
                     const accessToken = result.response.headers.get('access_token');
                     const refreshToken = result.response.headers.get('refresh_token');
@@ -282,12 +261,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     async function loginWithPhone(phoneNumber: string, password: string): Promise<SafeUser | void> {
-        logger.debug("Phone login with number", phoneNumber);
+        logger.debug("Phone login attempt");
 
         try {
-            logger.debug("About to make POST request to phone login endpoint...");
-            logger.debug("Request body", { phone_number: phoneNumber, password: "***" });
-
             const result = await client.POST("/v1/auth/login/phone" as any, {
                 body: {
                     phone_number: phoneNumber,
@@ -295,22 +271,24 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 } as any
             });
 
-            console.log("Raw result from client.POST:", result);
-            console.log("Result data:", result.data);
-            console.log("Result error:", result.error);
-            console.log("Result response:", result.response);
-
             if (result.error) {
-                console.log("Error details:", JSON.stringify(result.error, null, 2));
-                throw new Error(`Phone login failed: ${JSON.stringify(result.error)}`);
+                const errorDetail = (result.error as any)?.detail || '';
+                const errorStatus = result.response?.status;
+
+                logger.error("Phone login error", { status: errorStatus, detail: errorDetail });
+
+                if (errorStatus === 404) {
+                    throw new Error("ACCOUNT_NOT_FOUND");
+                }
+
+                // Surface the API's descriptive error message
+                throw new Error(errorDetail || 'Phone login failed. Please try again.');
             }
 
             if (result.data) {
                 const userData = result.data as SafeUser;
                 setUser(userData);
 
-                // Save tokens if they exist in response headers
-                console.log(result.response?.headers);
                 if (result.response?.headers) {
                     const accessToken = result.response.headers.get('access_token');
                     const refreshToken = result.response.headers.get('refresh_token');
@@ -326,24 +304,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 return userData;
             }
 
-            console.log("No data or error in response - this is unexpected");
+            logger.error("No data or error in response - this is unexpected");
         } catch (error) {
             console.error("Phone login failed with exception:", error);
             Sentry.captureException(error, {
                 tags: { "auth.method": "phone", "auth.flow": "login" },
             });
-            showToast(ERROR_MESSAGES.ACCOUNT_NOT_FOUND_PHONE, "warning", "Sign-In Failed");
             throw error;
         }
     }
 
     async function loginWithOTP(phoneNumber: string, code: string): Promise<SafeUser | void> {
-        logger.debug("OTP login with number", phoneNumber);
+        logger.debug("OTP login attempt");
 
         try {
-            logger.debug("About to make POST request to OTP login endpoint...");
-            logger.debug("Request body", { phone_number: phoneNumber, code: "***" });
-
             const result = await client.POST("/v1/auth/login/otp" as any, {
                 body: {
                     phone_number: phoneNumber,
@@ -351,33 +325,26 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 } as any
             });
 
-            logger.debug("Raw result from client.POST", result);
-            logger.debug("Result data", result.data);
-            logger.debug("Result error", result.error);
-            logger.debug("Result response", result.response);
-
             if (result.error) {
-                logger.error("Error details", JSON.stringify(result.error, null, 2));
-
-                // Check for specific error types
-                const errorDetail = result.error?.detail || '';
+                const errorDetail = (result.error as any)?.detail || '';
                 const errorStatus = result.response?.status;
 
-                if (errorStatus === 401 || errorDetail.includes('Invalid or expired OTP')) {
+                logger.error("OTP login error", { status: errorStatus, detail: errorDetail });
+
+                if (errorStatus === 401) {
                     throw new Error("INVALID_OTP");
-                } else if (errorStatus === 404 || errorDetail.includes('Account does not exist')) {
+                } else if (errorStatus === 404) {
                     throw new Error("ACCOUNT_NOT_FOUND");
                 }
 
-                throw new Error(`OTP login failed: ${errorDetail || 'An unexpected error occurred'}`);
+                // Surface the API's descriptive error message
+                throw new Error(errorDetail || 'OTP login failed. Please try again.');
             }
 
             if (result.data) {
                 const userData = result.data as SafeUser;
                 setUser(userData);
 
-                // Save tokens if they exist in response headers
-                logger.debug("Response headers", result.response?.headers);
                 if (result.response?.headers) {
                     const accessToken = result.response.headers.get('access_token');
                     const refreshToken = result.response.headers.get('refresh_token');

--- a/frontend/utils/errorParser.ts
+++ b/frontend/utils/errorParser.ts
@@ -177,6 +177,8 @@ export const ERROR_MESSAGES = {
     ACCOUNT_NOT_FOUND_GOOGLE: "No account found with this Google account. Sign up first!",
     ACCOUNT_NOT_FOUND_APPLE: "No account found with this Apple ID. Sign up first!",
     ACCOUNT_NOT_FOUND_PHONE: "No account found with this phone number. Sign up first!",
+    ACCOUNT_NOT_FOUND_EMAIL: "No account found with this email. Please sign up first.",
+    INCORRECT_PASSWORD: "Incorrect password. Please try again.",
     DUPLICATE_ACCOUNT: "An account already exists with this sign-in method. Try signing in instead.",
     OTP_INVALID: "Invalid or expired code. Please try again.",
 


### PR DESCRIPTION
## Summary
- **Backend**: Specific error messages instead of generic "Not Authorized" — distinguishes account-not-found (404) from wrong-password (401)
- **Backend**: Google auth now links to existing email accounts instead of erroring — if we find an account with your email, we log you in
- **Backend**: Added structured slog logging with provider, email, and failure context throughout auth handlers
- **Frontend**: Surfaces actual API error messages to users instead of generic "Something went wrong"
- Adds `LinkGoogleID` to UserRepository for account linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)