### PR TITLE
fix: improve backend error messages and add structured logging

### DIFF
--- a/backend/internal/handlers/activity/activity.go
+++ b/backend/internal/handlers/activity/activity.go
@@ -2,6 +2,7 @@ package Activity
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -14,7 +15,8 @@ type Handler struct {
 func (h *Handler) GetActivities(ctx context.Context, input *GetActivitiesInput) (*GetActivitiesOutput, error) {
 	activities, err := h.service.GetAllActivitys()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch activities", err)
+		slog.Error("unable to fetch activities", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch activities. Please try again.", err)
 	}
 
 	return &GetActivitiesOutput{Body: activities}, nil
@@ -77,7 +79,8 @@ func (h *Handler) GetActivityByUserAndYear(ctx context.Context, input *GetActivi
 
 	activities, err := h.service.GetActivityByUserAndYear(userID, input.Year)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch activities", err)
+		slog.Error("unable to fetch activities by user and year", "userId", input.UserID, "year", input.Year, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch activities for the specified year. Please try again.", err)
 	}
 
 	return &GetActivityByUserAndYearOutput{Body: activities}, nil
@@ -91,7 +94,8 @@ func (h *Handler) GetRecentActivity(ctx context.Context, input *GetRecentActivit
 
 	activities, err := h.service.GetRecentActivity(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch recent activity", err)
+		slog.Error("unable to fetch recent activity", "userId", input.UserID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch recent activity. Please try again.", err)
 	}
 
 	// Ensure we always return an empty array instead of null
@@ -107,7 +111,8 @@ func (h *Handler) GetRecentActivity(ctx context.Context, input *GetRecentActivit
 func (h *Handler) GetActivitiesHuma(ctx context.Context, input *GetActivitiesInput) (*GetActivitiesOutput, error) {
 	activities, err := h.service.GetAllActivitys()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get activities", err)
+		slog.Error("unable to get activities", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch activities. Please try again.", err)
 	}
 
 	resp := &GetActivitiesOutput{Body: activities}
@@ -174,7 +179,8 @@ func (h *Handler) GetRecentActivityHuma(ctx context.Context, input *GetRecentAct
 
 	activities, err := h.service.GetRecentActivity(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch recent activity", err)
+		slog.Error("unable to fetch recent activity", "userId", input.UserID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch recent activity. Please try again.", err)
 	}
 
 	// Ensure we always return an empty array instead of null

--- a/backend/internal/handlers/auth/auth.go
+++ b/backend/internal/handlers/auth/auth.go
@@ -39,7 +39,11 @@ func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutpu
 			}
 			return nil, huma.Error401Unauthorized(fiberErr.Message, err)
 		}
-		return nil, huma.Error500InternalServerError("Unable to sign in. Please try again.", err)
+		slog.LogAttrs(ctx, slog.LevelError, "Unexpected error during email login",
+			slog.String("email", input.Body.Email),
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error500InternalServerError("Unable to sign in due to a server error. Please try again later.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
@@ -48,7 +52,7 @@ func (h *Handler) LoginHuma(ctx context.Context, input *LoginInput) (*LoginOutpu
 			slog.String("userId", id.Hex()),
 			slog.String("error", err.Error()),
 		)
-		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+		return nil, huma.Error500InternalServerError("Unable to complete login due to a token generation error. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
@@ -77,7 +81,10 @@ func (h *Handler) LoginWithPhoneHuma(ctx context.Context, input *LoginWithPhoneI
 			}
 			return nil, huma.Error401Unauthorized(fiberErr.Message, err)
 		}
-		return nil, huma.Error500InternalServerError("Unable to sign in. Please try again.", err)
+		slog.LogAttrs(ctx, slog.LevelError, "Unexpected error during phone login",
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error500InternalServerError("Unable to sign in due to a server error. Please try again later.", err)
 	}
 
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
@@ -86,7 +93,7 @@ func (h *Handler) LoginWithPhoneHuma(ctx context.Context, input *LoginWithPhoneI
 			slog.String("userId", id.Hex()),
 			slog.String("error", err.Error()),
 		)
-		return nil, huma.Error500InternalServerError("Unable to complete login. Please try again.", err)
+		return nil, huma.Error500InternalServerError("Unable to complete login due to a token generation error. Please try again.", err)
 	}
 
 	resp := &LoginOutput{}
@@ -106,7 +113,11 @@ func (h *Handler) LoginWithTokenHuma(ctx context.Context, input *LoginWithTokenI
 
 	user, err := h.service.GetUser(user_id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to load your profile. Please try again.", err)
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to load user profile during token login",
+			slog.String("userId", user_id),
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error500InternalServerError("Unable to load your profile. Your account may have been deleted or is temporarily unavailable.", err)
 	}
 
 	resp := &LoginOutput{}
@@ -252,7 +263,7 @@ func (h *Handler) RegisterWithContext(ctx context.Context, input *RegisterInput)
 		slog.LogAttrs(ctx, slog.LevelError, "Token generation failed during registration",
 			slog.String("error", err.Error()),
 		)
-		return nil, huma.Error500InternalServerError("Token generation failed", err)
+		return nil, huma.Error500InternalServerError("Unable to complete registration due to a token generation error. Please try again.", err)
 	}
 
 	aaid := ctx.Value(appleIDContextKey)
@@ -443,12 +454,12 @@ func (h *Handler) LogoutHuma(ctx context.Context, input *LogoutInput) (*LogoutOu
 
 	split := strings.Split(input.Authorization, " ")
 	if len(split) != 2 {
-		return nil, huma.Error400BadRequest("Invalid authorization format", nil)
+		return nil, huma.Error400BadRequest("Invalid authorization format. Expected: Bearer <token>", nil)
 	}
 
 	tokenType, accessToken := split[0], split[1]
 	if tokenType != "Bearer" {
-		return nil, huma.Error400BadRequest("Invalid authorization type", nil)
+		return nil, huma.Error400BadRequest("Invalid authorization type. Expected Bearer token.", nil)
 	}
 
 	// increase the count by one
@@ -459,7 +470,11 @@ func (h *Handler) LogoutHuma(ctx context.Context, input *LogoutInput) (*LogoutOu
 
 	err = h.service.InvalidateTokens(user_id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to log out. Please try again.", err)
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to invalidate tokens during logout",
+			slog.String("userId", user_id),
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error500InternalServerError("Unable to log out due to a server error. Please try again later.", err)
 	}
 
 	resp := &LogoutOutput{}
@@ -488,8 +503,8 @@ func (h *Handler) UpdatePushTokenHuma(ctx context.Context, input *UpdatePushToke
 
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		slog.Error("❌ Push token validation failed", "errors", errs)
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		slog.Error("Push token validation failed", "errors", errs)
+		return nil, huma.Error400BadRequest("Invalid push token. Please check the token format and try again.", fmt.Errorf("validation errors: %v", errs))
 	}
 	slog.Info("✅ Push token validated successfully")
 
@@ -535,14 +550,14 @@ func RequireAuthFromHuma(ctx context.Context) (string, error) {
 func (h *Handler) SendOTPHuma(ctx context.Context, input *SendOTPInput) (*SendOTPOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid phone number", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Call the service method which handles the async Sinch API call
 	verificationID, err := h.service.SendOTP(ctx, input.Body.PhoneNumber)
 	if err != nil {
 		slog.Error("Failed to send OTP", "error", err, "phone", input.Body.PhoneNumber)
-		return nil, huma.Error500InternalServerError("Unable to send verification code. Please try again.", err)
+		return nil, huma.Error500InternalServerError("Unable to send verification code. The SMS service may be temporarily unavailable.", err)
 	}
 
 	resp := &SendOTPOutput{}
@@ -556,14 +571,14 @@ func (h *Handler) SendOTPHuma(ctx context.Context, input *SendOTPInput) (*SendOT
 func (h *Handler) VerifyOTPHuma(ctx context.Context, input *VerifyOTPInput) (*VerifyOTPOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid phone number and verification code", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Call the service method which handles the async Sinch API call
 	valid, status, err := h.service.VerifyOTP(ctx, input.Body.PhoneNumber, input.Body.Code)
 	if err != nil {
 		slog.Error("Failed to verify OTP", "error", err, "phone", input.Body.PhoneNumber)
-		return nil, huma.Error500InternalServerError("Unable to verify code. Please try again.", err)
+		return nil, huma.Error500InternalServerError("Unable to verify code. The verification service may be temporarily unavailable.", err)
 	}
 
 	resp := &VerifyOTPOutput{}
@@ -583,14 +598,14 @@ func (h *Handler) VerifyOTPHuma(ctx context.Context, input *VerifyOTPInput) (*Ve
 func (h *Handler) LoginWithOTPHuma(ctx context.Context, input *LoginWithOTPInput) (*LoginWithOTPOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid phone number and verification code", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Step 1: Verify the OTP code
 	valid, status, err := h.service.VerifyOTP(ctx, input.Body.PhoneNumber, input.Body.Code)
 	if err != nil {
 		slog.Error("Failed to verify OTP during login", "error", err, "phone", input.Body.PhoneNumber)
-		return nil, huma.Error500InternalServerError("Unable to verify code. Please try again.", err)
+		return nil, huma.Error500InternalServerError("Unable to verify code. The verification service may be temporarily unavailable.", err)
 	}
 
 	if !valid {
@@ -609,7 +624,7 @@ func (h *Handler) LoginWithOTPHuma(ctx context.Context, input *LoginWithOTPInput
 	result, err := completeLogin(h.service, id.Hex(), *count, user)
 	if err != nil {
 		slog.Error("Token generation failed during OTP login", "error", err, "user_id", id.Hex())
-		return nil, huma.Error500InternalServerError("Token generation failed", err)
+		return nil, huma.Error500InternalServerError("Unable to complete login due to a token generation error. Please try again.", err)
 	}
 
 	resp := &LoginWithOTPOutput{}
@@ -654,7 +669,7 @@ func (h *Handler) AcceptTermsHuma(ctx context.Context, input *AcceptTermsInput) 
 	// Validate input
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide a valid terms version to accept", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context (set by auth middleware)

--- a/backend/internal/handlers/auth/fiber_middleware.go
+++ b/backend/internal/handlers/auth/fiber_middleware.go
@@ -34,7 +34,7 @@ func FiberAuthMiddleware(collections map[string]*mongo.Collection, cfg config.Co
 			xlog.AuthError(fmt.Sprintf("Invalid authorization header format (parts: %d, first: %s)",
 				len(parts), parts[0]))
 			return c.Status(401).JSON(fiber.Map{
-				"error":  "Invalid authorization header format",
+				"error":  "Invalid authorization header format. Expected: Bearer <token>",
 				"status": 401,
 			})
 		}
@@ -78,7 +78,7 @@ func FiberAuthMiddleware(collections map[string]*mongo.Collection, cfg config.Co
 			if err != nil {
 				xlog.AuthError(fmt.Sprintf("Failed to generate new tokens: %v", err))
 				return c.Status(500).JSON(fiber.Map{
-					"error":  "Failed to generate new tokens",
+					"error":  "Session refresh failed. Please log in again.",
 					"status": 500,
 				})
 			}
@@ -87,7 +87,7 @@ func FiberAuthMiddleware(collections map[string]*mongo.Collection, cfg config.Co
 			if err := service.UseToken(userID); err != nil {
 				xlog.AuthError(fmt.Sprintf("Failed to mark token as used: %v", err))
 				return c.Status(500).JSON(fiber.Map{
-					"error":  "Failed to update token usage",
+					"error":  "Session update failed. Please log in again.",
 					"status": 500,
 				})
 			}
@@ -153,7 +153,7 @@ func FiberAuthMiddlewareForServer(collections map[string]*mongo.Collection) fibe
 	if err != nil {
 		slog.Error("Failed to load configuration for Fiber auth middleware", "error", err.Error())
 		return func(c *fiber.Ctx) error {
-			return c.Status(500).JSON(fiber.Map{"error": "Server configuration error"})
+			return c.Status(500).JSON(fiber.Map{"error": "Server configuration error. Authentication service is unavailable."})
 		}
 	}
 	return FiberAuthMiddleware(collections, cfg)

--- a/backend/internal/handlers/auth/forgot_pass/forgot_pass.go
+++ b/backend/internal/handlers/auth/forgot_pass/forgot_pass.go
@@ -2,6 +2,7 @@ package forgot_pass
 
 import (
 	"errors"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/xerr"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
@@ -36,8 +37,9 @@ func (h *Handler) ForgotPassword(c *fiber.Ctx) error {
 	err = h.service.CreateOTP(reqBody.Email, 15)
 
 	if err != nil {
+		slog.Error("Failed to create OTP for password reset", "email", reqBody.Email, "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Internal server error",
+			"error": "Unable to send password reset email. Please try again later.",
 		})
 	}
 
@@ -95,8 +97,10 @@ func (h *Handler) ChangePassword(c *fiber.Ctx) error {
 				JSON(xerr.Unauthorized("OTP not verified or does not exist"))
 		} else if errors.Is(err, ErrNoResetDoc) {
 			// Could not find corresponding doc in pw-resets
-			return c.Status(fiber.StatusInternalServerError).
-				JSON(xerr.InternalServerError())
+			slog.Error("No password reset request found when changing password", "email", reqBody.Email)
+			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
+				"error": "No active password reset request found. Please request a new password reset first.",
+			})
 		}
 		return err
 	}

--- a/backend/internal/handlers/auth/middleware.go
+++ b/backend/internal/handlers/auth/middleware.go
@@ -41,10 +41,10 @@ func AuthMiddleware(collections map[string]*mongo.Collection, cfg config.Config)
 			// Parse Bearer token
 			parts := strings.Split(authHeader, " ")
 			if len(parts) != 2 || parts[0] != "Bearer" {
-				slog.Error("❌ AUTH MIDDLEWARE: Invalid authorization header format",
+				slog.Error("AUTH MIDDLEWARE: Invalid authorization header format",
 					"parts_count", len(parts),
 					"first_part", parts[0])
-				http.Error(w, `{"error":"Invalid authorization header format","status":401}`, http.StatusUnauthorized)
+				http.Error(w, `{"error":"Invalid authorization header format. Expected: Bearer <token>","status":401}`, http.StatusUnauthorized)
 				return
 			}
 
@@ -82,8 +82,8 @@ func AuthMiddleware(collections map[string]*mongo.Collection, cfg config.Config)
 				timezone = newTimezone
 				newAccess, newRefresh, err := service.GenerateTokens(userID, newCount, timezone)
 				if err != nil {
-					slog.Error("❌ AUTH MIDDLEWARE: Failed to generate new tokens", "error", err.Error())
-					http.Error(w, `{"error":"Failed to generate new tokens","status":500}`, http.StatusInternalServerError)
+					slog.Error("AUTH MIDDLEWARE: Failed to generate new tokens", "error", err.Error())
+					http.Error(w, `{"error":"Session refresh failed. Please log in again.","status":500}`, http.StatusInternalServerError)
 					return
 				}
 
@@ -91,8 +91,8 @@ func AuthMiddleware(collections map[string]*mongo.Collection, cfg config.Config)
 
 				// Mark refresh token as used
 				if err := service.UseToken(userID); err != nil {
-					slog.Error("❌ AUTH MIDDLEWARE: Failed to mark token as used", "error", err.Error())
-					http.Error(w, `{"error":"Failed to update token usage","status":500}`, http.StatusInternalServerError)
+					slog.Error("AUTH MIDDLEWARE: Failed to mark token as used", "error", err.Error())
+					http.Error(w, `{"error":"Session update failed. Please log in again.","status":500}`, http.StatusInternalServerError)
 					return
 				}
 

--- a/backend/internal/handlers/blueprint/blueprint.go
+++ b/backend/internal/handlers/blueprint/blueprint.go
@@ -3,6 +3,7 @@ package Blueprint
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -58,7 +59,8 @@ func (h *Handler) CreateBlueprintHuma(ctx context.Context, input *CreateBlueprin
 
 	blueprint, err := h.service.CreateBlueprint(&internalDoc)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create blueprint", err)
+		slog.Error("failed to create blueprint", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create blueprint. Please try again.", err)
 	}
 
 	return &CreateBlueprintOutput{Body: *blueprint}, nil
@@ -67,7 +69,8 @@ func (h *Handler) CreateBlueprintHuma(ctx context.Context, input *CreateBlueprin
 func (h *Handler) GetBlueprintsHuma(ctx context.Context, input *GetBlueprintsInput) (*GetBlueprintsOutput, error) {
 	blueprints, err := h.service.GetAllBlueprints()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get blueprints", err)
+		slog.Error("failed to get blueprints", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve blueprints. Please try again.", err)
 	}
 
 	return &GetBlueprintsOutput{Body: blueprints}, nil
@@ -100,7 +103,8 @@ func (h *Handler) UpdateBlueprintHuma(ctx context.Context, input *UpdateBlueprin
 	}
 
 	if err := h.service.UpdatePartialBlueprint(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update blueprint", err)
+		slog.Error("failed to update blueprint", "blueprintId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update blueprint. Please try again.", err)
 	}
 
 	resp := &UpdateBlueprintOutput{}
@@ -121,7 +125,8 @@ func (h *Handler) DeleteBlueprintHuma(ctx context.Context, input *DeleteBlueprin
 	}
 
 	if err := h.service.DeleteBlueprint(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete blueprint", err)
+		slog.Error("failed to delete blueprint", "blueprintId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete blueprint. Please try again.", err)
 	}
 
 	resp := &DeleteBlueprintOutput{}
@@ -151,7 +156,8 @@ func (h *Handler) SubscribeToBlueprintHuma(ctx context.Context, input *Subscribe
 		if err == mongo.ErrNoDocuments {
 			return nil, huma.Error400BadRequest("Already subscribed or blueprint not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to subscribe", err)
+		slog.Error("failed to subscribe to blueprint", "blueprintId", input.ID, "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to subscribe to blueprint. Please try again.", err)
 	}
 
 	resp := &SubscribeToBlueprintOutput{}
@@ -181,7 +187,8 @@ func (h *Handler) UnsubscribeFromBlueprintHuma(ctx context.Context, input *Unsub
 		if err == mongo.ErrNoDocuments {
 			return nil, huma.Error400BadRequest("Not subscribed or blueprint not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to unsubscribe", err)
+		slog.Error("failed to unsubscribe from blueprint", "blueprintId", input.ID, "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to unsubscribe from blueprint. Please try again.", err)
 	}
 
 	resp := &UnsubscribeFromBlueprintOutput{}
@@ -192,7 +199,8 @@ func (h *Handler) UnsubscribeFromBlueprintHuma(ctx context.Context, input *Unsub
 func (h *Handler) SearchBlueprintsHuma(ctx context.Context, input *SearchBlueprintsInput) (*SearchBlueprintsOutput, error) {
 	blueprints, err := h.service.SearchBlueprints(input.Query)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to search blueprints", err)
+		slog.Error("failed to search blueprints", "query", input.Query, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to search blueprints. Please try again.", err)
 	}
 	return &SearchBlueprintsOutput{Body: blueprints}, nil
 }
@@ -205,7 +213,8 @@ func (h *Handler) AutocompleteBlueprintsHuma(ctx context.Context, input *Autocom
 
 	blueprints, err := h.service.AutocompleteBlueprints(input.Query)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to autocomplete blueprints", err)
+		slog.Error("failed to autocomplete blueprints", "query", input.Query, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to autocomplete blueprints. Please try again.", err)
 	}
 	return &AutocompleteBlueprintsOutput{Body: blueprints}, nil
 }
@@ -224,7 +233,8 @@ func (h *Handler) GetUserSubscribedBlueprintsHuma(ctx context.Context, input *Ge
 
 	blueprints, err := h.service.GetUserSubscribedBlueprints(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get subscribed blueprints", err)
+		slog.Error("failed to get subscribed blueprints", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve subscribed blueprints. Please try again.", err)
 	}
 
 	return &GetUserSubscribedBlueprintsOutput{Body: blueprints}, nil
@@ -244,7 +254,8 @@ func (h *Handler) GetBlueprintsByCreatorHuma(ctx context.Context, input *GetBlue
 
 	blueprints, err := h.service.GetBlueprintsByCreator(creatorID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get blueprints by creator", err)
+		slog.Error("failed to get blueprints by creator", "creatorId", input.CreatorID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve blueprints by creator. Please try again.", err)
 	}
 
 	return &GetBlueprintsByCreatorOutput{Body: blueprints}, nil
@@ -253,7 +264,8 @@ func (h *Handler) GetBlueprintsByCreatorHuma(ctx context.Context, input *GetBlue
 func (h *Handler) GetBlueprintByCategoryHuma(ctx context.Context, input *GetBlueprintByCategoryInput) (*GetBlueprintByCategoryOutput, error) {
 	blueprintGroups, err := h.service.GetBlueprintByCategory()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get blueprints by category", err)
+		slog.Error("failed to get blueprints by category", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve blueprints by category. Please try again.", err)
 	}
 
 	return &GetBlueprintByCategoryOutput{Body: blueprintGroups}, nil
@@ -282,13 +294,15 @@ func (h *Handler) GenerateAndCreateBlueprintHuma(ctx context.Context, input *Gen
 		if err == types.ErrInsufficientCredits {
 			return nil, huma.Error403Forbidden("Insufficient credits. You need at least 1 AI credit to generate a blueprint.", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		slog.Error("failed to process credit for blueprint generation", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to process credit. Please try again.", err)
 	}
 
 	// Call Genkit flow to generate blueprint
 	generatedBlueprint, err := h.callGeminiGenerateBlueprintFlow(ctx, userID, input.Body.Description)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to generate blueprint with AI", err)
+		slog.Error("failed to generate blueprint with AI", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to generate blueprint with AI. Please try again.", err)
 	}
 
 	// Create internal document for database operations
@@ -315,7 +329,8 @@ func (h *Handler) GenerateAndCreateBlueprintHuma(ctx context.Context, input *Gen
 	// Save blueprint to database
 	blueprint, err := h.service.CreateBlueprint(&internalDoc)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create blueprint", err)
+		slog.Error("failed to save generated blueprint", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to save generated blueprint. Please try again.", err)
 	}
 
 	return &GenerateAndCreateBlueprintOutput{Body: *blueprint}, nil

--- a/backend/internal/handlers/calendar/calendar.go
+++ b/backend/internal/handlers/calendar/calendar.go
@@ -34,6 +34,7 @@ func (h *Handler) ConnectGoogle(ctx context.Context, input *ConnectGoogleInput) 
 
 	authURL, err := h.service.InitiateOAuth(ProviderGoogle, userID)
 	if err != nil {
+		slog.Error("Failed to initiate Google OAuth", "userId", userID, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to initiate Google Calendar connection. Please try again.", err)
 	}
 
@@ -119,6 +120,7 @@ func (h *Handler) GetConnections(ctx context.Context, input *GetConnectionsInput
 
 	connections, err := h.service.GetConnections(ctx, userObjID)
 	if err != nil {
+		slog.Error("Failed to get calendar connections", "userId", userID, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to load calendar connections. Please try again.", err)
 	}
 
@@ -145,6 +147,7 @@ func (h *Handler) Disconnect(ctx context.Context, input *DisconnectInput) (*Disc
 	}
 
 	if err := h.service.DisconnectProvider(ctx, userObjID, connectionID); err != nil {
+		slog.Error("Failed to disconnect calendar provider", "userId", userID, "connectionId", input.ConnectionID, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to disconnect calendar. Please try again.", err)
 	}
 
@@ -200,6 +203,7 @@ func (h *Handler) GetEvents(ctx context.Context, input *GetEventsInput) (*GetEve
 	// Fetch events
 	events, err := h.service.FetchEvents(ctx, connectionID, startTime, endTime)
 	if err != nil {
+		slog.Error("Failed to fetch calendar events", "connectionId", input.ConnectionID, "start", startTime, "end", endTime, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to fetch calendar events. Please try again.", err)
 	}
 
@@ -245,6 +249,7 @@ func (h *Handler) ListCalendars(ctx context.Context, input *ListCalendarsInput) 
 
 	calendars, err := h.service.ListCalendarsForConnection(ctx, connectionID, userObjID)
 	if err != nil {
+		slog.Error("Failed to list calendars for connection", "userId", userID, "connectionId", input.ConnectionID, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to list calendars. Please try again.", err)
 	}
 
@@ -271,6 +276,7 @@ func (h *Handler) SetupWorkspaces(ctx context.Context, input *SetupWorkspacesInp
 	}
 
 	if err := h.service.SetupWorkspacesForConnection(ctx, connectionID, userObjID, input.Body.CalendarIDs, input.Body.MergeIntoOne, input.Body.MakePublic); err != nil {
+		slog.Error("Failed to set up calendar workspaces", "userId", userID, "connectionId", input.ConnectionID, "calendarIds", input.Body.CalendarIDs, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to set up calendar workspaces. Please try again.", err)
 	}
 
@@ -341,6 +347,7 @@ func (h *Handler) SyncEvents(ctx context.Context, input *SyncEventsInput) (*Sync
 	// Sync events to tasks
 	result, err := h.service.SyncEventsToTasks(ctx, connectionID, userObjID, startTime, endTime)
 	if err != nil {
+		slog.Error("Failed to sync calendar events to tasks", "userId", userID, "connectionId", input.ConnectionID, "start", startTime, "end", endTime, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to sync calendar events. Please try again.", err)
 	}
 

--- a/backend/internal/handlers/category/category.go
+++ b/backend/internal/handlers/category/category.go
@@ -45,7 +45,8 @@ func (h *Handler) CreateCategory(ctx context.Context, input *CreateCategoryInput
 
 	_, err = h.service.CreateCategory(&doc)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create Category", err)
+		slog.Error("unable to create category", "userId", user_id, "categoryName", input.Body.Name, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create category. Please try again.", err)
 	}
 
 	// When creating a proxy category, upsert workspace metadata if icon/color provided
@@ -63,7 +64,8 @@ func (h *Handler) CreateCategory(ctx context.Context, input *CreateCategoryInput
 func (h *Handler) GetCategories(ctx context.Context, input *GetCategoriesInput) (*GetCategoriesOutput, error) {
 	Categories, err := h.service.GetAllCategories()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch categories", err)
+		slog.Error("unable to fetch categories", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch categories. Please try again.", err)
 	}
 
 	return &GetCategoriesOutput{Body: Categories}, nil
@@ -116,7 +118,8 @@ func (h *Handler) UpdatePartialCategory(ctx context.Context, input *UpdateCatego
 
 	_, err = h.service.UpdatePartialCategory(id, input.Body, user_id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update category", err)
+		slog.Error("unable to update category", "userId", user_id_str, "categoryId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update category. Please try again.", err)
 	}
 
 	// Return a simple success response
@@ -143,7 +146,8 @@ func (h *Handler) DeleteCategory(ctx context.Context, input *DeleteCategoryInput
 	}
 
 	if err := h.service.DeleteCategory(user_id_obj, id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete category", err)
+		slog.Error("unable to delete category", "userId", user_id, "categoryId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete category. Please try again.", err)
 	}
 
 	resp := &DeleteCategoryOutput{}
@@ -173,7 +177,8 @@ func (h *Handler) DeleteWorkspace(ctx context.Context, input *DeleteWorkspaceInp
 
 	err = h.service.DeleteWorkspace(workspaceName, user_id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete workspace", err)
+		slog.Error("unable to delete workspace", "userId", user_id_str, "workspaceName", workspaceName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete workspace. Please try again.", err)
 	}
 
 	resp := &DeleteWorkspaceOutput{}
@@ -204,7 +209,8 @@ func (h *Handler) RenameWorkspace(ctx context.Context, input *RenameWorkspaceInp
 
 	err = h.service.RenameWorkspace(oldWorkspaceName, newWorkspaceName, user_id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to rename workspace", err)
+		slog.Error("unable to rename workspace", "userId", user_id_str, "oldName", oldWorkspaceName, "newName", newWorkspaceName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to rename workspace. Please try again.", err)
 	}
 
 	resp := &RenameWorkspaceOutput{}
@@ -226,7 +232,8 @@ func (h *Handler) GetWorkspaces(ctx context.Context, input *GetWorkspacesInput) 
 
 	workspaces, err := h.service.GetWorkspaces(user_id_obj)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch workspaces", err)
+		slog.Error("unable to fetch workspaces", "userId", user_id_str, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch workspaces. Please try again.", err)
 	}
 
 	return &GetWorkspacesOutput{Body: workspaces}, nil
@@ -249,7 +256,8 @@ func (h *Handler) UpdateWorkspace(ctx context.Context, input *UpdateWorkspaceInp
 	}
 
 	if err := h.service.UpdateWorkspaceMeta(workspaceName, user_id, input.Body.Icon, input.Body.Color); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update workspace metadata", err)
+		slog.Error("unable to update workspace metadata", "userId", user_id_str, "workspaceName", workspaceName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update workspace metadata. Please try again.", err)
 	}
 
 	resp := &UpdateWorkspaceOutput{}
@@ -405,7 +413,8 @@ func (h *Handler) SetupDefaultWorkspace(ctx context.Context, input *SetupDefault
 	}
 
 	if len(createdCategories) == 0 {
-		return nil, huma.Error500InternalServerError("Failed to create any categories", err)
+		slog.Error("unable to create any default workspace categories", "userId", user_id, "workspaceName", workspaceName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to set up default workspace. Please try again.", err)
 	}
 
 	slog.LogAttrs(ctx, slog.LevelInfo, "Default workspace created with multiple categories",

--- a/backend/internal/handlers/congratulation/congratulation.go
+++ b/backend/internal/handlers/congratulation/congratulation.go
@@ -3,6 +3,7 @@ package congratulation
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -41,7 +42,8 @@ func (h *Handler) CreateCongratulationHuma(ctx context.Context, input *CreateCon
 	// Get sender information from the users collection
 	senderInfo, err := h.service.GetSenderInfo(senderID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get sender information", err)
+		slog.Error("failed to get sender information", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get sender information. Please try again.", err)
 	}
 
 	// Default type to "message" if not provided
@@ -79,7 +81,8 @@ func (h *Handler) CreateCongratulationHuma(ctx context.Context, input *CreateCon
 		if strings.Contains(err.Error(), "insufficient congratulation balance") {
 			return nil, huma.Error400BadRequest("Insufficient congratulation balance", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to create congratulation", err)
+		slog.Error("failed to create congratulation", "userId", user_id, "receiver", input.Body.Receiver, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create congratulation. Please try again.", err)
 	}
 
 	return &CreateCongratulationOutput{Body: *congratulation}, nil
@@ -99,7 +102,8 @@ func (h *Handler) GetCongratulationsHuma(ctx context.Context, input *GetCongratu
 
 	congratulations, err := h.service.GetAllCongratulations(receiverID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get congratulations", err)
+		slog.Error("failed to get congratulations", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get congratulations. Please try again.", err)
 	}
 
 	return &GetCongratulationsOutput{Body: congratulations}, nil
@@ -122,7 +126,8 @@ func (h *Handler) GetCongratulationHuma(ctx context.Context, input *GetCongratul
 		if err == mongo.ErrNoDocuments {
 			return nil, huma.Error404NotFound("Congratulation not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to get congratulation", err)
+		slog.Error("failed to get congratulation", "congratulationId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get congratulation. Please try again.", err)
 	}
 
 	return &GetCongratulationOutput{Body: *congratulation}, nil
@@ -141,7 +146,8 @@ func (h *Handler) UpdateCongratulationHuma(ctx context.Context, input *UpdateCon
 	}
 
 	if err := h.service.UpdatePartialCongratulation(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update congratulation", err)
+		slog.Error("failed to update congratulation", "congratulationId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update congratulation. Please try again.", err)
 	}
 
 	resp := &UpdateCongratulationOutput{}
@@ -162,7 +168,8 @@ func (h *Handler) DeleteCongratulationHuma(ctx context.Context, input *DeleteCon
 	}
 
 	if err := h.service.DeleteCongratulation(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete congratulation", err)
+		slog.Error("failed to delete congratulation", "congratulationId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete congratulation. Please try again.", err)
 	}
 
 	resp := &DeleteCongratulationOutput{}
@@ -199,7 +206,8 @@ func (h *Handler) MarkCongratulationsReadHuma(ctx context.Context, input *MarkCo
 
 	count, err := h.service.MarkCongratulationsAsRead(objectIDs)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to mark congratulations as read", err)
+		slog.Error("failed to mark congratulations as read", "ids", input.Body.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to mark congratulations as read. Please try again.", err)
 	}
 
 	resp := &MarkCongratulationsReadOutput{}

--- a/backend/internal/handlers/connection/connection.go
+++ b/backend/internal/handlers/connection/connection.go
@@ -3,6 +3,7 @@ package Connection
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
@@ -17,7 +18,7 @@ type Handler struct {
 func (h *Handler) CreateConnectionHuma(ctx context.Context, input *CreateConnectionInput) (*CreateConnectionOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your connection request details", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context for authorization
@@ -41,7 +42,8 @@ func (h *Handler) CreateConnectionHuma(ctx context.Context, input *CreateConnect
 	// Create connection request - service will fetch requester details
 	connection, err := h.service.CreateConnectionRequest(requesterID, receiverID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create connection", err)
+		slog.Error("Failed to create connection request", "requesterId", requesterID.Hex(), "receiverId", receiverID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to send connection request. The user may not exist or a request may already be pending.", err)
 	}
 
 	return &CreateConnectionOutput{Body: *connection}, nil
@@ -56,7 +58,8 @@ func (h *Handler) GetConnectionsHuma(ctx context.Context, input *GetConnectionsI
 
 	Connections, err := h.service.GetAllConnections()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get connections", err)
+		slog.Error("Failed to fetch all connections", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load connections. Please try again.", err)
 	}
 
 	return &GetConnectionsOutput{Body: Connections}, nil
@@ -71,11 +74,12 @@ func (h *Handler) GetConnectionHuma(ctx context.Context, input *GetConnectionInp
 
 	id, err := primitive.ObjectIDFromHex(user_id)
 	if err != nil {
-		return nil, huma.Error400BadRequest("Invalid ID", err)
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
 	}
 
 	Connection, err := h.service.GetConnectionByID(id)
 	if err != nil {
+		slog.Error("Connection not found", "userId", id.Hex(), "error", err)
 		return nil, huma.Error404NotFound("Connection not found", err)
 	}
 
@@ -91,12 +95,13 @@ func (h *Handler) GetConnectionsByReceiverHuma(ctx context.Context, input *GetCo
 
 	id, err := primitive.ObjectIDFromHex(user_id)
 	if err != nil {
-		return nil, huma.Error400BadRequest("Invalid user ID", err)
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
 	}
 
 	connections, err := h.service.GetPendingRequestsByReceiver(id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get connections", err)
+		slog.Error("Failed to fetch pending connection requests", "userId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load pending connection requests. Please try again.", err)
 	}
 
 	return &GetConnectionsByReceiverOutput{Body: connections}, nil
@@ -116,7 +121,8 @@ func (h *Handler) GetConnectionsByRequesterHuma(ctx context.Context, input *GetC
 
 	connections, err := h.service.GetByRequester(id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get connections", err)
+		slog.Error("Failed to fetch connections by requester", "requesterId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load sent connection requests. Please try again.", err)
 	}
 
 	return &GetConnectionsByRequesterOutput{Body: connections}, nil
@@ -135,7 +141,8 @@ func (h *Handler) UpdateConnectionHuma(ctx context.Context, input *UpdateConnect
 	}
 
 	if err := h.service.UpdatePartialConnection(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update connection", err)
+		slog.Error("Failed to update connection", "connectionId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update connection. Please try again.", err)
 	}
 
 	resp := &UpdateConnectionOutput{}
@@ -156,7 +163,8 @@ func (h *Handler) DeleteConnectionHuma(ctx context.Context, input *DeleteConnect
 	}
 
 	if err := h.service.DeleteConnection(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete connection", err)
+		slog.Error("Failed to delete connection", "connectionId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to remove connection. Please try again.", err)
 	}
 
 	resp := &DeleteConnectionOutput{}
@@ -185,7 +193,8 @@ func (h *Handler) AcceptConnectionHuma(ctx context.Context, input *AcceptConnect
 
 	// Accept the connection request
 	if err := h.service.AcceptConnection(connectionID, userID); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to accept connection", err)
+		slog.Error("Failed to accept connection request", "connectionId", connectionID.Hex(), "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to accept connection request. It may have been withdrawn or already accepted.", err)
 	}
 
 	resp := &AcceptConnectionOutput{}
@@ -208,7 +217,8 @@ func (h *Handler) GetFriendsHuma(ctx context.Context, input *GetFriendsInput) (*
 
 	friends, err := h.service.GetFriends(userOID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get friends", err)
+		slog.Error("Failed to fetch friends list", "userId", userOID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load your friends list. Please try again.", err)
 	}
 
 	return &GetFriendsOutput{Body: friends}, nil
@@ -239,7 +249,8 @@ func (h *Handler) BlockUserHuma(ctx context.Context, input *BlockUserInput) (*Bl
 
 	err = h.service.BlockUser(ctx, blockerID, blockedID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to block user", err)
+		slog.Error("Failed to block user", "blockerId", blockerID.Hex(), "blockedId", blockedID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to block user. Please try again.", err)
 	}
 
 	resp := &BlockUserOutput{}
@@ -267,7 +278,8 @@ func (h *Handler) UnblockUserHuma(ctx context.Context, input *UnblockUserInput) 
 
 	err = h.service.UnblockUser(ctx, blockerID, blockedID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to unblock user", err)
+		slog.Error("Failed to unblock user", "blockerId", blockerID.Hex(), "blockedId", blockedID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to unblock user. Please try again.", err)
 	}
 
 	resp := &UnblockUserOutput{}
@@ -290,7 +302,8 @@ func (h *Handler) GetBlockedUsersHuma(ctx context.Context, input *GetBlockedUser
 
 	blockedUsers, err := h.service.GetBlockedUsers(ctx, userOID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get blocked users", err)
+		slog.Error("Failed to fetch blocked users", "userId", userOID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load blocked users list. Please try again.", err)
 	}
 
 	return &GetBlockedUsersOutput{Body: blockedUsers}, nil

--- a/backend/internal/handlers/encouragement/encouragement.go
+++ b/backend/internal/handlers/encouragement/encouragement.go
@@ -3,6 +3,7 @@ package encouragement
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -70,7 +71,8 @@ func (h *Handler) CreateEncouragementHuma(ctx context.Context, input *CreateEnco
 	// Get sender information from the users collection
 	senderInfo, err := h.service.GetSenderInfo(senderID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get sender information", err)
+		slog.Error("failed to get sender information", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get sender information. Please try again.", err)
 	}
 
 	// Default type to "message" if not provided
@@ -99,7 +101,8 @@ func (h *Handler) CreateEncouragementHuma(ctx context.Context, input *CreateEnco
 		if strings.Contains(err.Error(), "insufficient encouragement balance") {
 			return nil, huma.Error400BadRequest("Insufficient encouragement balance", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to create encouragement", err)
+		slog.Error("failed to create encouragement", "userId", user_id, "receiver", input.Body.Receiver, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create encouragement. Please try again.", err)
 	}
 
 	return &CreateEncouragementOutput{Body: *encouragement}, nil
@@ -119,7 +122,8 @@ func (h *Handler) GetEncouragementsHuma(ctx context.Context, input *GetEncourage
 
 	encouragements, err := h.service.GetAllEncouragements(receiverID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get encouragements", err)
+		slog.Error("failed to get encouragements", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get encouragements. Please try again.", err)
 	}
 
 	return &GetEncouragementsOutput{Body: encouragements}, nil
@@ -142,7 +146,8 @@ func (h *Handler) GetEncouragementHuma(ctx context.Context, input *GetEncouragem
 		if err == mongo.ErrNoDocuments {
 			return nil, huma.Error404NotFound("Encouragement not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to get encouragement", err)
+		slog.Error("failed to get encouragement", "encouragementId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get encouragement. Please try again.", err)
 	}
 
 	return &GetEncouragementOutput{Body: *encouragement}, nil
@@ -161,7 +166,8 @@ func (h *Handler) UpdateEncouragementHuma(ctx context.Context, input *UpdateEnco
 	}
 
 	if err := h.service.UpdatePartialEncouragement(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update encouragement", err)
+		slog.Error("failed to update encouragement", "encouragementId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update encouragement. Please try again.", err)
 	}
 
 	resp := &UpdateEncouragementOutput{}
@@ -182,7 +188,8 @@ func (h *Handler) DeleteEncouragementHuma(ctx context.Context, input *DeleteEnco
 	}
 
 	if err := h.service.DeleteEncouragement(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete encouragement", err)
+		slog.Error("failed to delete encouragement", "encouragementId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete encouragement. Please try again.", err)
 	}
 
 	resp := &DeleteEncouragementOutput{}
@@ -219,7 +226,8 @@ func (h *Handler) MarkEncouragementsReadHuma(ctx context.Context, input *MarkEnc
 
 	count, err := h.service.MarkEncouragementsAsRead(objectIDs)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to mark encouragements as read", err)
+		slog.Error("failed to mark encouragements as read", "ids", input.Body.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to mark encouragements as read. Please try again.", err)
 	}
 
 	resp := &MarkEncouragementsReadOutput{}

--- a/backend/internal/handlers/group/group.go
+++ b/backend/internal/handlers/group/group.go
@@ -3,6 +3,7 @@ package Group
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
@@ -26,7 +27,7 @@ func NewHandler(collections map[string]*mongo.Collection) *Handler {
 func (h *Handler) CreateGroupHuma(ctx context.Context, input *CreateGroupInput) (*CreateGroupOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your group details", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context (set by auth middleware)
@@ -78,7 +79,8 @@ func (h *Handler) CreateGroupHuma(ctx context.Context, input *CreateGroupInput) 
 
 	createdGroup, err := h.service.CreateGroup(&group)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create group", err)
+		slog.Error("Failed to create group", "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create group due to a database error. Please try again.", err)
 	}
 
 	return &CreateGroupOutput{Body: *createdGroup.ToAPI()}, nil
@@ -98,7 +100,8 @@ func (h *Handler) GetGroupsHuma(ctx context.Context, input *GetGroupsInput) (*Ge
 
 	groups, err := h.service.GetAllGroups(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get groups", err)
+		slog.Error("Failed to fetch groups", "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load your groups. Please try again.", err)
 	}
 
 	var apiGroups []types.GroupDocumentAPI
@@ -126,7 +129,7 @@ func (h *Handler) GetGroupHuma(ctx context.Context, input *GetGroupInput) (*GetG
 
 	id, err := primitive.ObjectIDFromHex(input.ID)
 	if err != nil {
-		return nil, huma.Error400BadRequest("Invalid ID format", err)
+		return nil, huma.Error400BadRequest("Invalid group ID format", err)
 	}
 
 	group, err := h.service.GetGroupByID(id)
@@ -137,11 +140,12 @@ func (h *Handler) GetGroupHuma(ctx context.Context, input *GetGroupInput) (*GetG
 	// Check if user has access to this group
 	hasAccess, err := h.service.IsUserInGroup(id, userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to check group access", err)
+		slog.Error("Failed to check group membership", "groupId", id.Hex(), "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to verify group access. Please try again.", err)
 	}
 
 	if !hasAccess {
-		return nil, huma.Error403Forbidden("Access denied", fmt.Errorf("user not in group"))
+		return nil, huma.Error403Forbidden("You do not have access to this group", fmt.Errorf("user not in group"))
 	}
 
 	return &GetGroupOutput{Body: *group.ToAPI()}, nil
@@ -150,7 +154,7 @@ func (h *Handler) GetGroupHuma(ctx context.Context, input *GetGroupInput) (*GetG
 func (h *Handler) UpdateGroupHuma(ctx context.Context, input *UpdateGroupInput) (*UpdateGroupOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your group details", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context for authorization
@@ -166,12 +170,13 @@ func (h *Handler) UpdateGroupHuma(ctx context.Context, input *UpdateGroupInput) 
 
 	id, err := primitive.ObjectIDFromHex(input.ID)
 	if err != nil {
-		return nil, huma.Error400BadRequest("Invalid ID format", err)
+		return nil, huma.Error400BadRequest("Invalid group ID format", err)
 	}
 
 	err = h.service.UpdateGroup(id, input.Body, userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update group", err)
+		slog.Error("Failed to update group", "groupId", id.Hex(), "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update group. Please try again.", err)
 	}
 
 	return &UpdateGroupOutput{
@@ -195,12 +200,13 @@ func (h *Handler) DeleteGroupHuma(ctx context.Context, input *DeleteGroupInput) 
 
 	id, err := primitive.ObjectIDFromHex(input.ID)
 	if err != nil {
-		return nil, huma.Error400BadRequest("Invalid ID format", err)
+		return nil, huma.Error400BadRequest("Invalid group ID format", err)
 	}
 
 	err = h.service.DeleteGroup(id, userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete group", err)
+		slog.Error("Failed to delete group", "groupId", id.Hex(), "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete group. You may not have permission or the group may not exist.", err)
 	}
 
 	return &DeleteGroupOutput{
@@ -213,7 +219,7 @@ func (h *Handler) DeleteGroupHuma(ctx context.Context, input *DeleteGroupInput) 
 func (h *Handler) AddMemberHuma(ctx context.Context, input *AddMemberInput) (*AddMemberOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your group details", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context for authorization
@@ -239,7 +245,8 @@ func (h *Handler) AddMemberHuma(ctx context.Context, input *AddMemberInput) (*Ad
 
 	err = h.service.AddMember(groupID, userID, requesterID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to add member", err)
+		slog.Error("Failed to add member to group", "groupId", groupID.Hex(), "memberId", userID.Hex(), "requesterId", requesterID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to add member to group. The user may already be a member or you may not have permission.", err)
 	}
 
 	return &AddMemberOutput{
@@ -252,7 +259,7 @@ func (h *Handler) AddMemberHuma(ctx context.Context, input *AddMemberInput) (*Ad
 func (h *Handler) RemoveMemberHuma(ctx context.Context, input *RemoveMemberInput) (*RemoveMemberOutput, error) {
 	errs := xvalidator.Validator.Validate(input.Body)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please check your group details", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	// Extract user_id from context for authorization
@@ -278,7 +285,8 @@ func (h *Handler) RemoveMemberHuma(ctx context.Context, input *RemoveMemberInput
 
 	err = h.service.RemoveMember(groupID, userID, requesterID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to remove member", err)
+		slog.Error("Failed to remove member from group", "groupId", groupID.Hex(), "memberId", userID.Hex(), "requesterId", requesterID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to remove member from group. You may not have permission.", err)
 	}
 
 	return &RemoveMemberOutput{

--- a/backend/internal/handlers/notifications/huma_handlers.go
+++ b/backend/internal/handlers/notifications/huma_handlers.go
@@ -3,6 +3,7 @@ package notifications
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
@@ -46,13 +47,15 @@ func (h *Handler) GetNotificationsHuma(ctx context.Context, input *GetNotificati
 	// Get notifications
 	notifications, err := h.service.GetUserNotifications(userObjectID, limit, skip)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch notifications", err)
+		slog.Error("Failed to fetch notifications", "userId", userObjectID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load your notifications. Please try again.", err)
 	}
 
 	// Get unread count
 	unreadCount, err := h.service.GetUnreadCount(userObjectID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch unread count", err)
+		slog.Error("Failed to fetch unread notification count", "userId", userObjectID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load notification count. Please try again.", err)
 	}
 
 	return &GetNotificationsOutput{
@@ -79,7 +82,7 @@ func (h *Handler) MarkNotificationsReadHuma(ctx context.Context, input *MarkNoti
 	// Add explicit validation
 	errs := xvalidator.Validator.Validate(input)
 	if len(errs) > 0 {
-		return nil, huma.Error400BadRequest("Validation failed", fmt.Errorf("validation errors: %v", errs))
+		return nil, huma.Error400BadRequest("Please provide valid notification IDs", fmt.Errorf("validation errors: %v", errs))
 	}
 
 	if len(input.Body.ID) == 0 {
@@ -91,7 +94,7 @@ func (h *Handler) MarkNotificationsReadHuma(ctx context.Context, input *MarkNoti
 	for i, idStr := range input.Body.ID {
 		id, err := primitive.ObjectIDFromHex(idStr)
 		if err != nil {
-			return nil, huma.Error400BadRequest("Invalid ID format", fmt.Errorf("invalid ID at index %d: %s", i, idStr))
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Invalid notification ID format at position %d", i), fmt.Errorf("invalid ID at index %d: %s", i, idStr))
 		}
 		objectIDs[i] = id
 	}
@@ -99,7 +102,8 @@ func (h *Handler) MarkNotificationsReadHuma(ctx context.Context, input *MarkNoti
 	// Mark notifications as read
 	err = h.service.MarkNotificationsAsRead(objectIDs)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to mark notifications as read", err)
+		slog.Error("Failed to mark notifications as read", "notificationCount", len(objectIDs), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to mark notifications as read. Please try again.", err)
 	}
 
 	resp := &MarkNotificationsReadOutput{}
@@ -124,7 +128,8 @@ func (h *Handler) MarkAllNotificationsReadHuma(ctx context.Context, input *MarkA
 	// Mark all notifications as read
 	err = h.service.MarkAllAsReadForUser(userObjectID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to mark all notifications as read", err)
+		slog.Error("Failed to mark all notifications as read", "userId", userObjectID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to mark all notifications as read. Please try again.", err)
 	}
 
 	return &MarkAllNotificationsReadOutput{
@@ -156,7 +161,8 @@ func (h *Handler) DeleteNotificationHuma(ctx context.Context, input *DeleteNotif
 		if err == mongo.ErrNoDocuments {
 			return nil, huma.Error404NotFound("Notification not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to delete notification", err)
+		slog.Error("Failed to delete notification", "notificationId", notificationID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete notification. Please try again.", err)
 	}
 
 	return &DeleteNotificationOutput{

--- a/backend/internal/handlers/notifications/operations.go
+++ b/backend/internal/handlers/notifications/operations.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"log/slog"
 	"strconv"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -13,7 +14,7 @@ func (s *Service) GetNotifications(c *fiber.Ctx) error {
 	userIDStr, err := auth.RequireAuthFiber(c)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": "Unauthorized",
+			"error": "Authentication required",
 		})
 	}
 
@@ -45,16 +46,18 @@ func (s *Service) GetNotifications(c *fiber.Ctx) error {
 
 	notifications, err := s.GetUserNotifications(userID, limit, skip)
 	if err != nil {
+		slog.Error("Failed to fetch notifications", "userId", userID.Hex(), "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to fetch notifications",
+			"error": "Unable to load your notifications. Please try again.",
 		})
 	}
 
 	// Get unread count
 	unreadCount, err := s.GetUnreadCount(userID)
 	if err != nil {
+		slog.Error("Failed to fetch unread notification count", "userId", userID.Hex(), "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to fetch unread count",
+			"error": "Unable to load notification count. Please try again.",
 		})
 	}
 
@@ -70,7 +73,7 @@ func (s *Service) MarkAsRead(c *fiber.Ctx) error {
 	_, err := auth.RequireAuthFiber(c)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": "Unauthorized",
+			"error": "Authentication required",
 		})
 	}
 
@@ -98,8 +101,9 @@ func (s *Service) MarkAsRead(c *fiber.Ctx) error {
 
 	err = s.MarkNotificationsAsRead(notificationIDs)
 	if err != nil {
+		slog.Error("Failed to mark notifications as read", "count", len(notificationIDs), "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to mark notifications as read",
+			"error": "Unable to mark notifications as read. Please try again.",
 		})
 	}
 
@@ -113,7 +117,7 @@ func (s *Service) MarkAllAsRead(c *fiber.Ctx) error {
 	userIDStr, err := auth.RequireAuthFiber(c)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": "Unauthorized",
+			"error": "Authentication required",
 		})
 	}
 
@@ -126,8 +130,9 @@ func (s *Service) MarkAllAsRead(c *fiber.Ctx) error {
 
 	err = s.MarkAllAsReadForUser(userID)
 	if err != nil {
+		slog.Error("Failed to mark all notifications as read", "userId", userID.Hex(), "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to mark all notifications as read",
+			"error": "Unable to mark all notifications as read. Please try again.",
 		})
 	}
 
@@ -141,7 +146,7 @@ func (s *Service) DeleteNotificationHandler(c *fiber.Ctx) error {
 	_, err := auth.RequireAuthFiber(c)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{
-			"error": "Unauthorized",
+			"error": "Authentication required",
 		})
 	}
 
@@ -155,8 +160,9 @@ func (s *Service) DeleteNotificationHandler(c *fiber.Ctx) error {
 
 	err = s.DeleteNotification(notificationID)
 	if err != nil {
+		slog.Error("Failed to delete notification", "notificationId", notificationID.Hex(), "error", err)
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
-			"error": "Failed to delete notification",
+			"error": "Unable to delete notification. Please try again.",
 		})
 	}
 

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -3,6 +3,7 @@ package Post
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -39,7 +40,8 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 	var user types.User
 	err = h.service.Users.FindOne(context.Background(), bson.M{"_id": userObjID}).Decode(&user)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get user info", err)
+		slog.Error("failed to get user info for post creation", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get user info. Please try again.", err)
 	}
 
 	doc := types.PostDocument{
@@ -64,7 +66,7 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 	if input.Body.BlueprintID != nil {
 		blueprintID, err := primitive.ObjectIDFromHex(*input.Body.BlueprintID)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("Invalid blueprint id", err)
+			return nil, huma.Error400BadRequest("Invalid blueprint ID format", err)
 		}
 
 		blueprintIsPublic := false
@@ -92,7 +94,8 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 
 	createdPost, userStats, err := h.service.CreatePost(&doc)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create post", err)
+		slog.Error("failed to create post", "userId", user_id, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create post. Please try again.", err)
 	}
 
 	// Prepare response with user stats
@@ -120,7 +123,8 @@ func (h *Handler) GetPostsHuma(ctx context.Context, input *GetPostsInput) (*GetP
 
 	posts, total, err := h.service.GetAllPosts(limit, offset)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get posts", err)
+		slog.Error("failed to get posts", "limit", limit, "offset", offset, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get posts. Please try again.", err)
 	}
 
 	var apiPosts []types.PostDocumentAPI
@@ -161,7 +165,8 @@ func (h *Handler) GetFriendsPostsHuma(ctx context.Context, input *GetFriendsPost
 
 	posts, total, err := h.service.GetFriendsPosts(userID, limit, offset)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get friends posts", err)
+		slog.Error("failed to get friends posts", "userId", userIDStr, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get friends posts. Please try again.", err)
 	}
 
 	var apiPosts []types.PostDocumentAPI
@@ -211,7 +216,8 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 	// Get friends posts
 	posts, postsTotal, err := h.service.GetFriendsPosts(userID, postsNeeded, offset)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get feed", err)
+		slog.Error("failed to get feed posts", "userId", userIDStr, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get feed. Please try again.", err)
 	}
 
 	// Get friends' public tasks (with user data from aggregation pipeline)
@@ -398,7 +404,8 @@ func (h *Handler) GetUserGroupsHuma(ctx context.Context, input *GetUserGroupsInp
 
 	groups, err := h.service.GetUserGroups(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get user groups", err)
+		slog.Error("failed to get user groups", "userId", userIDStr, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get user groups. Please try again.", err)
 	}
 
 	var apiGroups []types.GroupDocumentAPI
@@ -426,7 +433,8 @@ func (h *Handler) GetPostsByBlueprintHuma(ctx context.Context, input *GetPostsBy
 
 	posts, err := h.service.GetPostsByBlueprint(blueprintID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get posts by blueprint", err)
+		slog.Error("failed to get posts by blueprint", "blueprintId", input.BlueprintID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get posts by blueprint. Please try again.", err)
 	}
 
 	var apiPosts []types.PostDocumentAPI
@@ -482,7 +490,8 @@ func (h *Handler) GetUserPostsHuma(ctx context.Context, input *GetUserPostsInput
 	// Check relationship between viewer and profile user
 	canView, err := h.service.CheckRelationship(viewerID, profileUserID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to check relationship", err)
+		slog.Error("failed to check relationship", "viewerId", viewerIDStr, "profileUserId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to check relationship. Please try again.", err)
 	}
 
 	// If not authorized to view, return empty paginated response (similar to tasks behavior)
@@ -552,7 +561,8 @@ func (h *Handler) UpdatePostHuma(ctx context.Context, input *UpdatePostInput) (*
 	}
 
 	if err := h.service.UpdatePartialPost(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update post", err)
+		slog.Error("failed to update post", "userId", user_id, "postId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update post. Please try again.", err)
 	}
 
 	resp := &UpdatePostOutput{}
@@ -587,7 +597,8 @@ func (h *Handler) DeletePostHuma(ctx context.Context, input *DeletePostInput) (*
 	}
 
 	if err := h.service.DeletePost(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete post", err)
+		slog.Error("failed to delete post", "userId", user_id, "postId", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete post. Please try again.", err)
 	}
 
 	resp := &DeletePostOutput{}
@@ -614,7 +625,8 @@ func (h *Handler) AddCommentHuma(ctx context.Context, input *AddCommentInput) (*
 	var user types.User
 	err = h.service.Users.FindOne(context.Background(), bson.M{"_id": userObjID}).Decode(&user)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get user info", err)
+		slog.Error("failed to get user info for comment", "userId", user_id, "postId", input.PostID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get user info. Please try again.", err)
 	}
 
 	// Parse mentions
@@ -654,7 +666,8 @@ func (h *Handler) AddCommentHuma(ctx context.Context, input *AddCommentInput) (*
 	}
 
 	if err := h.service.AddComment(postID, doc); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to add comment", err)
+		slog.Error("failed to add comment", "userId", user_id, "postId", input.PostID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to add comment. Please try again.", err)
 	}
 
 	output := &AddCommentOutput{}
@@ -666,7 +679,7 @@ func (h *Handler) AddCommentHuma(ctx context.Context, input *AddCommentInput) (*
 func (h *Handler) ToggleReactionHuma(ctx context.Context, input *AddReactionInput) (*AddReactionOutput, error) {
 	user_id, err := auth.RequireAuth(ctx)
 	if err != nil {
-		return nil, huma.Error401Unauthorized("Unauthorized", err)
+		return nil, huma.Error401Unauthorized("Authentication required", err)
 	}
 
 	userObjID, err := primitive.ObjectIDFromHex(user_id)
@@ -688,7 +701,8 @@ func (h *Handler) ToggleReactionHuma(ctx context.Context, input *AddReactionInpu
 	wasAdded, err := h.service.ToggleReaction(reaction)
 
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to process reaction", err)
+		slog.Error("failed to process reaction", "userId", user_id, "postId", input.PostID, "emoji", input.Body.Emoji, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to process reaction. Please try again.", err)
 	}
 
 	var message string
@@ -751,7 +765,8 @@ func (h *Handler) DeleteCommentHuma(ctx context.Context, input *DeleteCommentInp
 	}
 
 	if err := h.service.DeleteComment(postID, commentID); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete comment", err)
+		slog.Error("failed to delete comment", "userId", user_id, "postId", input.PostID, "commentId", input.CommentID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete comment. Please try again.", err)
 	}
 
 	resp := &DeleteCommentOutput{}

--- a/backend/internal/handlers/profile/profile.go
+++ b/backend/internal/handlers/profile/profile.go
@@ -17,7 +17,8 @@ type Handler struct {
 func (h *Handler) GetProfiles(ctx context.Context, input *GetProfilesInput) (*GetProfilesOutput, error) {
 	profiles, err := h.service.GetAllProfiles()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get profiles", err)
+		slog.Error("Failed to fetch profiles", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load profiles. Please try again.", err)
 	}
 
 	return &GetProfilesOutput{Body: profiles}, nil
@@ -30,7 +31,8 @@ func (h *Handler) UpdatePartialProfile(ctx context.Context, input *UpdateProfile
 	}
 
 	if err := h.service.UpdatePartialProfile(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update profile", err)
+		slog.Error("Failed to update profile", "profileId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update profile. Please try again.", err)
 	}
 
 	resp := &UpdateProfileOutput{}
@@ -45,7 +47,8 @@ func (h *Handler) DeleteProfile(ctx context.Context, input *DeleteProfileInput) 
 	}
 
 	if err := h.service.DeleteProfile(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete profile", err)
+		slog.Error("Failed to delete profile", "profileId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete profile. Please try again.", err)
 	}
 
 	resp := &DeleteProfileOutput{}
@@ -56,7 +59,7 @@ func (h *Handler) DeleteProfile(ctx context.Context, input *DeleteProfileInput) 
 func (h *Handler) GetProfileByEmail(ctx context.Context, input *GetProfileByEmailInput) (*GetProfileByEmailOutput, error) {
 	profile, err := h.service.GetProfileByEmail(input.Email)
 	if err != nil {
-		return nil, huma.Error404NotFound("Profile not found", err)
+		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
 	return &GetProfileByEmailOutput{Body: *profile}, nil
@@ -65,7 +68,7 @@ func (h *Handler) GetProfileByEmail(ctx context.Context, input *GetProfileByEmai
 func (h *Handler) GetProfileByPhone(ctx context.Context, input *GetProfileByPhoneInput) (*GetProfileByPhoneOutput, error) {
 	profile, err := h.service.GetProfileByPhone(input.Phone)
 	if err != nil {
-		return nil, huma.Error404NotFound("Profile not found", err)
+		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
 	return &GetProfileByPhoneOutput{Body: *profile}, nil
@@ -82,7 +85,8 @@ func (h *Handler) SearchProfiles(ctx context.Context, input *SearchProfilesInput
 	}
 
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to search profiles", err)
+		slog.Error("Failed to search profiles", "query", input.Query, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to search profiles. Please try again.", err)
 	}
 
 	return &SearchProfilesOutput{Body: profiles}, nil
@@ -93,7 +97,8 @@ func (h *Handler) SearchProfiles(ctx context.Context, input *SearchProfilesInput
 func (h *Handler) GetProfilesHuma(ctx context.Context, input *GetProfilesInput) (*GetProfilesOutput, error) {
 	profiles, err := h.service.GetAllProfiles()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get profiles", err)
+		slog.Error("Failed to fetch profiles", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load profiles. Please try again.", err)
 	}
 
 	resp := &GetProfilesOutput{Body: profiles}
@@ -108,7 +113,7 @@ func (h *Handler) GetProfileHuma(ctx context.Context, input *GetProfileInput) (*
 
 	profile, err := h.service.GetProfileByID(id)
 	if err != nil {
-		return nil, huma.Error404NotFound("Profile not found", err)
+		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
 	// Try to get authenticated user ID - if not present, continue without relationship check
@@ -148,7 +153,8 @@ func (h *Handler) GetProfileHuma(ctx context.Context, input *GetProfileInput) (*
 	if relationship.Status == RelationshipConnected || relationship.Status == RelationshipSelf {
 		tasks, err := h.service.GetProfileTasks(id)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("Failed to get profile tasks", err)
+			slog.Error("Failed to get profile tasks", "profileId", id.Hex(), "error", err)
+			return nil, huma.Error500InternalServerError("Unable to load profile tasks. Please try again.", err)
 		}
 		profile.Tasks = tasks
 
@@ -175,7 +181,8 @@ func (h *Handler) UpdateProfileHuma(ctx context.Context, input *UpdateProfileInp
 	}
 
 	if err := h.service.UpdatePartialProfile(id, input.Body); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update profile", err)
+		slog.Error("Failed to update profile", "profileId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update profile. Please try again.", err)
 	}
 
 	resp := &UpdateProfileOutput{}
@@ -190,7 +197,8 @@ func (h *Handler) DeleteProfileHuma(ctx context.Context, input *DeleteProfileInp
 	}
 
 	if err := h.service.DeleteProfile(id); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to delete profile", err)
+		slog.Error("Failed to delete profile", "profileId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete profile. Please try again.", err)
 	}
 
 	resp := &DeleteProfileOutput{}
@@ -201,7 +209,7 @@ func (h *Handler) DeleteProfileHuma(ctx context.Context, input *DeleteProfileInp
 func (h *Handler) GetProfileByEmailHuma(ctx context.Context, input *GetProfileByEmailInput) (*GetProfileByEmailOutput, error) {
 	profile, err := h.service.GetProfileByEmail(input.Email)
 	if err != nil {
-		return nil, huma.Error404NotFound("Profile not found", err)
+		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
 	resp := &GetProfileByEmailOutput{Body: *profile}
@@ -211,7 +219,7 @@ func (h *Handler) GetProfileByEmailHuma(ctx context.Context, input *GetProfileBy
 func (h *Handler) GetProfileByPhoneHuma(ctx context.Context, input *GetProfileByPhoneInput) (*GetProfileByPhoneOutput, error) {
 	profile, err := h.service.GetProfileByPhone(input.Phone)
 	if err != nil {
-		return nil, huma.Error404NotFound("Profile not found", err)
+		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
 	resp := &GetProfileByPhoneOutput{Body: *profile}
@@ -234,7 +242,7 @@ func (h *Handler) GetUserCredits(ctx context.Context, input *GetUserCreditsInput
 	credits, err := types.GetCredits(ctx, h.service.Profiles, userObjID)
 	if err != nil {
 		slog.Error("Failed to get user credits", "error", err.Error(), "userID", userID)
-		return nil, huma.Error500InternalServerError("Failed to retrieve credits", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve your credits. Please try again.", err)
 	}
 
 	return &GetUserCreditsOutput{Body: *credits}, nil
@@ -243,7 +251,8 @@ func (h *Handler) GetUserCredits(ctx context.Context, input *GetUserCreditsInput
 func (h *Handler) GetSuggestedUsers(ctx context.Context, input *GetSuggestedUsersInput) (*GetSuggestedUsersOutput, error) {
 	users, err := h.service.GetSuggestedUsers()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get suggested users", err)
+		slog.Error("Failed to get suggested users", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load suggested users. Please try again.", err)
 	}
 
 	return &GetSuggestedUsersOutput{Body: users}, nil
@@ -253,7 +262,7 @@ func (h *Handler) FindUsersByPhoneNumbers(ctx context.Context, input *FindUsersB
 	// Get authenticated user ID
 	userIDStr, err := auth.RequireAuth(ctx)
 	if err != nil {
-		return nil, huma.Error401Unauthorized("Unauthorized", err)
+		return nil, huma.Error401Unauthorized("Authentication required", err)
 	}
 
 	userID, err := primitive.ObjectIDFromHex(userIDStr)
@@ -263,7 +272,8 @@ func (h *Handler) FindUsersByPhoneNumbers(ctx context.Context, input *FindUsersB
 
 	users, err := h.service.FindUsersByPhoneNumbers(input.Body.Numbers, userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to find users by phone numbers", err)
+		slog.Error("Failed to find users by phone numbers", "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to find users by phone numbers. Please try again.", err)
 	}
 
 	return &FindUsersByPhoneNumbersOutput{Body: users}, nil
@@ -290,7 +300,8 @@ func (h *Handler) SearchProfilesHuma(ctx context.Context, input *SearchProfilesI
 	}
 
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to search profiles", err)
+		slog.Error("Failed to search profiles", "query", input.Query, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to search profiles. Please try again.", err)
 	}
 
 	// Add relationship information to each profile
@@ -338,7 +349,8 @@ func (h *Handler) AutocompleteProfilesHuma(ctx context.Context, input *Autocompl
 
 	profiles, err := h.service.AutocompleteProfiles(input.Query)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to autocomplete profiles", err)
+		slog.Error("Failed to autocomplete profiles", "query", input.Query, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to search profiles. Please try again.", err)
 	}
 
 	// Add relationship information to each profile
@@ -379,7 +391,8 @@ func (h *Handler) UpdateTimezone(ctx context.Context, input *UpdateTimezoneInput
 	}
 
 	if err := h.service.UpdateTimezone(authUserID, input.Body.Timezone); err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update timezone", err)
+		slog.Error("Failed to update timezone", "userId", authUserID.Hex(), "timezone", input.Body.Timezone, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update timezone. Please try again.", err)
 	}
 
 	resp := &UpdateTimezoneOutput{}

--- a/backend/internal/handlers/referral/referral.go
+++ b/backend/internal/handlers/referral/referral.go
@@ -3,6 +3,7 @@ package referral
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
@@ -34,7 +35,8 @@ func (h *Handler) GetReferralInfoHuma(ctx context.Context, input *GetReferralInf
 	// GetReferralByUserID auto-creates document if it doesn't exist
 	referral, err := h.service.GetReferralByUserID(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get referral info", err)
+		slog.Error("Failed to get referral info", "error", err, "user_id", userIDStr)
+		return nil, huma.Error500InternalServerError("Unable to get referral info. Please try again.", err)
 	}
 
 	return &GetReferralInfoOutput{Body: *referral}, nil
@@ -66,13 +68,15 @@ func (h *Handler) ApplyReferralCodeHuma(ctx context.Context, input *ApplyReferra
 	// Get referrer info
 	referrer, err := h.service.GetReferralByCode(input.Body.ReferralCode)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get referrer info", err)
+		slog.Error("Failed to get referrer info", "error", err, "referral_code", input.Body.ReferralCode)
+		return nil, huma.Error500InternalServerError("Unable to get referrer info. Please try again.", err)
 	}
 
 	var referrerUser types.User
 	err = h.service.Users.FindOne(context.Background(), bson.M{"_id": referrer.UserID}).Decode(&referrerUser)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get referrer user info", err)
+		slog.Error("Failed to get referrer user info", "error", err, "referrer_user_id", referrer.UserID)
+		return nil, huma.Error500InternalServerError("Unable to get referrer user info. Please try again.", err)
 	}
 
 	return &ApplyReferralCodeOutput{
@@ -119,7 +123,8 @@ func (h *Handler) UnlockFeatureHuma(ctx context.Context, input *UnlockFeatureInp
 	// Get updated referral info
 	referral, err := h.service.GetReferralByUserID(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get updated referral info", err)
+		slog.Error("Failed to get updated referral info", "error", err, "user_id", userIDStr)
+		return nil, huma.Error500InternalServerError("Unable to get updated referral info. Please try again.", err)
 	}
 
 	return &UnlockFeatureOutput{
@@ -150,7 +155,8 @@ func (h *Handler) GetReferralStatsHuma(ctx context.Context, input *GetReferralSt
 	// GetReferralByUserID auto-creates document if it doesn't exist
 	referral, err := h.service.GetReferralByUserID(userID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get referral stats", err)
+		slog.Error("Failed to get referral stats", "error", err, "user_id", userIDStr)
+		return nil, huma.Error500InternalServerError("Unable to get referral stats. Please try again.", err)
 	}
 
 	activeReferrals := 0

--- a/backend/internal/handlers/report/handler.go
+++ b/backend/internal/handlers/report/handler.go
@@ -47,7 +47,7 @@ func (h *Handler) ReportPostHuma(ctx context.Context, input *ReportPostInput) (*
 			return nil, huma.Error409Conflict("You have already reported this content", err)
 		}
 		slog.Error("Failed to report post", "error", err, "user_id", user_id, "post_id", input.PostID)
-		return nil, huma.Error500InternalServerError("Failed to submit report", err)
+		return nil, huma.Error500InternalServerError("Unable to submit report. Please try again.", err)
 	}
 
 	resp := &ReportPostOutput{}
@@ -92,7 +92,7 @@ func (h *Handler) ReportCommentHuma(ctx context.Context, input *ReportCommentInp
 			return nil, huma.Error409Conflict("You have already reported this content", err)
 		}
 		slog.Error("Failed to report comment", "error", err, "user_id", user_id, "comment_id", input.CommentID)
-		return nil, huma.Error500InternalServerError("Failed to submit report", err)
+		return nil, huma.Error500InternalServerError("Unable to submit report. Please try again.", err)
 	}
 
 	resp := &ReportCommentOutput{}
@@ -129,7 +129,7 @@ func (h *Handler) GetReportsHuma(ctx context.Context, input *GetReportsInput) (*
 	reports, total, err := h.service.GetReports(ctx, input.Status, limit, offset)
 	if err != nil {
 		slog.Error("Failed to get reports", "error", err)
-		return nil, huma.Error500InternalServerError("Failed to retrieve reports", err)
+		return nil, huma.Error500InternalServerError("Unable to retrieve reports. Please try again.", err)
 	}
 
 	// Convert to API format

--- a/backend/internal/handlers/rewards/rewards.go
+++ b/backend/internal/handlers/rewards/rewards.go
@@ -16,7 +16,7 @@ func (h *Handler) RedeemRewardHuma(ctx context.Context, input *RedeemRewardInput
 	userID, ok := auth.GetUserIDFromContext(ctx)
 	if !ok {
 		slog.Error("Failed to get user ID from context")
-		return nil, huma.Error401Unauthorized("unauthorized")
+		return nil, huma.Error401Unauthorized("Authentication required")
 	}
 
 	userObjID, err := primitive.ObjectIDFromHex(userID)
@@ -54,7 +54,7 @@ func (h *Handler) RedeemRewardHuma(ctx context.Context, input *RedeemRewardInput
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 
-		return nil, huma.Error500InternalServerError("failed to redeem reward")
+		return nil, huma.Error500InternalServerError("Unable to redeem reward. Please try again.")
 	}
 
 	slog.Info("Reward redeemed successfully", "user_id", userID, "reward_type", rewardType, "kudos_remaining", response.KudosRemaining)

--- a/backend/internal/handlers/settings/settings.go
+++ b/backend/internal/handlers/settings/settings.go
@@ -2,6 +2,7 @@ package settings
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/danielgtaylor/huma/v2"
@@ -22,7 +23,8 @@ func (h *Handler) GetUserSettingsHuma(ctx context.Context, input *GetUserSetting
 
 	settings, err := h.service.GetUserSettings(userObjID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to get settings", err)
+		slog.Error("Failed to fetch user settings", "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load your settings. Please try again.", err)
 	}
 
 	return &GetUserSettingsOutput{Body: *settings}, nil
@@ -42,7 +44,8 @@ func (h *Handler) UpdateUserSettingsHuma(ctx context.Context, input *UpdateUserS
 
 	err = h.service.UpdateUserSettings(userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update settings", err)
+		slog.Error("Failed to update user settings", "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update your settings. Please try again.", err)
 	}
 
 	return &UpdateUserSettingsOutput{

--- a/backend/internal/handlers/spaces/s3bucket.go
+++ b/backend/internal/handlers/spaces/s3bucket.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -40,7 +41,8 @@ func (h *Handler) GetPresignedUrlHuma(ctx context.Context, input *GetPresignedUr
 	// get the name of the bucket
 	bucketName := h.config.DO.SpacesBucket
 	if bucketName == "" {
-		return nil, huma.Error500InternalServerError("SPACES_BUCKET environment variable is not set", fmt.Errorf("bucket name not configured"))
+		slog.Error("SPACES_BUCKET environment variable is not set")
+		return nil, huma.Error500InternalServerError("File upload service is not configured. Please contact support.", fmt.Errorf("bucket name not configured"))
 	}
 
 	object := &GetParams{
@@ -50,7 +52,8 @@ func (h *Handler) GetPresignedUrlHuma(ctx context.Context, input *GetPresignedUr
 
 	url, err := h.service.GetPresignedUrl(object)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to generate presigned URL", err)
+		slog.Error("Unable to generate presigned URL", "key", key, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to generate presigned URL. Please try again.", err)
 	}
 
 	return &GetPresignedUrlOutput{Body: url}, nil
@@ -64,7 +67,8 @@ func (h *Handler) CreatePresignedUrlHuma(ctx context.Context, input *CreatePresi
 
 	bucketName := h.config.DO.SpacesBucket
 	if bucketName == "" {
-		return nil, huma.Error500InternalServerError("SPACES_BUCKET environment variable is not set", fmt.Errorf("bucket name not configured"))
+		slog.Error("SPACES_BUCKET environment variable is not set")
+		return nil, huma.Error500InternalServerError("File upload service is not configured. Please contact support.", fmt.Errorf("bucket name not configured"))
 	}
 
 	object := &PostParams{
@@ -74,7 +78,8 @@ func (h *Handler) CreatePresignedUrlHuma(ctx context.Context, input *CreatePresi
 
 	urlAndKey, err := h.service.CreateUrlAndKey(object)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create presigned URL", err)
+		slog.Error("Unable to create presigned URL", "fileType", fileType, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create presigned URL. Please try again.", err)
 	}
 
 	return &CreatePresignedUrlOutput{Body: urlAndKey}, nil
@@ -92,7 +97,8 @@ func (h *Handler) GenerateImageUploadURL(ctx context.Context, input *GenerateIma
 		bucketName = h.config.DO.SpacesBucket
 	}
 	if bucketName == "" {
-		return nil, huma.Error500InternalServerError("No bucket configured", fmt.Errorf("neither Spaces nor DO Spaces bucket is configured"))
+		slog.Error("No bucket configured for image upload", "resourceType", input.ResourceType, "resourceID", input.ResourceID)
+		return nil, huma.Error500InternalServerError("File upload service is not configured. Please contact support.", fmt.Errorf("neither Spaces nor DO Spaces bucket is configured"))
 	}
 
 	// Get spaces URL for public URL generation
@@ -108,7 +114,8 @@ func (h *Handler) GenerateImageUploadURL(ctx context.Context, input *GenerateIma
 	// Generate presigned URL
 	result, err := h.service.GenerateImageUploadURL(ctx, params, bucketName, spacesURL)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to generate upload URL", err)
+		slog.Error("Unable to generate upload URL", "resourceType", input.ResourceType, "resourceID", input.ResourceID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to generate upload URL. Please try again.", err)
 	}
 
 	resp := &GenerateImageUploadURLOutput{}
@@ -132,7 +139,8 @@ func (h *Handler) ConfirmImageUpload(ctx context.Context, input *ConfirmImageUpl
 		// Update profile picture in database
 		err = h.updateProfilePicture(objectID, input.Body.PublicURL)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("Failed to update profile picture", err)
+			slog.Error("Unable to update profile picture during image upload confirmation", "userID", input.ResourceID, "error", err)
+			return nil, huma.Error500InternalServerError("Unable to update profile picture. Please try again.", err)
 		}
 
 	case "blueprint":
@@ -171,13 +179,15 @@ func (h *Handler) ProcessAndUploadImage(ctx context.Context, input *ProcessAndUp
 	// Process the image
 	processedImage, err := h.processor.ProcessImage(ctx, imageData, variant)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to process image", err)
+		slog.Error("Unable to process image", "resourceType", input.ResourceType, "resourceID", input.ResourceID, "variant", variant, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to process image. Please try again.", err)
 	}
 
 	// Get bucket configuration
 	bucketName := h.config.DO.SpacesBucket
 	if bucketName == "" {
-		return nil, huma.Error500InternalServerError("Spaces bucket not configured", fmt.Errorf("bucket name not configured"))
+		slog.Error("Spaces bucket not configured for image processing", "resourceType", input.ResourceType, "resourceID", input.ResourceID)
+		return nil, huma.Error500InternalServerError("File upload service is not configured. Please contact support.", fmt.Errorf("bucket name not configured"))
 	}
 
 	// Generate key for the processed image
@@ -194,7 +204,8 @@ func (h *Handler) ProcessAndUploadImage(ctx context.Context, input *ProcessAndUp
 	})
 
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to upload processed image", err)
+		slog.Error("Unable to upload processed image", "key", key, "bucket", bucketName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to upload processed image. Please try again.", err)
 	}
 
 	// Generate URLs using auto-CDN logic
@@ -225,7 +236,8 @@ func (h *Handler) ProcessAndUploadImage(ctx context.Context, input *ProcessAndUp
 		}
 		err = h.updateProfilePicture(objectID, publicURL)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("Failed to update profile picture", err)
+			slog.Error("Unable to update profile picture after image processing", "userID", input.ResourceID, "error", err)
+			return nil, huma.Error500InternalServerError("Unable to update profile picture. Please try again.", err)
 		}
 	case "blueprint":
 		// For blueprints, no immediate database update needed

--- a/backend/internal/handlers/subscription/handler.go
+++ b/backend/internal/handlers/subscription/handler.go
@@ -118,7 +118,7 @@ func (h *Handler) HandleWebhook(ctx context.Context, input *WebhookEvent) (*Subs
 
 	if err != nil {
 		slog.Error("Error handling webhook event", "type", event.Type, "error", err)
-		return nil, huma.Error500InternalServerError(fmt.Sprintf("Failed to handle event: %v", err))
+		return nil, huma.Error500InternalServerError(fmt.Sprintf("Unable to handle event. Please try again. (%s)", event.Type))
 	}
 
 	return webhookOK(), nil

--- a/backend/internal/handlers/task/nlp_handlers.go
+++ b/backend/internal/handlers/task/nlp_handlers.go
@@ -37,7 +37,7 @@ func (h *Handler) QueryTasksNaturalLanguage(ctx context.Context, input *QueryTas
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
 			slog.String("userID", userID),
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		return nil, huma.Error500InternalServerError("Unable to process your credit. Please try again later.", err)
 	}
 
 	timezone := input.Body.Timezone
@@ -76,13 +76,15 @@ func (h *Handler) QueryTasksNaturalLanguage(ctx context.Context, input *QueryTas
 	// Convert AI output to TaskQueryFilters
 	filters, err := convertQueryOutput(queryOutput)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to parse AI query response", err)
+		slog.Error("Failed to parse AI query response", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("The AI response could not be interpreted. Please try rephrasing your query.", err)
 	}
 
 	// Execute query
 	tasks, err := h.service.QueryTasksByUser(userObjID, filters)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to query tasks. Please try again.", err)
+		slog.Error("Failed to execute natural language task query", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to query tasks due to a server error. Please try again.", err)
 	}
 
 	output := &QueryTasksNaturalLanguageOutput{}
@@ -118,7 +120,7 @@ func (h *Handler) CreateTaskNaturalLanguage(ctx context.Context, input *CreateTa
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
 			slog.String("userID", userID),
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		return nil, huma.Error500InternalServerError("Unable to process your credit. Please try again later.", err)
 	}
 
 	// Default to EST if no timezone provided
@@ -242,7 +244,7 @@ func (h *Handler) EditTasksNaturalLanguage(ctx context.Context, input *EditTasks
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
 			slog.String("userID", userID),
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		return nil, huma.Error500InternalServerError("Unable to process your credit. Please try again later.", err)
 	}
 
 	timezone := input.Body.Timezone
@@ -681,7 +683,7 @@ func (h *Handler) IntentTaskNaturalLanguage(ctx context.Context, input *IntentTa
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
 			slog.String("userID", userID),
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		return nil, huma.Error500InternalServerError("Unable to process your credit. Please try again later.", err)
 	}
 
 	timezone := input.Body.Timezone
@@ -800,7 +802,8 @@ func (h *Handler) PreviewTaskNaturalLanguage(ctx context.Context, input *Preview
 	// Check credits without consuming
 	hasCredit, err := h.service.Users.CheckCredits(ctx, userObjID, types.CreditTypeNaturalLanguage)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to check credits", err)
+		slog.Error("Failed to check user credits", "userId", userID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to verify your credit balance. Please try again later.", err)
 	}
 	if !hasCredit {
 		return nil, huma.Error403Forbidden("Insufficient credits. You need at least 1 natural language credit to use this feature.", types.ErrInsufficientCredits)
@@ -864,7 +867,7 @@ func (h *Handler) ConfirmTaskNaturalLanguage(ctx context.Context, input *Confirm
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
 			slog.String("userID", userID),
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to process credit", err)
+		return nil, huma.Error500InternalServerError("Unable to process your credit. Please try again later.", err)
 	}
 
 	// Process new categories with their tasks

--- a/backend/internal/handlers/task/query_handlers.go
+++ b/backend/internal/handlers/task/query_handlers.go
@@ -24,7 +24,8 @@ func (h *Handler) QueryTasksByUser(ctx context.Context, input *QueryTasksByUserI
 
 	tasks, err := h.service.QueryTasksByUser(user_id_obj, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to query tasks. Please try again.", err)
+		slog.Error("Failed to query tasks", "userId", user_id_obj.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to query tasks due to a server error. Please try again.", err)
 	}
 
 	return &QueryTasksByUserOutput{Body: tasks}, nil
@@ -56,7 +57,8 @@ func (h *Handler) GetCompletedTasks(ctx context.Context, input *GetCompletedTask
 
 	tasks, totalCount, err := h.service.GetCompletedTasks(userObjID, page, limit)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch completed tasks", err)
+		slog.Error("Failed to fetch completed tasks", "userId", userObjID.Hex(), "page", page, "limit", limit, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load completed tasks. Please try again.", err)
 	}
 
 	// Calculate total pages
@@ -110,7 +112,7 @@ func (h *Handler) GetCompletedTasksByDate(ctx context.Context, input *GetComplet
 	if err != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "GetCompletedTasksByDate: service error",
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to fetch completed tasks", err)
+		return nil, huma.Error500InternalServerError("Unable to load completed tasks for the specified date. Please try again.", err)
 	}
 
 	slog.LogAttrs(ctx, slog.LevelInfo, "GetCompletedTasksByDate: returning tasks",

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -3,6 +3,7 @@ package task
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"time"
 
@@ -67,7 +68,8 @@ func (h *Handler) GetTasksByUser(ctx context.Context, input *GetTasksByUserInput
 
 	tasks, err := h.service.GetTasksByUser(user_id_obj, sortDocument)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to load tasks. Please try again.", err)
+		slog.Error("Failed to fetch tasks for user", "userId", user_id_obj.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load your tasks due to a server error. Please try again later.", err)
 	}
 
 	return &GetTasksByUserOutput{Body: tasks}, nil
@@ -195,13 +197,15 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 			taskParams.Checklist,
 		)
 		if err != nil {
-			return nil, huma.Error500InternalServerError("Unable to create recurring task. Please try again.", err)
+			slog.Error("Failed to create recurring task template", "userId", userObjID.Hex(), "categoryId", categoryID.Hex(), "error", err)
+			return nil, huma.Error500InternalServerError("Unable to create recurring task template. Please try again.", err)
 		}
 	}
 
 	doc, err := h.service.CreateTask(categoryID, &task)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to create task. Please try again.", err)
+		slog.Error("Failed to create task", "userId", userObjID.Hex(), "categoryId", categoryID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create task due to a database error. Please try again.", err)
 	}
 
 	return &CreateTaskOutput{Body: *doc}, nil
@@ -210,7 +214,8 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 func (h *Handler) GetTasks(ctx context.Context, input *GetTasksInput) (*GetTasksOutput, error) {
 	tasks, err := h.service.GetAllTasks()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to load tasks. Please try again.", err)
+		slog.Error("Failed to fetch all tasks", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load tasks due to a server error. Please try again later.", err)
 	}
 
 	return &GetTasksOutput{Body: tasks}, nil
@@ -329,6 +334,7 @@ func (h *Handler) UpdateTask(ctx context.Context, input *UpdateTaskInput) (*Upda
 			updateData.Checklist,
 		)
 		if err != nil {
+			slog.Error("Failed to create recurring template during task update", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
 			return nil, huma.Error500InternalServerError("Unable to create recurring template. Please try again.", err)
 		}
 
@@ -356,7 +362,8 @@ func (h *Handler) UpdateTask(ctx context.Context, input *UpdateTaskInput) (*Upda
 	// Use the UpdatePartialTask service method which matches the available service signature
 	_, err = h.service.UpdatePartialTask(id, categoryID, updateData)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to update task. Please try again.", err)
+		slog.Error("Failed to update task", "taskId", id.Hex(), "categoryId", categoryID.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task due to a database error. Please try again.", err)
 	}
 
 	resp := &UpdateTaskOutput{}
@@ -394,7 +401,8 @@ func (h *Handler) CompleteTask(ctx context.Context, input *CompleteTaskInput) (*
 	// Use the CompleteTask service method and get streak info
 	result, err := h.service.CompleteTask(userObjID, id, categoryID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to complete task. Please try again.", err)
+		slog.Error("Failed to complete task", "taskId", id.Hex(), "categoryId", categoryID.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to complete task due to a server error. Please try again.", err)
 	}
 
 	// Delete the task from the tasks collection
@@ -403,7 +411,8 @@ func (h *Handler) CompleteTask(ctx context.Context, input *CompleteTaskInput) (*
 		Category: input.Category,
 	})
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to delete task. Please try again.", err)
+		slog.Error("Failed to delete task after completion", "taskId", id.Hex(), "categoryId", categoryID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Task was completed but could not be removed. Please try again.", err)
 	}
 
 	resp := &CompleteTaskOutput{}
@@ -462,7 +471,8 @@ func (h *Handler) DeleteTask(ctx context.Context, input *DeleteTaskInput) (*Dele
 	// Delete the task
 	err = h.service.DeleteTask(categoryID, id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to delete task. Please try again.", err)
+		slog.Error("Failed to delete task", "taskId", id.Hex(), "categoryId", categoryID.Hex(), "userId", userID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete task due to a database error. Please try again.", err)
 	}
 
 	// If requested and template exists, delete the recurring template as well
@@ -470,7 +480,7 @@ func (h *Handler) DeleteTask(ctx context.Context, input *DeleteTaskInput) (*Dele
 		err = h.service.DeleteTemplateTask(*templateID)
 		if err != nil {
 			// Log the error but don't fail the entire operation since the task was already deleted
-			fmt.Printf("Warning: Failed to delete template task %s: %v\n", templateID.Hex(), err)
+			slog.Error("Failed to delete template task after task deletion", "templateId", templateID.Hex(), "error", err)
 		}
 	}
 
@@ -510,7 +520,8 @@ func (h *Handler) BulkCompleteTask(ctx context.Context, input *BulkCompleteTaskI
 	// Call the bulk complete service method
 	result, err := h.service.BulkCompleteTask(userObjID, input.Body.Tasks)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to complete tasks. Please try again.", err)
+		slog.Error("Failed to bulk complete tasks", "userId", userObjID.Hex(), "taskCount", len(input.Body.Tasks), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to complete tasks due to a server error. Please try again.", err)
 	}
 
 	return result, nil
@@ -540,7 +551,8 @@ func (h *Handler) BulkDeleteTask(ctx context.Context, input *BulkDeleteTaskInput
 	// Call the bulk delete service method
 	result, err := h.service.BulkDeleteTask(userObjID, input.Body.Tasks)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to delete tasks. Please try again.", err)
+		slog.Error("Failed to bulk delete tasks", "userId", userObjID.Hex(), "taskCount", len(input.Body.Tasks), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete tasks due to a server error. Please try again.", err)
 	}
 
 	return result, nil
@@ -575,7 +587,8 @@ func (h *Handler) ActivateTask(ctx context.Context, input *ActivateTaskInput) (*
 
 	err = h.service.ActivateTask(userObjID, categoryID, id, active)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task activation status", err)
+		slog.Error("Failed to update task activation status", "taskId", id.Hex(), "userId", userObjID.Hex(), "active", active, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task activation status. Please try again.", err)
 	}
 
 	resp := &ActivateTaskOutput{}
@@ -591,7 +604,8 @@ func (h *Handler) GetActiveTasks(ctx context.Context, input *GetActiveTasksInput
 
 	tasks, err := h.service.GetActiveTasks(id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch active tasks", err)
+		slog.Error("Failed to fetch active tasks", "userId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load active tasks. Please try again.", err)
 	}
 
 	return &GetActiveTasksOutput{Body: tasks}, nil
@@ -622,7 +636,8 @@ func (h *Handler) UpdateTaskNotes(ctx context.Context, input *UpdateTaskNotesInp
 
 	err = h.service.UpdateTaskNotes(id, categoryID, userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task notes", err)
+		slog.Error("Failed to update task notes", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task notes. Please try again.", err)
 	}
 
 	resp := &UpdateTaskNotesOutput{}
@@ -655,7 +670,8 @@ func (h *Handler) UpdateTaskChecklist(ctx context.Context, input *UpdateTaskChec
 
 	err = h.service.UpdateTaskChecklist(id, categoryID, userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task checklist", err)
+		slog.Error("Failed to update task checklist", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task checklist. Please try again.", err)
 	}
 
 	resp := &UpdateTaskChecklistOutput{}
@@ -688,7 +704,8 @@ func (h *Handler) UpdateTaskDeadline(ctx context.Context, input *UpdateTaskDeadl
 
 	err = h.service.UpdateTaskDeadline(id, categoryID, userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task deadline", err)
+		slog.Error("Failed to update task deadline", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task deadline. Please try again.", err)
 	}
 
 	resp := &UpdateTaskDeadlineOutput{}
@@ -721,7 +738,8 @@ func (h *Handler) UpdateTaskStart(ctx context.Context, input *UpdateTaskStartInp
 
 	err = h.service.UpdateTaskStart(id, categoryID, userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task start date/time", err)
+		slog.Error("Failed to update task start date/time", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task start date/time. Please try again.", err)
 	}
 
 	resp := &UpdateTaskStartOutput{}
@@ -754,7 +772,8 @@ func (h *Handler) UpdateTaskReminders(ctx context.Context, input *UpdateTaskRemi
 
 	err = h.service.UpdateTaskReminders(id, categoryID, userObjID, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update task reminders", err)
+		slog.Error("Failed to update task reminders", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update task reminders. Please try again.", err)
 	}
 
 	resp := &UpdateTaskReminderOutput{}

--- a/backend/internal/handlers/task/template_handlers.go
+++ b/backend/internal/handlers/task/template_handlers.go
@@ -23,7 +23,8 @@ func (h *Handler) CreateTaskFromTemplate(ctx context.Context, input *CreateTaskF
 
 	doc, err := h.service.CreateTaskFromTemplate(templateID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to create task from template", err)
+		slog.Error("Failed to create task from template", "templateId", templateID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to create task from template. The template may be invalid or unavailable.", err)
 	}
 
 	return &CreateTaskFromTemplateOutput{Body: *doc}, nil
@@ -46,7 +47,8 @@ func (h *Handler) GetTasksWithStartTimesOlderThanOneDay(ctx context.Context, inp
 
 	tasks, err := h.service.GetTasksWithStartTimesOlderThanOneDay(userObjID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to load tasks. Please try again.", err)
+		slog.Error("Failed to fetch overdue tasks", "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load overdue tasks. Please try again.", err)
 	}
 
 	return &GetTasksWithStartTimesOlderThanOneDayOutput{Body: tasks}, nil
@@ -66,7 +68,8 @@ func (h *Handler) GetRecurringTasksWithPastDeadlines(ctx context.Context, input 
 
 	tasks, err := h.service.GetRecurringTasksWithPastDeadlines(userObjID)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch recurring tasks", err)
+		slog.Error("Failed to fetch recurring tasks with past deadlines", "userId", userObjID.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load recurring tasks with past deadlines. Please try again.", err)
 	}
 
 	return &GetRecurringTasksWithPastDeadlinesOutput{Body: tasks}, nil
@@ -80,7 +83,8 @@ func (h *Handler) GetTemplateByID(ctx context.Context, input *GetTemplateByIDInp
 
 	template, err := h.service.GetTemplateByID(id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch template", err)
+		slog.Error("Failed to fetch template", "templateId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load template. It may have been deleted.", err)
 	}
 
 	return &GetTemplateByIDOutput{Body: *template}, nil
@@ -100,7 +104,8 @@ func (h *Handler) UpdateTemplate(ctx context.Context, input *UpdateTemplateInput
 
 	err = h.service.UpdateTemplateTask(id, input.Body)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to update template task", err)
+		slog.Error("Failed to update template task", "templateId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update template. Please try again.", err)
 	}
 
 	resp := &UpdateTemplateOutput{}
@@ -121,7 +126,8 @@ func (h *Handler) ResetTemplateMetrics(ctx context.Context, input *ResetTemplate
 
 	err = h.service.ResetTemplateMetrics(id)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to reset template metrics", err)
+		slog.Error("Failed to reset template metrics", "templateId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to reset template metrics. Please try again.", err)
 	}
 
 	resp := &ResetTemplateMetricsOutput{}
@@ -148,7 +154,8 @@ func (h *Handler) UndoMissedTask(ctx context.Context, input *UndoMissedTaskInput
 		if err.Error() == "no recent miss to undo" {
 			return nil, huma.Error409Conflict("No recent miss to undo for this template", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to undo missed task", err)
+		slog.Error("Failed to undo missed task", "templateId", id.Hex(), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to undo missed task. Please try again.", err)
 	}
 
 	resp := &UndoMissedTaskOutput{}
@@ -176,7 +183,7 @@ func (h *Handler) GetUserTemplates(ctx context.Context, input *GetUserTemplatesI
 	if err != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to fetch templates",
 			slog.String("error", err.Error()))
-		return nil, huma.Error500InternalServerError("Failed to fetch templates", err)
+		return nil, huma.Error500InternalServerError("Unable to load your templates. Please try again.", err)
 	}
 
 	slog.LogAttrs(ctx, slog.LevelInfo, "GetUserTemplates handler returning",

--- a/backend/internal/handlers/waitlist/waitlist.go
+++ b/backend/internal/handlers/waitlist/waitlist.go
@@ -51,7 +51,7 @@ func (h *Handler) CreateWaitlistHuma(ctx context.Context, input *CreateWaitlistI
 			return nil, huma.Error409Conflict("Duplicate email", fmt.Errorf("email %s already exists in waitlist", internalDoc.Email))
 		}
 
-		return nil, huma.Error500InternalServerError("Failed to create waitlist entry", err)
+		return nil, huma.Error500InternalServerError("Unable to create waitlist entry. Please try again.", err)
 	}
 
 	err = twillio.SendWaitlistEmail(internalDoc.Email, internalDoc.Name)
@@ -78,7 +78,8 @@ func (h *Handler) GetWaitlistsHuma(ctx context.Context, input *GetWaitlistsInput
 
 	waitlists, err := h.service.GetAllWaitlists()
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Failed to fetch waitlists", err)
+		slog.Error("Unable to fetch waitlists", "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch waitlists. Please try again.", err)
 	}
 
 	return &GetWaitlistsOutput{Body: waitlists}, nil
@@ -101,7 +102,8 @@ func (h *Handler) GetWaitlistHuma(ctx context.Context, input *GetWaitlistInput) 
 		if strings.Contains(err.Error(), "no documents") {
 			return nil, huma.Error404NotFound("Waitlist entry not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to fetch waitlist entry", err)
+		slog.Error("Unable to fetch waitlist entry", "id", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to fetch waitlist entry. Please try again.", err)
 	}
 
 	return &GetWaitlistOutput{Body: *waitlist}, nil
@@ -123,7 +125,8 @@ func (h *Handler) DeleteWaitlistHuma(ctx context.Context, input *DeleteWaitlistI
 		if strings.Contains(err.Error(), "no documents") {
 			return nil, huma.Error404NotFound("Waitlist entry not found", err)
 		}
-		return nil, huma.Error500InternalServerError("Failed to delete waitlist entry", err)
+		slog.Error("Unable to delete waitlist entry", "id", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to delete waitlist entry. Please try again.", err)
 	}
 
 	resp := &DeleteWaitlistOutput{}


### PR DESCRIPTION
## Summary
- Audited all 27 backend handler files across every feature module (auth, task, group, connection, profile, notifications, post, blueprint, calendar, category, congratulation, encouragement, referral, report, rewards, settings, spaces, subscription, waitlist)
- Added `slog.Error()` calls with structured context (userId, resourceId, etc.) before every `Error500InternalServerError` return — previously most 500s had no server-side logging
- Replaced all generic/vague user-facing error messages (`"Internal server error"`, `"Failed to X"`, `"Validation failed"`, bare `"Unauthorized"`) with descriptive, actionable messages
- Fixed incorrect HTTP status code: `"Invalid blueprint id"` was returning 500 instead of 400

## Test plan
- [x] `go build ./...` passes
- [x] All pre-commit hooks pass (go vet, go fmt, unit tests)
- [ ] Verify error messages render correctly on the frontend for common failure scenarios (login, task CRUD, connection requests)
- [ ] Confirm Sentry receives structured error logs with the new context fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)