### PR TITLE
feat: task visibility overhaul + follow-up notifications

### DIFF
--- a/backend/internal/handlers/task/checkin.go
+++ b/backend/internal/handlers/task/checkin.go
@@ -33,6 +33,14 @@ var CheckinTimes = []CheckinInfo{
 	},
 }
 
+// openTaskCheckinMessage returns a check-in message that includes open task count when applicable
+func openTaskCheckinMessage(displayName string, openTaskCount int, baseMessage string) string {
+	if openTaskCount > 0 {
+		return fmt.Sprintf("Hey %s, you have %d open tasks from today \u2014 tap to review!", displayName, openTaskCount)
+	}
+	return fmt.Sprintf(baseMessage, displayName)
+}
+
 func (h *Handler) HandleCheckin() (fiber.Map, error) {
 	// Get current time in UTC
 	nowUTC := time.Now().UTC()
@@ -139,8 +147,15 @@ func (h *Handler) HandleCheckin() (fiber.Map, error) {
 			taskCounts = &TaskCounts{ScheduledToday: 0, DeadlineToday: 0}
 		}
 
-		// Personalize the message with the user's display name
-		personalizedMessage := fmt.Sprintf(matchedCheckin.Message, user.DisplayName)
+		// Get open task count for this user
+		openTaskCount, openErr := h.service.GetOpenTaskCountForUser(user.ID, loc)
+		if openErr != nil {
+			slog.Error("Error getting open task count for user", "user_id", user.ID, "error", openErr)
+			openTaskCount = 0
+		}
+
+		// Personalize the message — include open task count when available
+		personalizedMessage := openTaskCheckinMessage(user.DisplayName, openTaskCount, matchedCheckin.Message)
 
 		notifications = append(notifications, xutils.Notification{
 			Token:   user.PushToken,
@@ -152,6 +167,7 @@ func (h *Handler) HandleCheckin() (fiber.Map, error) {
 				"timestamp":       userLocalTime.Format(time.RFC3339),
 				"scheduled_today": fmt.Sprintf("%d", taskCounts.ScheduledToday),
 				"deadline_today":  fmt.Sprintf("%d", taskCounts.DeadlineToday),
+				"open_tasks":      fmt.Sprintf("%d", openTaskCount),
 				"url":             "/(logged-in)/(tabs)/(task)/review",
 			},
 		})
@@ -271,6 +287,45 @@ func (s *Service) GetUserTaskCountsForTodayWithTimezone(userID primitive.ObjectI
 // This uses UTC for backward compatibility
 func (s *Service) GetUserTaskCountsForToday(userID primitive.ObjectID) (*TaskCounts, error) {
 	return s.GetUserTaskCountsForTodayWithTimezone(userID, time.UTC)
+}
+
+// GetOpenTaskCountForUser returns the count of tasks where startDate <= today and have no deadline
+func (s *Service) GetOpenTaskCountForUser(userID primitive.ObjectID, loc *time.Location) (int, error) {
+	ctx := context.Background()
+
+	now := time.Now().In(loc)
+	endOfDay := time.Date(now.Year(), now.Month(), now.Day(), 23, 59, 59, 999999999, loc).UTC()
+
+	pipeline := []bson.M{
+		{"$match": bson.M{"user": userID}},
+		{"$unwind": "$tasks"},
+		{"$match": bson.M{
+			"tasks.startDate": bson.M{
+				"$ne":  nil,
+				"$lte": endOfDay,
+			},
+			"tasks.deadline":  nil,
+			"tasks.startTime": nil,
+		}},
+		{"$count": "total"},
+	}
+
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return 0, fmt.Errorf("failed to count open tasks: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var result struct {
+		Total int `bson:"total"`
+	}
+	if cursor.Next(ctx) {
+		if err := cursor.Decode(&result); err != nil {
+			return 0, fmt.Errorf("failed to decode open task count: %w", err)
+		}
+	}
+
+	return result.Total, nil
 }
 
 // GetUsersWithPushTokens retrieves all users that have push tokens for notifications

--- a/backend/internal/handlers/task/reminder.go
+++ b/backend/internal/handlers/task/reminder.go
@@ -15,6 +15,9 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+const FollowUpReminderType = "FOLLOW_UP"
+const FollowUpDelay = 3 * time.Hour
+
 func (h *Handler) HandleReminder() (fiber.Map, error) {
 	tasks, err := h.service.GetTasksWithPastReminders()
 	if err != nil {
@@ -142,6 +145,31 @@ func ParseReminder(params CreateTaskParams) []*Reminder {
 	return reminders
 }
 
+// BuildFollowUpReminder creates a FOLLOW_UP reminder for a task based on its timing.
+// Returns nil if the task doesn't qualify (no deadline, no startTime, or trigger time already stale).
+func BuildFollowUpReminder(deadline *time.Time, startTime *time.Time) *Reminder {
+	var triggerTime time.Time
+
+	if deadline != nil {
+		triggerTime = deadline.Add(FollowUpDelay)
+	} else if startTime != nil {
+		triggerTime = startTime.Add(FollowUpDelay)
+	} else {
+		return nil
+	}
+
+	// Don't create follow-up if trigger time is already in the past
+	if triggerTime.Before(xutils.NowUTC()) {
+		return nil
+	}
+
+	return &Reminder{
+		TriggerTime: triggerTime,
+		Type:        FollowUpReminderType,
+		Sent:        false,
+	}
+}
+
 func (s *Service) GetTasksWithPastReminders() ([]TaskDocument, error) {
 	ctx := context.Background()
 
@@ -185,12 +213,19 @@ func (s *Service) SendReminder(userID primitive.ObjectID, reminder *Reminder, ta
 	// Generate descriptive reminder message
 	message := s.generateReminderMessage(reminder, task)
 
+	title := ""
+	if reminder.Type == FollowUpReminderType {
+		title = fmt.Sprintf("How was %s?", task.Content)
+	}
+
 	// send the reminder to the user
 	return xutils.SendNotification(xutils.Notification{
 		Token:   user.PushToken,
 		Message: message,
+		Title:   title,
 		Data: map[string]string{
 			"taskId": task.ID.Hex(),
+			"type":   reminder.Type,
 		},
 	})
 }
@@ -200,6 +235,11 @@ func (s *Service) generateReminderMessage(reminder *Reminder, task *TaskDocument
 	now := time.Now()
 	taskName := task.Content
 	hasWindow := task.Deadline != nil && (task.StartDate != nil || task.StartTime != nil)
+
+	// Follow-up reminders use specific copy
+	if reminder.Type == FollowUpReminderType {
+		return "Swipe to document this task as complete"
+	}
 
 	// Use custom message if provided
 	if reminder.CustomMessage != nil && *reminder.CustomMessage != "" {

--- a/backend/internal/handlers/task/service_test.go
+++ b/backend/internal/handlers/task/service_test.go
@@ -1287,3 +1287,52 @@ func (s *TaskServiceTestSuite) TestCreateTaskFromTemplate_Flex_PeriodRollover_Tr
 	s.Equal(2, updatedTemplate.TimesMissed, "Should have 2 missed tasks from previous period")
 	s.Equal(0, updatedTemplate.Streak, "Streak should be reset due to missed tasks")
 }
+
+// ========================================
+// BuildFollowUpReminder Tests
+// ========================================
+
+func (s *TaskServiceTestSuite) TestBuildFollowUpReminder_WithDeadline() {
+	deadline := xutils.NowUTC().Add(2 * time.Hour)
+	reminder := BuildFollowUpReminder(&deadline, nil)
+
+	s.NotNil(reminder)
+	s.Equal(FollowUpReminderType, reminder.Type)
+	s.False(reminder.Sent)
+	// Trigger time should be deadline + 3 hours
+	expectedTrigger := deadline.Add(3 * time.Hour)
+	s.WithinDuration(expectedTrigger, reminder.TriggerTime, time.Second)
+}
+
+func (s *TaskServiceTestSuite) TestBuildFollowUpReminder_WithStartTime() {
+	startTime := xutils.NowUTC().Add(1 * time.Hour)
+	reminder := BuildFollowUpReminder(nil, &startTime)
+
+	s.NotNil(reminder)
+	s.Equal(FollowUpReminderType, reminder.Type)
+	expectedTrigger := startTime.Add(3 * time.Hour)
+	s.WithinDuration(expectedTrigger, reminder.TriggerTime, time.Second)
+}
+
+func (s *TaskServiceTestSuite) TestBuildFollowUpReminder_DeadlineTakesPriority() {
+	deadline := xutils.NowUTC().Add(5 * time.Hour)
+	startTime := xutils.NowUTC().Add(1 * time.Hour)
+	reminder := BuildFollowUpReminder(&deadline, &startTime)
+
+	s.NotNil(reminder)
+	// Should use deadline, not startTime
+	expectedTrigger := deadline.Add(3 * time.Hour)
+	s.WithinDuration(expectedTrigger, reminder.TriggerTime, time.Second)
+}
+
+func (s *TaskServiceTestSuite) TestBuildFollowUpReminder_NilWhenNoTimes() {
+	reminder := BuildFollowUpReminder(nil, nil)
+	s.Nil(reminder)
+}
+
+func (s *TaskServiceTestSuite) TestBuildFollowUpReminder_NilWhenStale() {
+	// Trigger time would be in the past
+	pastDeadline := xutils.NowUTC().Add(-4 * time.Hour)
+	reminder := BuildFollowUpReminder(&pastDeadline, nil)
+	s.Nil(reminder)
+}

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -129,6 +129,12 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 		LastEdited:     time.Now(),
 	}
 
+	// Auto-inject a FOLLOW_UP reminder if the task has a deadline or startTime
+	followUp := BuildFollowUpReminder(task.Deadline, task.StartTime)
+	if followUp != nil {
+		task.Reminders = append(task.Reminders, followUp)
+	}
+
 	// Frontend now sends a pre-combined startDate (date + time in local timezone),
 	// so we only need to handle the fallback when startDate is nil.
 	if task.StartDate == nil {

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
@@ -1184,8 +1185,12 @@ func (s *Service) UpdateTaskDeadline(id primitive.ObjectID, categoryID primitive
 		bson.M{"$set": updateFields},
 		getTaskArrayFilterOptions(id),
 	)
+	if err != nil {
+		return handleMongoError(ctx, "update task deadline", err)
+	}
 
-	return handleMongoError(ctx, "update task deadline", err)
+	// Recalculate FOLLOW_UP reminder
+	return s.recalculateFollowUp(ctx, id, categoryID, update.Deadline)
 }
 
 // UpdateTaskStart updates the start date and time fields of a task
@@ -1240,4 +1245,34 @@ func (s *Service) UpdateTaskReminders(id primitive.ObjectID, categoryID primitiv
 	)
 
 	return handleMongoError(ctx, "update task reminders", err)
+}
+
+// recalculateFollowUp removes any existing FOLLOW_UP reminder and injects a new one based on the new deadline.
+func (s *Service) recalculateFollowUp(ctx context.Context, taskID primitive.ObjectID, categoryID primitive.ObjectID, deadline *time.Time) error {
+	// Remove existing FOLLOW_UP reminders
+	_, err := s.Tasks.UpdateOne(
+		ctx,
+		bson.M{"_id": categoryID},
+		bson.M{"$pull": bson.M{"tasks.$[t].reminders": bson.M{"type": FollowUpReminderType}}},
+		getTaskArrayFilterOptions(taskID),
+	)
+	if err != nil {
+		return handleMongoError(ctx, "remove old follow-up reminder", err)
+	}
+
+	// Build and inject new follow-up based on the new deadline
+	followUp := BuildFollowUpReminder(deadline, nil)
+	if followUp != nil {
+		_, err = s.Tasks.UpdateOne(
+			ctx,
+			bson.M{"_id": categoryID},
+			bson.M{"$push": bson.M{"tasks.$[t].reminders": followUp}},
+			getTaskArrayFilterOptions(taskID),
+		)
+		if err != nil {
+			return handleMongoError(ctx, "inject new follow-up reminder", err)
+		}
+	}
+
+	return nil
 }

--- a/backend/internal/handlers/task/util.go
+++ b/backend/internal/handlers/task/util.go
@@ -389,6 +389,12 @@ func constructTaskFromTemplate(templateDoc *TemplateTaskDocument) TaskDocument {
 		}
 	}
 
+	// Auto-inject a FOLLOW_UP reminder for the generated task instance
+	followUp := BuildFollowUpReminder(task.Deadline, task.StartTime)
+	if followUp != nil {
+		task.Reminders = append(task.Reminders, followUp)
+	}
+
 	return task
 }
 

--- a/frontend/app/(logged-in)/(tabs)/(task)/daily.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/daily.tsx
@@ -89,7 +89,7 @@ const Daily = (props: Props) => {
         tasksUnscheduled,
         listUnscheduledTasks,
         upcomingTasks,
-        pastTasks,
+        openTasks,
         overdueTasks,
     } = useDailyTasks(selectedDate);
 
@@ -206,7 +206,7 @@ const Daily = (props: Props) => {
                             tasksForSelectedDate={tasksForSelectedDate}
                             overdueTasks={overdueTasks}
                             upcomingTasks={upcomingTasks}
-                            pastTasks={pastTasks}
+                            openTasks={openTasks}
                             unscheduledTasks={listUnscheduledTasks}
                             onQuickSchedule={handleQuickSchedule}
                         />

--- a/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
@@ -29,6 +29,7 @@ import { usePathname } from "expo-router";
 import PrimaryButton from "@/components/inputs/PrimaryButton";
 import InlineCategoryCreator from "@/components/InlineCategoryCreator";
 import { UpcomingCategory } from "@/components/UpcomingCategory";
+import { OpenTasksCategory } from "@/components/OpenTasksCategory";
 import { FunnelSimple, SortAscending, CalendarBlank } from "phosphor-react-native";
 import * as PhosphorIcons from "phosphor-react-native";
 
@@ -459,6 +460,19 @@ const WorkspaceContent = ({
                                     const visible = [...categories]
                                         .filter((c) => c.name !== "!-proxy-!" && !c.id.startsWith("upcoming-"))
                                         .sort((a, b) => b.tasks.length - a.tasks.length);
+                                    const today = new Date();
+                                    today.setHours(0, 0, 0, 0);
+                                    const openTasksList: { task: any; categoryId: string }[] = [];
+                                    visible.forEach((category) => {
+                                        category.tasks.forEach((task) => {
+                                            if (!task.startDate) return;
+                                            const taskStartDate = new Date(task.startDate);
+                                            taskStartDate.setHours(0, 0, 0, 0);
+                                            if (taskStartDate < today && !task.deadline) {
+                                                openTasksList.push({ task, categoryId: category.id });
+                                            }
+                                        });
+                                    });
                                     return (
                                         <>
                                             {visible.map((category, index) => {
@@ -483,6 +497,9 @@ const WorkspaceContent = ({
                                                     />
                                                 );
                                             })}
+                                            {openTasksList.length > 0 && (
+                                                <OpenTasksCategory tasks={openTasksList} />
+                                            )}
                                             {upcomingCat && upcomingCat.tasks.length > 0 && (
                                                 <UpcomingCategory
                                                     tasks={upcomingCat.tasks}

--- a/frontend/components/OpenTasksCategory.tsx
+++ b/frontend/components/OpenTasksCategory.tsx
@@ -1,0 +1,73 @@
+import React, { useState } from "react";
+import { StyleSheet, View, TouchableOpacity } from "react-native";
+import { ThemedText } from "./ThemedText";
+import { Task } from "../api/types";
+import SwipableTaskCard from "./cards/SwipableTaskCard";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { CaretDown, CaretRight } from "phosphor-react-native";
+import { MotiView, AnimatePresence } from "moti";
+
+interface OpenTasksCategoryProps {
+    tasks: { task: Task; categoryId: string }[];
+}
+
+export const OpenTasksCategory: React.FC<OpenTasksCategoryProps> = ({ tasks }) => {
+    const ThemedColor = useThemeColor();
+    const [expanded, setExpanded] = useState(false);
+
+    if (tasks.length === 0) return null;
+
+    return (
+        <View style={styles.container}>
+            <View style={[styles.dividerLine, { backgroundColor: ThemedColor.disabled }]} />
+            <TouchableOpacity
+                style={styles.header}
+                activeOpacity={0.6}
+                onPress={() => setExpanded((v) => !v)}>
+                <ThemedText type="lightBody" style={{ color: ThemedColor.caption }}>
+                    Open Tasks ({tasks.length})
+                </ThemedText>
+                {expanded ? (
+                    <CaretDown size={14} color={ThemedColor.caption} />
+                ) : (
+                    <CaretRight size={14} color={ThemedColor.caption} />
+                )}
+            </TouchableOpacity>
+            <AnimatePresence>
+                {expanded && (
+                    <MotiView
+                        from={{ opacity: 0, height: 0 }}
+                        animate={{ opacity: 1, height: "auto" as any }}
+                        exit={{ opacity: 0, height: 0 }}
+                        transition={{ type: "timing", duration: 200 }}
+                        style={{ overflow: "hidden", gap: 12 }}>
+                        {tasks.map(({ task, categoryId }) => (
+                            <SwipableTaskCard
+                                key={task.id + task.content}
+                                redirect={true}
+                                categoryId={categoryId}
+                                task={task}
+                            />
+                        ))}
+                    </MotiView>
+                )}
+            </AnimatePresence>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 12,
+        marginBottom: 4,
+    },
+    dividerLine: {
+        height: StyleSheet.hairlineWidth,
+        marginBottom: 2,
+    },
+    header: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+    },
+});

--- a/frontend/components/daily/TaskListView.tsx
+++ b/frontend/components/daily/TaskListView.tsx
@@ -11,7 +11,7 @@ interface TaskListViewProps {
     tasksForSelectedDate: any[];
     overdueTasks: any[];
     upcomingTasks: any[];
-    pastTasks: any[];
+    openTasks: any[];
     unscheduledTasks: any[];
     onQuickSchedule: (task: any, type: 'deadline' | 'startDate') => void;
 }
@@ -21,7 +21,7 @@ const TaskListViewComponent: React.FC<TaskListViewProps> = ({
     tasksForSelectedDate,
     overdueTasks,
     upcomingTasks,
-    pastTasks,
+    openTasks,
     unscheduledTasks,
     onQuickSchedule,
 }) => {
@@ -45,28 +45,28 @@ const TaskListViewComponent: React.FC<TaskListViewProps> = ({
             {
                 key: "overdue",
                 tasks: overdueTasks,
-                title: "Overdue Tasks",
+                title: "Overdue",
                 description: "",
                 emptyMessage: "No overdue tasks",
             },
             {
+                key: "open",
+                tasks: openTasks,
+                title: "Open Tasks",
+                description: "These tasks have started but haven't been completed yet.",
+                emptyMessage: "No open tasks",
+            },
+            {
                 key: "upcoming",
                 tasks: upcomingTasks,
-                title: "Upcoming Tasks",
+                title: "Upcoming",
                 description: "These tasks have future start dates or deadlines.",
                 emptyMessage: "No upcoming tasks",
             },
             {
-                key: "past",
-                tasks: pastTasks,
-                title: "Past Tasks",
-                description: "These tasks started in the past but have no deadline.",
-                emptyMessage: "No past tasks",
-            },
-            {
                 key: "unscheduled",
                 tasks: unscheduledTasks,
-                title: "Unscheduled Tasks",
+                title: "Unscheduled",
                 description: "These are tasks that don't have a start date or deadline. Swipe right to schedule for this day.",
                 emptyMessage: "No unscheduled tasks",
                 useSchedulable: true,
@@ -78,7 +78,7 @@ const TaskListViewComponent: React.FC<TaskListViewProps> = ({
         const active = all.filter((s) => s.tasks.length > 0);
         const empty = all.filter((s) => s.tasks.length === 0);
         return [...active, ...empty];
-    }, [overdueTasks, upcomingTasks, pastTasks, unscheduledTasks, onQuickSchedule]);
+    }, [overdueTasks, openTasks, upcomingTasks, unscheduledTasks, onQuickSchedule]);
 
     return (
         <View style={styles.container}>
@@ -122,10 +122,10 @@ export const TaskListView = React.memo(TaskListViewComponent, (prevProps, nextPr
     const sameSelectedTasks = prevProps.tasksForSelectedDate.length === nextProps.tasksForSelectedDate.length;
     const sameOverdue = prevProps.overdueTasks.length === nextProps.overdueTasks.length;
     const sameUpcoming = prevProps.upcomingTasks.length === nextProps.upcomingTasks.length;
-    const samePast = prevProps.pastTasks.length === nextProps.pastTasks.length;
+    const sameOpen = prevProps.openTasks.length === nextProps.openTasks.length;
     const sameUnscheduled = prevProps.unscheduledTasks.length === nextProps.unscheduledTasks.length;
 
-    return sameDate && sameSelectedTasks && sameOverdue && sameUpcoming && samePast && sameUnscheduled;
+    return sameDate && sameSelectedTasks && sameOverdue && sameUpcoming && sameOpen && sameUnscheduled;
 });
 
 const styles = StyleSheet.create({

--- a/frontend/components/task/WorkspaceContent.tsx
+++ b/frontend/components/task/WorkspaceContent.tsx
@@ -33,6 +33,7 @@ import Feather from "@expo/vector-icons/Feather";
 import PrimaryButton from "@/components/inputs/PrimaryButton";
 import InlineCategoryCreator from "@/components/InlineCategoryCreator";
 import { UpcomingCategory } from "@/components/UpcomingCategory";
+import { OpenTasksCategory } from "@/components/OpenTasksCategory";
 
 interface WorkspaceContentProps {
     workspaceName?: string; // Optional: if not provided, uses global selected
@@ -215,6 +216,23 @@ const WorkspaceContentBody: React.FC<WorkspaceContentBodyProps> = ({
     const firstCategory = visibleCategories[0];
     const firstCategoryWithTasks = visibleCategories.find((category) => category.tasks.length > 0);
     const groupByDay = state.groupByDay;
+
+    const openTasks = useMemo(() => {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const result: { task: any; categoryId: string }[] = [];
+        visibleCategories.forEach((category) => {
+            category.tasks.forEach((task) => {
+                if (!task.startDate) return;
+                const taskStartDate = new Date(task.startDate);
+                taskStartDate.setHours(0, 0, 0, 0);
+                if (taskStartDate < today && !task.deadline) {
+                    result.push({ task, categoryId: category.id });
+                }
+            });
+        });
+        return result;
+    }, [visibleCategories]);
 
     const groupedByDay = useMemo(() => {
         if (!groupByDay) return [];
@@ -500,6 +518,9 @@ const WorkspaceContentBody: React.FC<WorkspaceContentBodyProps> = ({
                                                 />
                                             );
                                         })}
+                                    {openTasks.length > 0 && (
+                                        <OpenTasksCategory tasks={openTasks} />
+                                    )}
                                     {upcomingCategory && upcomingCategory.tasks.length > 0 && (
                                         <UpcomingCategory
                                             tasks={upcomingCategory.tasks}

--- a/frontend/hooks/useDailyTasks.ts
+++ b/frontend/hooks/useDailyTasks.ts
@@ -42,7 +42,7 @@ export const useDailyTasks = (selectedDate: Date) => {
         return tasksForSelectedDate.filter((task) => {
             // Strictly require startTime to be present
             if (task.startTime) return true;
-            
+
             // Fallback: check if startDate has specific time AND startTime is not explicitly null (if data structure allows)
             // But user feedback suggests we should be stricter.
             // If startTime is missing, but startDate has time, it might be timezone noise.
@@ -50,20 +50,20 @@ export const useDailyTasks = (selectedDate: Date) => {
             if (task.startDate) {
                 const taskDate = new Date(task.startDate);
                 const hasTime = taskDate.getHours() !== 0 || taskDate.getMinutes() !== 0 || taskDate.getSeconds() !== 0;
-                
+
                 // Only treat as specific time if it has non-zero time AND we don't have a conflicting signal
-                // For now, we'll assume that if it has a time component, it's intentional, 
+                // For now, we'll assume that if it has a time component, it's intentional,
                 // UNLESS it looks like a default UTC midnight in local time.
                 // But determining "default UTC midnight" depends on user timezone.
                 // Safer bet: If startTime is missing, treat as "all day" / "no specific time" unless clearly scheduled.
                 // Actually, the previous logic WAS checking for non-zero time.
                 // The user said "tasks without a start time" (implies null startTime).
                 // So we should probably ONLY rely on startTime for specific placement if possible.
-                
+
                 // Proposed fix: Only use startTime.
                 // If tasks migrate from legacy system using startDate as time, this might break them.
                 // But for new tasks, startTime should be used.
-                return false; 
+                return false;
             }
             return false;
         });
@@ -113,7 +113,7 @@ export const useDailyTasks = (selectedDate: Date) => {
         });
     }, [allTasks]);
 
-    const pastTasks = useMemo(() => {
+    const openTasks = useMemo(() => {
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         return allTasks.filter((task) => {
@@ -144,8 +144,7 @@ export const useDailyTasks = (selectedDate: Date) => {
         tasksUnscheduled,
         listUnscheduledTasks,
         upcomingTasks,
-        pastTasks,
+        openTasks,
         overdueTasks,
     };
 };
-


### PR DESCRIPTION
## Summary

- **Rename "Past Tasks" → "Open Tasks"** on the Daily page and reorder sections so Overdue and Open appear first (most urgent)
- **Add "Open Tasks" collapsible section** to both workspace pages, surfacing tasks that started but weren't completed
- **Auto-inject FOLLOW_UP reminders** on task creation — fires 3 hours after deadline (or startTime if no deadline) with "How was {task}?" notification
- **Enhance 5pm check-in** to include open task count: "Hey {name}, you have N open tasks from today — tap to review!"
- **Recalculate follow-ups** when deadlines change; completed tasks auto-skip (moved to separate collection)

## Test plan

- [ ] Verify Daily page shows sections in new order: Overdue → Open Tasks → Upcoming → Unscheduled
- [ ] Verify "Open Tasks" description reads "These tasks have started but haven't been completed yet."
- [ ] Create a task with a past start date and no deadline — confirm it appears in "Open Tasks" on both Daily and Workspace pages
- [ ] Create a task with a future deadline — confirm a FOLLOW_UP reminder is auto-injected (check DB)
- [ ] Complete a task before follow-up fires — confirm no notification is sent
- [ ] Change a task's deadline — confirm the FOLLOW_UP reminder is recalculated
- [ ] Backend unit tests pass: `go test ./internal/handlers/task/ -run TestBuildFollowUp -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)