### PR TITLE
fix: prevent spurious logouts from token refresh race condition

### DIFF
--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -17,12 +17,133 @@ export function clearUnauthorizedHandler() {
     onUnauthorized = null;
 }
 
+// --- Token refresh infrastructure ---
+
+// Mutex: only one refresh can happen at a time. Other requests wait for it.
+let refreshPromise: Promise<boolean> | null = null;
+
+/**
+ * Decode the `exp` claim from a JWT without a library.
+ * Returns expiry as epoch milliseconds, or null if unparseable.
+ */
+function getTokenExpiry(token: string): number | null {
+    try {
+        const payload = token.split('.')[1];
+        if (!payload) return null;
+        // Handle base64url → base64
+        const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+        const json = atob(base64);
+        const claims = JSON.parse(json);
+        return typeof claims.exp === 'number' ? claims.exp * 1000 : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Returns true if the token is expired or will expire within `bufferMs`.
+ * Defaults to a 60-second buffer so we refresh proactively.
+ */
+function isTokenExpired(token: string, bufferMs = 60_000): boolean {
+    const exp = getTokenExpiry(token);
+    if (exp === null) return true;
+    return Date.now() + bufferMs >= exp;
+}
+
+/**
+ * Perform a token refresh by hitting a lightweight authenticated endpoint.
+ * The server middleware detects the expired access token, validates the
+ * refresh token, and returns new tokens in response headers.
+ *
+ * Returns true if refresh succeeded (new tokens saved).
+ */
+async function performRefresh(): Promise<boolean> {
+    try {
+        const authData = await SecureStore.getItemAsync("auth_data");
+        if (!authData) return false;
+
+        const { access_token, refresh_token } = JSON.parse(authData);
+        if (!refresh_token) return false;
+
+        logger.debug("Performing token refresh");
+
+        const response = await fetch(
+            (process.env.EXPO_PUBLIC_URL ?? "") + "/api/v1/user/login",
+            {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${access_token}`,
+                    "refresh_token": refresh_token,
+                    "Content-Type": "application/json",
+                },
+            }
+        );
+
+        if (response.status === 401) {
+            logger.warn("Refresh failed: server returned 401");
+            return false;
+        }
+
+        // Check for new tokens in response headers
+        const newAccess = response.headers.get("access_token");
+        const newRefresh = response.headers.get("refresh_token");
+
+        if (newAccess && newRefresh) {
+            const newAuthData = { access_token: newAccess, refresh_token: newRefresh };
+            await SecureStore.setItemAsync("auth_data", JSON.stringify(newAuthData));
+
+            // Keep axios defaults in sync for legacy code
+            axios.defaults.headers.common["Authorization"] = `Bearer ${newAccess}`;
+            axios.defaults.headers.common["refresh_token"] = newRefresh;
+
+            logger.debug("Token refresh succeeded, new tokens saved");
+            return true;
+        }
+
+        // No new tokens but request succeeded — tokens were still valid
+        if (response.ok) return true;
+
+        return false;
+    } catch (error) {
+        logger.error("Token refresh error", error);
+        return false;
+    }
+}
+
+/**
+ * Ensure we have a valid (non-expired) access token before making a request.
+ * If the token is expired, triggers a refresh with a mutex so concurrent
+ * callers share a single refresh attempt.
+ */
+async function ensureValidToken(): Promise<boolean> {
+    const authData = await SecureStore.getItemAsync("auth_data");
+    if (!authData) return false;
+
+    const { access_token } = JSON.parse(authData);
+    if (!access_token) return false;
+
+    // Token still valid — no refresh needed
+    if (!isTokenExpired(access_token)) return true;
+
+    // Token expired — refresh, but only one at a time
+    if (refreshPromise) {
+        logger.debug("Waiting for in-progress token refresh");
+        return refreshPromise;
+    }
+
+    refreshPromise = performRefresh().finally(() => {
+        refreshPromise = null;
+    });
+
+    return refreshPromise;
+}
+
 // Create the base client
 const baseClient = createClient<paths>({
     baseUrl: (process.env.EXPO_PUBLIC_URL ?? "") + "/api",
 });
 
-// Add request interceptor for authentication
+// Add request/response interceptors
 baseClient.use({
     async onRequest({ request }) {
         logger.debug("Making request", {
@@ -31,6 +152,9 @@ baseClient.use({
         });
 
         try {
+            // Proactively refresh if token is expired — prevents 401 race
+            await ensureValidToken();
+
             const authData = await SecureStore.getItemAsync("auth_data");
 
             if (authData) {
@@ -61,31 +185,45 @@ baseClient.use({
     },
 
     async onResponse({ response, request }) {
-        // Handle 401 — both tokens invalid, force logout
-        if (response.status === 401 && onUnauthorized) {
-            logger.warn("Received 401, triggering auto-logout");
-            await SecureStore.deleteItemAsync("auth_data");
-            onUnauthorized();
+        // Handle 401 — but don't immediately log out.
+        // Check if tokens were already refreshed by another concurrent request.
+        if (response.status === 401) {
+            const authData = await SecureStore.getItemAsync("auth_data");
+
+            if (authData) {
+                const { access_token } = JSON.parse(authData);
+                const requestToken = request.headers.get("Authorization")?.replace("Bearer ", "");
+
+                // If the stored token differs from what this request used,
+                // another request already refreshed. Don't log out.
+                if (access_token && requestToken && access_token !== requestToken) {
+                    logger.debug("401 on stale request — tokens already refreshed, skipping logout");
+                    return response;
+                }
+            }
+
+            // Tokens haven't changed — this is a genuine auth failure
+            if (onUnauthorized) {
+                logger.warn("Received 401 with current tokens, triggering logout");
+                await SecureStore.deleteItemAsync("auth_data");
+                onUnauthorized();
+            }
+
             return response;
         }
 
-        // Handle token refresh in headers
+        // Handle token refresh in response headers (server-side middleware refreshed for us)
         const access_token = response.headers.get("access_token");
         const refresh_token = response.headers.get("refresh_token");
 
         if (access_token && refresh_token) {
-            logger.debug("Saving tokens from response headers");
+            logger.debug("Saving refreshed tokens from response headers");
             const authData = {
                 access_token: access_token,
                 refresh_token: refresh_token,
             };
 
             await SecureStore.setItemAsync("auth_data", JSON.stringify(authData));
-            logger.debug("Tokens saved successfully");
-
-            // Verify what was actually saved
-            const savedData = await SecureStore.getItemAsync("auth_data");
-            logger.debug("Verified saved data", { exists: !!savedData });
 
             // Update axios defaults for compatibility with existing code
             axios.defaults.headers.common["Authorization"] = `Bearer ${access_token}`;

--- a/frontend/hooks/useAuth.tsx
+++ b/frontend/hooks/useAuth.tsx
@@ -471,7 +471,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                     } catch (tokenError) {
                         logger.error("❌ Token login exception:", tokenError);
                         logger.error("❌ Error details:", tokenError.message);
-                        logout();
+                        // Only log out if this was an auth rejection (401).
+                        // Network errors or transient failures should not clear the session.
+                        const is401 = tokenError?.message?.includes('401') || tokenError?.status === 401;
+                        if (is401) {
+                            logout();
+                        }
                         return null;
                     }
                 }
@@ -481,7 +486,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
                 return null;
             } catch (error) {
                 logger.error("Error fetching auth data:", error);
-                logout();
+                // Don't log out on transient errors (network issues, SecureStore hiccups).
+                // The user's session is still valid — we just couldn't verify it right now.
                 return null;
             }
         })();


### PR DESCRIPTION
## Summary

- **Proactive token refresh** — before each API request, decode the JWT `exp` claim; if token expires within 60s, refresh proactively before sending the request
- **Refresh mutex** — only one refresh runs at a time; concurrent requests wait for the in-progress refresh instead of each triggering their own (which caused the race)
- **Stale-request 401 guard** — on 401, compare the token used in the request vs. what's in SecureStore; if they differ, another request already refreshed — skip logout
- **No logout on transient errors** — `fetchAuthData` no longer calls `logout()` on network timeouts or SecureStore failures, only on confirmed 401 rejections

## Root cause

When the 1-hour access token expired and the app fired multiple simultaneous requests (common on mobile foreground), the first request would refresh successfully via the server middleware, but the second request would get a 401 (refresh token already used). The frontend immediately logged the user out on any 401 with no retry or staleness check.

## Test plan

- [ ] Background the app for >1 hour, reopen — should NOT be logged out
- [ ] Toggle airplane mode briefly during API calls — should NOT be logged out
- [ ] Verify normal login/logout flow still works
- [ ] Verify token refresh happens transparently (check logs for "Token refresh succeeded")
- [ ] Kill and restart the app — should auto-login with stored tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)