### PR TITLE
feat: add dashboard stats row with clickable numbers

### DIFF
--- a/frontend/app/(logged-in)/(tabs)/(task)/index.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/index.tsx
@@ -1,5 +1,6 @@
 import { Dimensions, StyleSheet, View, TouchableOpacity } from "react-native";
 import React, { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ThemedView } from "@/components/ThemedView";
 import { useAuth } from "@/hooks/useAuth";
 import { useTasks } from "@/contexts/tasksContext";
@@ -51,6 +52,7 @@ const Home = (props: Props) => {
     const [showWorkspaceSelection, setShowWorkspaceSelection] = useState(false);
     const { focusMode, toggleFocusMode } = useFocusMode();
     const [refreshing, setRefreshing] = useState(false);
+    const queryClient = useQueryClient();
 
     const insets = useSafeAreaInsets();
     const safeAsync = useSafeAsync();
@@ -196,6 +198,7 @@ const Home = (props: Props) => {
             await Promise.all([
                 fetchWorkspaces(true), // Force refresh workspaces
                 fetchKudosCounts(true), // Force refresh kudos
+                queryClient.invalidateQueries({ queryKey: ["completedTasks"] }),
             ]);
             console.log("Refresh complete");
         } catch (error) {
@@ -203,7 +206,7 @@ const Home = (props: Props) => {
         } finally {
             setRefreshing(false);
         }
-    }, [fetchWorkspaces, fetchKudosCounts]);
+    }, [fetchWorkspaces, fetchKudosCounts, queryClient]);
 
     const drawerRef = useRef<DrawerLayout>(null);
 

--- a/frontend/components/dashboard/CompletedTaskRow.tsx
+++ b/frontend/components/dashboard/CompletedTaskRow.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { CheckCircle } from "phosphor-react-native";
+import { formatDistanceToNow } from "date-fns";
+import { Task } from "@/api/types";
+
+interface CompletedTaskRowProps {
+    task: Task;
+}
+
+const CompletedTaskRow: React.FC<CompletedTaskRowProps> = ({ task }) => {
+    const ThemedColor = useThemeColor();
+
+    return (
+        <View style={[styles.container, { backgroundColor: ThemedColor.lightenedCard, borderColor: ThemedColor.tertiary }]}>
+            <CheckCircle size={20} color={ThemedColor.success} weight="fill" />
+            <View style={styles.textContainer}>
+                <ThemedText
+                    type="defaultSemiBold"
+                    numberOfLines={1}
+                    style={{ textDecorationLine: "line-through", opacity: 0.7 }}
+                >
+                    {task.content}
+                </ThemedText>
+                {task.timeCompleted && (
+                    <ThemedText type="caption">
+                        {formatDistanceToNow(new Date(task.timeCompleted), { addSuffix: true })}
+                    </ThemedText>
+                )}
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        padding: 12,
+        paddingHorizontal: 16,
+        borderRadius: 12,
+        borderWidth: 1,
+    },
+    textContainer: {
+        flex: 1,
+        gap: 2,
+    },
+});
+
+export default CompletedTaskRow;

--- a/frontend/components/dashboard/DashboardStats.tsx
+++ b/frontend/components/dashboard/DashboardStats.tsx
@@ -1,0 +1,129 @@
+import React, { useState, useCallback } from "react";
+import { View, StyleSheet, LayoutAnimation, UIManager, Platform, TouchableOpacity } from "react-native";
+import { useRouter } from "expo-router";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTasks } from "@/contexts/tasksContext";
+import { useCompletedThisWeek } from "@/hooks/useCompletedThisWeek";
+import StatItem from "./StatItem";
+import SwipableTaskCard from "@/components/cards/SwipableTaskCard";
+import CompletedTaskRow from "./CompletedTaskRow";
+
+if (Platform.OS === "android" && UIManager.setLayoutAnimationEnabledExperimental) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const MAX_VISIBLE = 5;
+
+type ExpandedStat = "open" | "doneThisWeek" | null;
+
+const DashboardStats: React.FC = () => {
+    const router = useRouter();
+    const ThemedColor = useThemeColor();
+    const { unnestedTasks, dueTodayTasks } = useTasks();
+    const { completedThisWeek, isLoading: completedLoading } = useCompletedThisWeek();
+    const [expanded, setExpanded] = useState<ExpandedStat>(null);
+
+    const openTasks = unnestedTasks;
+
+    const handlePress = useCallback((stat: "open" | "dueToday" | "doneThisWeek") => {
+        if (stat === "dueToday") {
+            if (dueTodayTasks.length === 0) return;
+            router.push("/(logged-in)/(tabs)/(task)/daily");
+            return;
+        }
+        if (stat === "open" && openTasks.length === 0) return;
+        if (stat === "doneThisWeek" && completedThisWeek.length === 0) return;
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpanded((prev) => (prev === stat ? null : stat));
+    }, [router, dueTodayTasks.length, openTasks.length, completedThisWeek.length]);
+
+    const visibleOpen = openTasks.slice(0, MAX_VISIBLE);
+    const visibleCompleted = completedThisWeek.slice(0, MAX_VISIBLE);
+
+    return (
+        <View style={styles.wrapper}>
+            {/* Stats row */}
+            <View style={styles.row}>
+                <StatItem
+                    value={openTasks.length}
+                    label="Open"
+                    isSelected={expanded === "open"}
+                    isDimmed={expanded !== null && expanded !== "open"}
+                    onPress={() => handlePress("open")}
+                />
+                <StatItem
+                    value={dueTodayTasks.length}
+                    label="Due Today"
+                    isSelected={false}
+                    isDimmed={expanded !== null}
+                    onPress={() => handlePress("dueToday")}
+                />
+                <StatItem
+                    value={completedThisWeek.length}
+                    label="Done This Week"
+                    isSelected={expanded === "doneThisWeek"}
+                    isDimmed={expanded !== null && expanded !== "doneThisWeek"}
+                    onPress={() => handlePress("doneThisWeek")}
+                    isLoading={completedLoading}
+                />
+            </View>
+
+            {/* Expanded: Open tasks */}
+            {expanded === "open" && openTasks.length > 0 && (
+                <View style={styles.expandedList}>
+                    {visibleOpen.map((task, index) => (
+                        <SwipableTaskCard
+                            key={task.id || index}
+                            redirect={true}
+                            categoryId={task.categoryID!}
+                            task={task}
+                        />
+                    ))}
+                    {openTasks.length > MAX_VISIBLE && (
+                        <TouchableOpacity style={styles.showAll} activeOpacity={0.7}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
+                                Show all {openTasks.length} open →
+                            </ThemedText>
+                        </TouchableOpacity>
+                    )}
+                </View>
+            )}
+
+            {/* Expanded: Done This Week */}
+            {expanded === "doneThisWeek" && completedThisWeek.length > 0 && (
+                <View style={styles.expandedList}>
+                    {visibleCompleted.map((task, index) => (
+                        <CompletedTaskRow key={task.id || index} task={task} />
+                    ))}
+                    {completedThisWeek.length > MAX_VISIBLE && (
+                        <TouchableOpacity style={styles.showAll} activeOpacity={0.7}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
+                                Show all {completedThisWeek.length} completed →
+                            </ThemedText>
+                        </TouchableOpacity>
+                    )}
+                </View>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    wrapper: {
+        gap: 16,
+    },
+    row: {
+        flexDirection: "row",
+        justifyContent: "space-around",
+    },
+    expandedList: {
+        gap: 8,
+    },
+    showAll: {
+        alignItems: "center",
+        paddingVertical: 8,
+    },
+});
+
+export default DashboardStats;

--- a/frontend/components/dashboard/DashboardStats.tsx
+++ b/frontend/components/dashboard/DashboardStats.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback } from "react";
-import { View, StyleSheet, LayoutAnimation, UIManager, Platform, TouchableOpacity } from "react-native";
+import { View, StyleSheet, LayoutAnimation, UIManager, Platform } from "react-native";
 import { useRouter } from "expo-router";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -81,11 +81,11 @@ const DashboardStats: React.FC = () => {
                         />
                     ))}
                     {openTasks.length > MAX_VISIBLE && (
-                        <TouchableOpacity style={styles.showAll} activeOpacity={0.7}>
-                            <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
-                                Show all {openTasks.length} open →
+                        <View style={styles.showAll}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                                +{openTasks.length - MAX_VISIBLE} more
                             </ThemedText>
-                        </TouchableOpacity>
+                        </View>
                     )}
                 </View>
             )}
@@ -97,11 +97,11 @@ const DashboardStats: React.FC = () => {
                         <CompletedTaskRow key={task.id || index} task={task} />
                     ))}
                     {completedThisWeek.length > MAX_VISIBLE && (
-                        <TouchableOpacity style={styles.showAll} activeOpacity={0.7}>
-                            <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
-                                Show all {completedThisWeek.length} completed →
+                        <View style={styles.showAll}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                                +{completedThisWeek.length - MAX_VISIBLE} more
                             </ThemedText>
-                        </TouchableOpacity>
+                        </View>
                     )}
                 </View>
             )}

--- a/frontend/components/dashboard/HomescrollContent.tsx
+++ b/frontend/components/dashboard/HomescrollContent.tsx
@@ -4,6 +4,7 @@ import { MotiView } from "moti";
 import { ThemedText } from "@/components/ThemedText";
 import { WorkspaceGrid } from "./WorkspaceGrid";
 import DashboardCards from "@/components/dashboard/DashboardCards";
+import DashboardStats from "@/components/dashboard/DashboardStats";
 import BottomDashboardCards from "@/components/dashboard/BottomDashboardCards";
 import BasicCard from "@/components/cards/BasicCard";
 import { useRouter } from "expo-router";
@@ -293,6 +294,11 @@ export const HomeScrollContent: React.FC<HomeScrollContentProps> = ({
                         />
                     </View>
                 </BasicCard> */}
+
+                {/* Dashboard Stats */}
+                <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>
+                    <DashboardStats />
+                </View>
 
                 {/* Dashboard Cards */}
                 <View style={{ marginLeft: HORIZONTAL_PADDING, gap: 12, marginBottom: 18 }}>

--- a/frontend/components/dashboard/StatItem.tsx
+++ b/frontend/components/dashboard/StatItem.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { TouchableOpacity, StyleSheet, Dimensions } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+const base = 393;
+const scale = Dimensions.get("screen").width / base;
+
+interface StatItemProps {
+    value: number;
+    label: string;
+    isSelected: boolean;
+    isDimmed: boolean;
+    onPress: () => void;
+    isLoading?: boolean;
+}
+
+const StatItem: React.FC<StatItemProps> = ({ value, label, isSelected, isDimmed, onPress, isLoading }) => {
+    const ThemedColor = useThemeColor();
+
+    return (
+        <TouchableOpacity
+            style={[styles.container, isDimmed && styles.dimmed]}
+            onPress={onPress}
+            activeOpacity={0.7}
+        >
+            <ThemedText
+                style={[styles.number, { color: ThemedColor.header }]}
+            >
+                {isLoading ? "—" : value}
+            </ThemedText>
+            <ThemedText
+                type="caption"
+                style={[
+                    styles.label,
+                    isSelected && { color: ThemedColor.primary, fontWeight: "600" },
+                ]}
+            >
+                {label} {isSelected ? "‹" : "›"}
+            </ThemedText>
+        </TouchableOpacity>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        flex: 1,
+    },
+    dimmed: {
+        opacity: 0.4,
+    },
+    number: {
+        fontFamily: "Fraunces",
+        fontSize: 36 * scale,
+        fontWeight: "600",
+        lineHeight: 40 * scale,
+    },
+    label: {
+        textTransform: "uppercase",
+        letterSpacing: 0.5,
+        fontSize: 11 * scale,
+    },
+});
+
+export default StatItem;

--- a/frontend/hooks/useCompletedThisWeek.ts
+++ b/frontend/hooks/useCompletedThisWeek.ts
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
-import { getCompletedTasksAPI } from "@/api/task";
+import { getCompletedTasksAPI, PaginatedCompletedTasksResponse } from "@/api/task";
 import { useMemo } from "react";
 import { Task } from "@/api/types";
+import { startOfWeek } from "date-fns";
 
 export function useCompletedThisWeek() {
     const { data, isLoading, refetch } = useQuery({
@@ -11,12 +12,11 @@ export function useCompletedThisWeek() {
 
     const completedThisWeek = useMemo(() => {
         if (!data?.tasks) return [];
-        const sevenDaysAgo = new Date();
-        sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+        const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 });
 
-        return data.tasks.filter((task: any) => {
+        return data.tasks.filter((task) => {
             if (!task.timeCompleted) return false;
-            return new Date(task.timeCompleted) >= sevenDaysAgo;
+            return new Date(task.timeCompleted) >= weekStart;
         }) as Task[];
     }, [data?.tasks]);
 

--- a/frontend/hooks/useCompletedThisWeek.ts
+++ b/frontend/hooks/useCompletedThisWeek.ts
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { getCompletedTasksAPI } from "@/api/task";
+import { useMemo } from "react";
+import { Task } from "@/api/types";
+
+export function useCompletedThisWeek() {
+    const { data, isLoading, refetch } = useQuery({
+        queryKey: ["completedTasks", "thisWeek"],
+        queryFn: () => getCompletedTasksAPI(1, 100),
+    });
+
+    const completedThisWeek = useMemo(() => {
+        if (!data?.tasks) return [];
+        const sevenDaysAgo = new Date();
+        sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+        return data.tasks.filter((task: any) => {
+            if (!task.timeCompleted) return false;
+            return new Date(task.timeCompleted) >= sevenDaysAgo;
+        }) as Task[];
+    }, [data?.tasks]);
+
+    return { completedThisWeek, isLoading, refetch };
+}


### PR DESCRIPTION
## Summary
- Adds a row of three tappable stat numbers (Open, Due Today, Done This Week) at the top of the home dashboard
- **Open** and **Done This Week** expand inline task lists below the stats row (capped at 5)
- **Due Today** navigates to the existing Daily page
- Uses Fraunces font for numbers, no cards, no dividers — clean and minimal
- Pulls completed task count via existing `/v1/user/tasks/completed` endpoint with `startOfWeek` filtering
- Invalidates completed tasks cache on pull-to-refresh

## New files
- `frontend/hooks/useCompletedThisWeek.ts` — react-query hook for completed tasks this calendar week
- `frontend/components/dashboard/StatItem.tsx` — single tappable stat (Fraunces number + label + chevron)
- `frontend/components/dashboard/CompletedTaskRow.tsx` — completed task row (green check, strikethrough, relative time)
- `frontend/components/dashboard/DashboardStats.tsx` — orchestrator with expand/collapse via LayoutAnimation

## Modified files
- `HomeScrollContent.tsx` — inserted DashboardStats above "Jump Back In"
- `index.tsx` (home screen) — added `queryClient.invalidateQueries` on pull-to-refresh

## Test plan
- [ ] Stats row appears at the top of the home dashboard, above "Jump Back In"
- [ ] All three numbers render correctly (Open count, Due Today count, Done This Week count)
- [ ] Tap "Open" → inline list of up to 5 task cards expands, other stats dim
- [ ] Tap "Open" again → list collapses
- [ ] Tap "Due Today" → navigates to Daily page
- [ ] Tap "Done This Week" → inline list of completed tasks with green checkmarks
- [ ] If any stat is 0, tapping does nothing
- [ ] Pull to refresh → numbers update
- [ ] "Done This Week" resets on Monday (uses calendar week, not rolling 7 days)

🤖 Generated with [Claude Code](https://claude.com/claude-code)