### PR TITLE
feat: optimize Genkit flows with prompt-injected context and voice normalization

### DIFF
--- a/backend/internal/gemini/flows.go
+++ b/backend/internal/gemini/flows.go
@@ -78,21 +78,8 @@ func InitFlows(g *genkit.Genkit, tools *ToolSet) *FlowSet {
 	// Enhanced flow with category context and tool calling
 	multiTaskFromTextFlowWithContext := genkit.DefineFlow(g, "multiTaskFromTextFlowWithContext",
 		func(ctx context.Context, input MultiTaskFromTextInputWithUser) (MultiTaskFromTextOutput, error) {
-			currentTime := time.Now().UTC().Format(time.RFC3339)
-
 			// Enhanced prompt that instructs the AI to use the tool
-			prompt := fmt.Sprintf(`You are a task organization assistant. Generate a set of categories and tasks based on the user's input text.
-
-IMPORTANT: Before creating categories, call the getUserCategories tool with userId "%s" to see what categories the user already has. Try to assign tasks to existing categories when appropriate, or create new categories only when needed.
-
-Current time: %s
-User input: %s
-
-Your response should include:
-1. categories: An array of category objects with "name" and "workspaceName" fields. New categories should include tasks in the tasks array.
-2. tasks: An array of categoryTaskPair objects, each with appropriate fields. The categoryId should be the ID of the existing category in the user's database. These are exlusively for tasks that belong to existing categories.
-
-When choosing category names, prefer existing categories from the user's database when the task fits. Only create new categories when the task doesn't match any existing category.`, input.UserID, currentTime, input.Text)
+			prompt := BuildMultiTaskWithContextPrompt(input.UserID, input.Text, input.Timezone)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.MultiTaskFromTextWithContext")
 			defer span.End()
@@ -257,29 +244,7 @@ Generate a high-quality, comprehensive blueprint that the user can immediately s
 	// NL-to-query flow: converts natural language into structured task filter parameters
 	queryTasksFlow := genkit.DefineFlow(g, "queryTasksFlow",
 		func(ctx context.Context, input QueryTasksFlowInput) (TaskQueryFiltersOutput, error) {
-			currentTime := time.Now().UTC().Format(time.RFC3339)
-
-			prompt := fmt.Sprintf(`You are a task search assistant. Convert the user's natural language query into structured filter parameters for searching their tasks.
-
-IMPORTANT: Call the getUserCategories tool with userId "%s" to see what categories/workspaces exist. Use the returned category IDs when the user refers to a specific category or workspace by name.
-
-Current time: %s
-User's timezone: %s
-
-User query: "%s"
-
-Return a TaskQueryFiltersOutput with the appropriate filters:
-- categoryIds: IDs of relevant categories (match by name from getUserCategories results). Leave empty if no specific category is mentioned.
-- priorities: relevant priority values (1=low, 2=medium, 3=high). E.g. [3] for "high priority", [1,2] for "low and medium priority".
-- deadlineFrom/deadlineTo: ISO8601 datetime range for deadline filter. E.g. for "due this week", set deadlineFrom to start of current week and deadlineTo to end of current week in the user's timezone.
-- startTimeFrom/startTimeTo: ISO8601 datetime range for start date filter.
-- hasDeadline: set to true if user says "with deadline" or "due", false if "without deadline".
-- hasStartTime: set to true if user says "scheduled" or "with start date", false if "unscheduled".
-- sortBy: appropriate sorting field (timestamp, priority, value, deadline). Default to "timestamp".
-- sortDir: -1 for "newest/latest/most recent", 1 for "oldest". Default to -1.
-
-Be precise with date ranges based on the user's timezone. Only set filters that are clearly implied by the query.`,
-				input.UserID, currentTime, input.Timezone, input.Text)
+			prompt := BuildQueryTasksPrompt(input.UserID, input.Text, input.Timezone)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.QueryTasks")
 			defer span.End()
@@ -298,37 +263,7 @@ Be precise with date ranges based on the user's timezone. Only set filters that 
 	// Edit tasks via natural language
 	editTasksFlow := genkit.DefineFlow(g, "editTasksFlow",
 		func(ctx context.Context, input EditTasksFlowInput) (EditTasksFlowOutput, error) {
-			now := time.Now().UTC().Format(time.RFC3339)
-
-			prompt := fmt.Sprintf(`You are a task editing assistant. The user wants to edit one or more of their tasks or recurring templates.
-
-STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and recurring templates.
-         The result contains two arrays: "tasks" (regular one-off tasks) and "templates" (recurring task templates).
-STEP 2: Identify which item(s) the user is referring to by matching their description to content/notes.
-         If the user mentions something recurring or a "template", look in templates first.
-STEP 3: Construct edit instructions for each matched item.
-
-Current time: %s
-User's timezone: %s
-User instruction: "%s"
-
-Return an EditTasksFlowOutput with two arrays:
-- instructions: edits for regular tasks. Each entry must have:
-    - taskId: exact hex ID from the "tasks" array
-    - categoryId: exact hex categoryId from the "tasks" array
-    - updates: only include fields that should change
-- templateInstructions: edits for recurring templates. Each entry must have:
-    - taskId: exact hex ID from the "templates" array
-    - categoryId: exact hex categoryId from the "templates" array
-    - updates: only include fields that should change
-
-For time fields in updates:
-    - Omit entirely to leave unchanged
-    - ISO8601 string to set a new value (interpret relative times like "next Friday" using current time + timezone)
-    - Empty string "" to explicitly clear/remove the field
-
-If the user's instruction doesn't match anything, return empty arrays for both.`,
-				input.UserID, now, input.Timezone, input.Text)
+			prompt := BuildEditTasksPrompt(input.UserID, input.Text, input.Timezone)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.EditTasks")
 			defer span.End()
@@ -349,51 +284,7 @@ If the user's instruction doesn't match anything, return empty arrays for both.`
 	// then deletes (destructive, needs user confirmation), then creates (additive, needs preview).
 	intentRouterFlow := genkit.DefineFlow(g, "intentRouterFlow",
 		func(ctx context.Context, input IntentRouterInput) (IntentRouterOutput, error) {
-			now := time.Now().UTC().Format(time.RFC3339)
-
-			prompt := fmt.Sprintf(`You are a task management assistant. The user has given you a natural language instruction that may contain one or more operations: creating new tasks, editing existing tasks, or deleting existing tasks.
-
-STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and templates (needed for edit and delete operations).
-STEP 2: Call getUserCategories with userId "%s" to see their existing categories and workspaces (needed for create operations).
-STEP 3: Decompose the user's instruction into one or more typed operations.
-
-Current time: %s
-User's timezone: %s
-User instruction: "%s"
-
-Return an IntentRouterOutput with an "ops" array. Each element must have:
-- "type": one of "create", "edit", or "delete"
-- Exactly one payload field matching the type:
-  - For "create": populate "createPayload" with the same structure as multiTaskFromTextFlowWithContext output:
-      { "categories": [...new categories with tasks...], "tasks": [...tasks for existing categories...] }
-      Use the categoryIds from getUserCategories when assigning tasks to existing categories.
-  - For "edit": populate "editPayload" with the same structure as editTasksFlow output:
-      { "instructions": [...], "templateInstructions": [...] }
-      Use exact hex IDs from getUserActiveTasks results.
-  - For "delete": populate "deletePayload" with query filters to match the tasks the user wants to delete.
-      ONLY these fields are allowed — do NOT include any other fields:
-        - "categoryIds": string array of category IDs (from getUserCategories)
-        - "priorities": integer array of priority values (1=low, 2=medium, 3=high)
-        - "deadlineFrom": ISO8601 datetime string (start of deadline range, optional)
-        - "deadlineTo": ISO8601 datetime string (end of deadline range, optional)
-        - "startTimeFrom": ISO8601 datetime string (start of start-time range, optional)
-        - "startTimeTo": ISO8601 datetime string (end of start-time range, optional)
-        - "hasDeadline": boolean (true = only tasks with a deadline, optional)
-        - "hasStartTime": boolean (true = only scheduled tasks, optional)
-        - "sortBy": one of "timestamp", "priority", "value", "deadline" (optional)
-        - "sortDir": -1 (newest first) or 1 (oldest first) (optional)
-      IMPORTANT: Do NOT include "taskIds", "ids", "taskId", or any direct task identifiers.
-      Use only the filter fields above to describe which tasks to delete.
-
-ORDERING RULES (important):
-1. Edit operations first (non-destructive, applied immediately server-side)
-2. Delete operations second (destructive, user will confirm in UI)
-3. Create operations last (additive, user will preview in UI)
-
-If the instruction contains only one type of operation, return a single-element "ops" array.
-If no matching tasks are found for an edit or delete, return an empty "ops" array rather than guessing.
-Only include operations that are clearly implied by the user's instruction.`,
-				input.UserID, input.UserID, now, input.Timezone, input.Text)
+			prompt := BuildIntentRouterPrompt(input.UserID, input.Text, input.Timezone)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.IntentRouter")
 			defer span.End()

--- a/backend/internal/gemini/flows.go
+++ b/backend/internal/gemini/flows.go
@@ -10,6 +10,7 @@ import (
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
 	"github.com/firebase/genkit/go/genkit"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
 )
@@ -79,14 +80,47 @@ func InitFlows(g *genkit.Genkit, tools *ToolSet, categoryService *Category.Servi
 	// Enhanced flow with category context and tool calling
 	multiTaskFromTextFlowWithContext := genkit.DefineFlow(g, "multiTaskFromTextFlowWithContext",
 		func(ctx context.Context, input MultiTaskFromTextInputWithUser) (MultiTaskFromTextOutput, error) {
-			// Enhanced prompt that instructs the AI to use the tool
-			prompt := BuildMultiTaskWithContextPrompt(input.UserID, input.Text, input.Timezone)
+			currentTime := time.Now().UTC().Format(time.RFC3339)
+
+			userID, err := primitive.ObjectIDFromHex(input.UserID)
+			if err != nil {
+				return MultiTaskFromTextOutput{}, fmt.Errorf("invalid user ID: %w", err)
+			}
+
+			categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+			if err != nil {
+				return MultiTaskFromTextOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+			}
+
+			prompt := fmt.Sprintf(`You are a task organization assistant. Generate a set of categories and tasks based on the user's input text.
+
+The user's existing workspaces and categories:
+%s
+
+Current time: %s
+User input: %s
+
+TEXT NORMALIZATION (apply to all task content you generate):
+- Fix capitalization: sentence case for task names ("buy groceries" -> "Buy groceries")
+- Remove filler words from voice input (um, uh, like, you know, so basically, i guess)
+- Keep the user's phrasing — do NOT significantly rewrite or paraphrase their words
+- Split compound sentences into separate tasks when they describe distinct actions
+  Example: "call mom and also buy groceries" -> two tasks: "Call mom", "Buy groceries"
+- Infer deadlines from context: "finish the report by friday" -> set deadline to this Friday
+- Infer priorities from urgency cues: "urgently fix the bug" -> priority 3, "maybe clean my desk" -> priority 1
+- When no priority cue exists, default to priority 2
+- When no deadline is mentioned, omit it — do not guess
+
+Your response should include:
+1. categories: An array of category objects with "name" and "workspaceName" fields. New categories should include tasks in the tasks array.
+2. tasks: An array of categoryTaskPair objects, each with appropriate fields. The categoryId should be the ID of the existing category from the list above. These are exclusively for tasks that belong to existing categories.
+
+When choosing category names, prefer existing categories from the list above when the task fits. Only create new categories when the task doesn't match any existing category.`, categorySummary, currentTime, input.Text)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.MultiTaskFromTextWithContext")
 			defer span.End()
 			resp, _, err := genkit.GenerateData[MultiTaskFromTextOutput](ctx, g,
 				ai.WithPrompt(prompt),
-				ai.WithTools(tools.GetUserCategories),
 			)
 			if err != nil {
 				span.RecordError(err)
@@ -167,23 +201,33 @@ Be specific with numbers, encouraging in tone, and actionable in recommendations
 		func(ctx context.Context, input GenerateBlueprintInput) (GenerateBlueprintOutput, error) {
 			currentTime := time.Now().UTC().Format(time.RFC3339)
 
+			userID, err := primitive.ObjectIDFromHex(input.UserID)
+			if err != nil {
+				return GenerateBlueprintOutput{}, fmt.Errorf("invalid user ID: %w", err)
+			}
+
+			categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+			if err != nil {
+				return GenerateBlueprintOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+			}
+
 			prompt := fmt.Sprintf(`You are a blueprint creation assistant. Generate a comprehensive, well-structured blueprint based on the user's description.
 
-User ID: %s
 Description: %s
 Current time: %s
 
+The user's existing workspaces and categories:
+%s
+
 IMPORTANT INSTRUCTIONS:
 
-1. CALL getUserCategories tool with userId "%s" to understand the user's existing categories and workspaces. This will help you create relevant and contextually appropriate blueprints.
-
-2. CALL fetchUnsplashImage tool with a relevant search query based on the blueprint theme to get a beautiful banner image. For example:
+1. CALL fetchUnsplashImage tool with a relevant search query based on the blueprint theme to get a beautiful banner image. For example:
    - For a "Morning Routine" blueprint, use query "morning sunrise coffee"
    - For a "Workout Plan" blueprint, use query "fitness gym workout"
    - For a "Meal Prep" blueprint, use query "healthy food meal prep"
    Choose a descriptive query that matches the blueprint's theme. Use the returned URL for the banner field.
 
-3. Create a complete blueprint with the following structure:
+2. Create a complete blueprint with the following structure:
    - name: A clear, concise name for the blueprint (e.g., "Morning Productivity Routine", "Weekly Meal Prep Plan")
    - description: A detailed description explaining the purpose and benefits of this blueprint
    - banner: Use the image URL returned from fetchUnsplashImage tool
@@ -207,7 +251,7 @@ IMPORTANT INSTRUCTIONS:
        - checklist: Array of checklist items (optional)
        - reminders: Array of reminder objects (optional)
 
-4. BLUEPRINT DESIGN GUIDELINES:
+3. BLUEPRINT DESIGN GUIDELINES:
    - Create 2-5 categories that logically organize the tasks
    - Each category should have 3-8 tasks
    - Tasks should be specific, actionable, and ordered logically
@@ -216,22 +260,22 @@ IMPORTANT INSTRUCTIONS:
    - For recurring tasks, consider daily/weekly patterns
    - Add helpful notes for tasks that need clarification
 
-5. QUALITY STANDARDS:
+4. QUALITY STANDARDS:
    - Ensure tasks are complete and actionable
    - Order tasks in a logical sequence
    - Balance task priorities across the blueprint
    - Make the blueprint immediately useful and practical
-   - Consider the user's existing workspace patterns from getUserCategories
+   - Consider the user's existing workspace patterns from the category list above
    - Use high-quality, relevant banner images from Unsplash
 
-Generate a high-quality, comprehensive blueprint that the user can immediately subscribe to and start using.`, input.UserID, input.Description, currentTime, input.UserID)
+Generate a high-quality, comprehensive blueprint that the user can immediately subscribe to and start using.`, input.Description, currentTime, categorySummary)
 
-			// Generate structured blueprint data with user context and Unsplash tool
+			// Generate structured blueprint data with Unsplash tool
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.GenerateBlueprint")
 			defer span.End()
 			resp, _, err := genkit.GenerateData[GenerateBlueprintOutput](ctx, g,
 				ai.WithPrompt(prompt),
-				ai.WithTools(tools.GetUserCategories, tools.FetchUnsplashImage),
+				ai.WithTools(tools.FetchUnsplashImage),
 			)
 			if err != nil {
 				span.RecordError(err)
@@ -245,13 +289,45 @@ Generate a high-quality, comprehensive blueprint that the user can immediately s
 	// NL-to-query flow: converts natural language into structured task filter parameters
 	queryTasksFlow := genkit.DefineFlow(g, "queryTasksFlow",
 		func(ctx context.Context, input QueryTasksFlowInput) (TaskQueryFiltersOutput, error) {
-			prompt := BuildQueryTasksPrompt(input.UserID, input.Text, input.Timezone)
+			currentTime := time.Now().UTC().Format(time.RFC3339)
+
+			userID, err := primitive.ObjectIDFromHex(input.UserID)
+			if err != nil {
+				return TaskQueryFiltersOutput{}, fmt.Errorf("invalid user ID: %w", err)
+			}
+
+			categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+			if err != nil {
+				return TaskQueryFiltersOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+			}
+
+			prompt := fmt.Sprintf(`You are a task search assistant. Convert the user's natural language query into structured filter parameters for searching their tasks.
+
+The user's existing workspaces and categories:
+%s
+
+Current time: %s
+User's timezone: %s
+
+User query: "%s"
+
+Return a TaskQueryFiltersOutput with the appropriate filters:
+- categoryIds: IDs of relevant categories (match by name from the list above). Leave empty if no specific category is mentioned.
+- priorities: relevant priority values (1=low, 2=medium, 3=high). E.g. [3] for "high priority", [1,2] for "low and medium priority".
+- deadlineFrom/deadlineTo: ISO8601 datetime range for deadline filter. E.g. for "due this week", set deadlineFrom to start of current week and deadlineTo to end of current week in the user's timezone.
+- startTimeFrom/startTimeTo: ISO8601 datetime range for start date filter.
+- hasDeadline: set to true if user says "with deadline" or "due", false if "without deadline".
+- hasStartTime: set to true if user says "scheduled" or "with start date", false if "unscheduled".
+- sortBy: appropriate sorting field (timestamp, priority, value, deadline). Default to "timestamp".
+- sortDir: -1 for "newest/latest/most recent", 1 for "oldest". Default to -1.
+
+Be precise with date ranges based on the user's timezone. Only set filters that are clearly implied by the query.`,
+				categorySummary, currentTime, input.Timezone, input.Text)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.QueryTasks")
 			defer span.End()
 			resp, _, err := genkit.GenerateData[TaskQueryFiltersOutput](ctx, g,
 				ai.WithPrompt(prompt),
-				ai.WithTools(tools.GetUserCategories),
 			)
 			if err != nil {
 				span.RecordError(err)
@@ -264,7 +340,49 @@ Generate a high-quality, comprehensive blueprint that the user can immediately s
 	// Edit tasks via natural language
 	editTasksFlow := genkit.DefineFlow(g, "editTasksFlow",
 		func(ctx context.Context, input EditTasksFlowInput) (EditTasksFlowOutput, error) {
-			prompt := BuildEditTasksPrompt(input.UserID, input.Text, input.Timezone)
+			now := time.Now().UTC().Format(time.RFC3339)
+
+			userID, err := primitive.ObjectIDFromHex(input.UserID)
+			if err != nil {
+				return EditTasksFlowOutput{}, fmt.Errorf("invalid user ID: %w", err)
+			}
+
+			categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+			if err != nil {
+				return EditTasksFlowOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+			}
+
+			prompt := fmt.Sprintf(`You are a task editing assistant. The user wants to edit one or more of their tasks or recurring templates.
+
+The user's existing workspaces and categories:
+%s
+
+STEP 1: Call getUserActiveTasks with userId "%s" and a query keyword extracted from the user's instruction to find the relevant tasks. If the instruction is broad (e.g., "change all my tasks"), call it without a query to get a slim overview of all tasks.
+STEP 2: Identify which item(s) the user is referring to by matching their description to content/notes.
+         If the user mentions something recurring or a "template", look in templates first.
+STEP 3: Construct edit instructions for each matched item.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an EditTasksFlowOutput with two arrays:
+- instructions: edits for regular tasks. Each entry must have:
+    - taskId: exact hex ID from the results
+    - categoryId: exact hex categoryId from the results
+    - updates: only include fields that should change
+- templateInstructions: edits for recurring templates. Each entry must have:
+    - taskId: exact hex ID from the results
+    - categoryId: exact hex categoryId from the results
+    - updates: only include fields that should change
+
+For time fields in updates:
+    - Omit entirely to leave unchanged
+    - ISO8601 string to set a new value (interpret relative times like "next Friday" using current time + timezone)
+    - Empty string "" to explicitly clear/remove the field
+
+If the user's instruction doesn't match anything, return empty arrays for both.`,
+				categorySummary, input.UserID, now, input.Timezone, input.Text)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.EditTasks")
 			defer span.End()
@@ -285,13 +403,79 @@ Generate a high-quality, comprehensive blueprint that the user can immediately s
 	// then deletes (destructive, needs user confirmation), then creates (additive, needs preview).
 	intentRouterFlow := genkit.DefineFlow(g, "intentRouterFlow",
 		func(ctx context.Context, input IntentRouterInput) (IntentRouterOutput, error) {
-			prompt := BuildIntentRouterPrompt(input.UserID, input.Text, input.Timezone)
+			now := time.Now().UTC().Format(time.RFC3339)
+
+			userID, err := primitive.ObjectIDFromHex(input.UserID)
+			if err != nil {
+				return IntentRouterOutput{}, fmt.Errorf("invalid user ID: %w", err)
+			}
+
+			categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+			if err != nil {
+				return IntentRouterOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+			}
+
+			prompt := fmt.Sprintf(`You are a task management assistant. The user has given you a natural language instruction that may contain one or more operations: creating new tasks, editing existing tasks, or deleting existing tasks.
+
+The user's existing workspaces and categories:
+%s
+
+STEP 1: If the instruction involves editing or deleting specific tasks, call getUserActiveTasks with userId "%s" and a query keyword to find the relevant tasks. If the instruction is broad, call it without a query for a slim overview.
+STEP 2: Decompose the user's instruction into one or more typed operations.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+TEXT NORMALIZATION (apply to all task content you create):
+- Fix capitalization: sentence case for task names ("buy groceries" -> "Buy groceries")
+- Remove filler words from voice input (um, uh, like, you know, so basically, i guess)
+- Keep the user's phrasing — do NOT significantly rewrite or paraphrase their words
+- Split compound sentences into separate tasks when they describe distinct actions
+  Example: "call mom and also buy groceries" -> two tasks: "Call mom", "Buy groceries"
+- Infer deadlines from context: "finish the report by friday" -> set deadline to this Friday
+- Infer priorities from urgency cues: "urgently fix the bug" -> priority 3, "maybe clean my desk" -> priority 1
+- When no priority cue exists, default to priority 2
+- When no deadline is mentioned, omit it — do not guess
+
+Return an IntentRouterOutput with an "ops" array. Each element must have:
+- "type": one of "create", "edit", or "delete"
+- Exactly one payload field matching the type:
+  - For "create": populate "createPayload" with:
+      { "categories": [...new categories with tasks...], "tasks": [...tasks for existing categories...] }
+      Use the categoryIds from the list above when assigning tasks to existing categories.
+  - For "edit": populate "editPayload" with:
+      { "instructions": [...], "templateInstructions": [...] }
+      Use exact hex IDs from getUserActiveTasks results.
+  - For "delete": populate "deletePayload" with query filters to match the tasks the user wants to delete.
+      ONLY these fields are allowed — do NOT include any other fields:
+        - "categoryIds": string array of category IDs (from the list above)
+        - "priorities": integer array of priority values (1=low, 2=medium, 3=high)
+        - "deadlineFrom": ISO8601 datetime string (start of deadline range, optional)
+        - "deadlineTo": ISO8601 datetime string (end of deadline range, optional)
+        - "startTimeFrom": ISO8601 datetime string (start of start-time range, optional)
+        - "startTimeTo": ISO8601 datetime string (end of start-time range, optional)
+        - "hasDeadline": boolean (true = only tasks with a deadline, optional)
+        - "hasStartTime": boolean (true = only scheduled tasks, optional)
+        - "sortBy": one of "timestamp", "priority", "value", "deadline" (optional)
+        - "sortDir": -1 (newest first) or 1 (oldest first) (optional)
+      IMPORTANT: Do NOT include "taskIds", "ids", "taskId", or any direct task identifiers.
+
+ORDERING RULES (important):
+1. Edit operations first (non-destructive, applied immediately server-side)
+2. Delete operations second (destructive, user will confirm in UI)
+3. Create operations last (additive, user will preview in UI)
+
+If the instruction contains only one type of operation, return a single-element "ops" array.
+If no matching tasks are found for an edit or delete, return an empty "ops" array rather than guessing.
+Only include operations that are clearly implied by the user's instruction.`,
+				categorySummary, input.UserID, now, input.Timezone, input.Text)
 
 			ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.IntentRouter")
 			defer span.End()
 			resp, _, err := genkit.GenerateData[IntentRouterOutput](ctx, g,
 				ai.WithPrompt(prompt),
-				ai.WithTools(tools.GetUserActiveTasks, tools.GetUserCategories),
+				ai.WithTools(tools.GetUserActiveTasks),
 			)
 			if err != nil {
 				span.RecordError(err)

--- a/backend/internal/gemini/flows.go
+++ b/backend/internal/gemini/flows.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	Category "github.com/abhikaboy/Kindred/internal/handlers/category"
 	"github.com/abhikaboy/Kindred/internal/handlers/task"
 	"github.com/firebase/genkit/go/ai"
 	"github.com/firebase/genkit/go/core"
@@ -27,7 +28,7 @@ type FlowSet struct {
 }
 
 // InitFlows initializes and registers all Genkit flows
-func InitFlows(g *genkit.Genkit, tools *ToolSet) *FlowSet {
+func InitFlows(g *genkit.Genkit, tools *ToolSet, categoryService *Category.Service) *FlowSet {
 	// Generate single task from description
 	generateTaskFlow := genkit.DefineFlow(g, "generateTaskFlow",
 		func(ctx context.Context, input GenerateTaskParams) (*task.CreateTaskParams, error) {

--- a/backend/internal/gemini/genkit.go
+++ b/backend/internal/gemini/genkit.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 
+	Category "github.com/abhikaboy/Kindred/internal/handlers/category"
 	"github.com/abhikaboy/Kindred/internal/unsplash"
 	"github.com/firebase/genkit/go/genkit"
 	"github.com/firebase/genkit/go/plugins/googlegenai"
@@ -20,8 +21,11 @@ func InitGenkit(collections map[string]*mongo.Collection, unsplashClient *unspla
 	// Initialize tools
 	tools := InitTools(g, collections, unsplashClient)
 
-	// Initialize flows with tools
-	flows := InitFlows(g, tools)
+	// Initialize category service for prompt injection
+	categoryService := Category.NewService(collections)
+
+	// Initialize flows with tools and category service
+	flows := InitFlows(g, tools, categoryService)
 
 	return &GeminiService{
 		Genkit:                           g,

--- a/backend/internal/gemini/prompts.go
+++ b/backend/internal/gemini/prompts.go
@@ -1,0 +1,131 @@
+package gemini
+
+import (
+	"fmt"
+	"time"
+)
+
+// BuildMultiTaskWithContextPrompt builds the prompt for multiTaskFromTextFlowWithContext.
+func BuildMultiTaskWithContextPrompt(userID, text, timezone string) string {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task organization assistant. Generate a set of categories and tasks based on the user's input text.
+
+IMPORTANT: Before creating categories, call the getUserCategories tool with userId "%s" to see what categories the user already has. Try to assign tasks to existing categories when appropriate, or create new categories only when needed.
+
+Current time: %s
+User input: %s
+
+Your response should include:
+1. categories: An array of category objects with "name" and "workspaceName" fields. New categories should include tasks in the tasks array.
+2. tasks: An array of categoryTaskPair objects, each with appropriate fields. The categoryId should be the ID of the existing category in the user's database. These are exlusively for tasks that belong to existing categories.
+
+When choosing category names, prefer existing categories from the user's database when the task fits. Only create new categories when the task doesn't match any existing category.`, userID, currentTime, text)
+}
+
+// BuildQueryTasksPrompt builds the prompt for queryTasksFlow.
+func BuildQueryTasksPrompt(userID, text, timezone string) string {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task search assistant. Convert the user's natural language query into structured filter parameters for searching their tasks.
+
+IMPORTANT: Call the getUserCategories tool with userId "%s" to see what categories/workspaces exist. Use the returned category IDs when the user refers to a specific category or workspace by name.
+
+Current time: %s
+User's timezone: %s
+
+User query: "%s"
+
+Return a TaskQueryFiltersOutput with the appropriate filters:
+- categoryIds: IDs of relevant categories (match by name from getUserCategories results). Leave empty if no specific category is mentioned.
+- priorities: relevant priority values (1=low, 2=medium, 3=high). E.g. [3] for "high priority", [1,2] for "low and medium priority".
+- deadlineFrom/deadlineTo: ISO8601 datetime range for deadline filter. E.g. for "due this week", set deadlineFrom to start of current week and deadlineTo to end of current week in the user's timezone.
+- startTimeFrom/startTimeTo: ISO8601 datetime range for start date filter.
+- hasDeadline: set to true if user says "with deadline" or "due", false if "without deadline".
+- hasStartTime: set to true if user says "scheduled" or "with start date", false if "unscheduled".
+- sortBy: appropriate sorting field (timestamp, priority, value, deadline). Default to "timestamp".
+- sortDir: -1 for "newest/latest/most recent", 1 for "oldest". Default to -1.
+
+Be precise with date ranges based on the user's timezone. Only set filters that are clearly implied by the query.`,
+		userID, currentTime, timezone, text)
+}
+
+// BuildEditTasksPrompt builds the prompt for editTasksFlow.
+func BuildEditTasksPrompt(userID, text, timezone string) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task editing assistant. The user wants to edit one or more of their tasks or recurring templates.
+
+STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and recurring templates.
+         The result contains two arrays: "tasks" (regular one-off tasks) and "templates" (recurring task templates).
+STEP 2: Identify which item(s) the user is referring to by matching their description to content/notes.
+         If the user mentions something recurring or a "template", look in templates first.
+STEP 3: Construct edit instructions for each matched item.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an EditTasksFlowOutput with two arrays:
+- instructions: edits for regular tasks. Each entry must have:
+    - taskId: exact hex ID from the "tasks" array
+    - categoryId: exact hex categoryId from the "tasks" array
+    - updates: only include fields that should change
+- templateInstructions: edits for recurring templates. Each entry must have:
+    - taskId: exact hex ID from the "templates" array
+    - categoryId: exact hex categoryId from the "templates" array
+    - updates: only include fields that should change
+
+For time fields in updates:
+    - Omit entirely to leave unchanged
+    - ISO8601 string to set a new value (interpret relative times like "next Friday" using current time + timezone)
+    - Empty string "" to explicitly clear/remove the field
+
+If the user's instruction doesn't match anything, return empty arrays for both.`,
+		userID, now, timezone, text)
+}
+
+// BuildIntentRouterPrompt builds the prompt for intentRouterFlow.
+func BuildIntentRouterPrompt(userID, text, timezone string) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task management assistant. The user has given you a natural language instruction that may contain one or more operations: creating new tasks, editing existing tasks, or deleting existing tasks.
+
+STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and templates (needed for edit and delete operations).
+STEP 2: Call getUserCategories with userId "%s" to see their existing categories and workspaces (needed for create operations).
+STEP 3: Decompose the user's instruction into one or more typed operations.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an IntentRouterOutput with an "ops" array. Each element must have:
+- "type": one of "create", "edit", or "delete"
+- Exactly one payload field matching the type:
+  - For "create": populate "createPayload" with the same structure as multiTaskFromTextFlowWithContext output:
+      { "categories": [...new categories with tasks...], "tasks": [...tasks for existing categories...] }
+      Use the categoryIds from getUserCategories when assigning tasks to existing categories.
+  - For "edit": populate "editPayload" with the same structure as editTasksFlow output:
+      { "instructions": [...], "templateInstructions": [...] }
+      Use exact hex IDs from getUserActiveTasks results.
+  - For "delete": populate "deletePayload" with query filters to match the tasks the user wants to delete.
+      ONLY these fields are allowed — do NOT include any other fields:
+        - "categoryIds": string array of category IDs (from getUserCategories)
+        - "priorities": integer array of priority values (1=low, 2=medium, 3=high)
+        - "deadlineFrom": ISO8601 datetime string (start of deadline range, optional)
+        - "deadlineTo": ISO8601 datetime string (end of deadline range, optional)
+        - "startTimeFrom": ISO8601 datetime string (start of start-time range, optional)
+        - "startTimeTo": ISO8601 datetime string (end of start-time range, optional)
+        - "hasDeadline": boolean (true = only tasks with a deadline, optional)
+        - "hasStartTime": boolean (true = only scheduled tasks, optional)
+        - "sortBy": one of "timestamp", "priority", "value", "deadline" (optional)
+        - "sortDir": -1 (newest first) or 1 (oldest first) (optional)
+      IMPORTANT: Do NOT include "taskIds", "ids", "taskId", or any direct task identifiers.
+      Use only the filter fields above to describe which tasks to delete.
+
+ORDERING RULES (important):
+1. Edit operations first (non-destructive, applied immediately server-side)
+2. Delete operations second (destructive, user will confirm in UI)
+3. Create operations last (additive, user will preview in UI)
+
+If the instruction contains only one type of operation, return a single-element "ops" array.
+If no matching tasks are found for an edit or delete, return an empty "ops" array rather than guessing.
+Only include operations that are clearly implied by the user's instruction.`,
+		userID, userID, now, timezone, text)
+}

--- a/backend/internal/gemini/tools.go
+++ b/backend/internal/gemini/tools.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	Category "github.com/abhikaboy/Kindred/internal/handlers/category"
@@ -202,72 +203,100 @@ func InitTools(g *genkit.Genkit, collections map[string]*mongo.Collection, unspl
 				return GetUserActiveTasksOutput{}, fmt.Errorf("invalid user ID: %w", err)
 			}
 
-			// Fetch categories — each category document embeds its tasks, so we get the
-			// correct categoryID from the parent document (avoids NilObjectID on older tasks
-			// that lack a stored categoryID field in the subdocument).
 			workspaces, err := categoryService.GetCategoriesByUser(userID)
 			if err != nil {
 				return GetUserActiveTasksOutput{}, fmt.Errorf("failed to fetch categories: %w", err)
 			}
 
-			output := GetUserActiveTasksOutput{
-				UserID: input.UserID,
-				Tasks:  make([]ActiveTaskInfo, 0),
-			}
+			hasQuery := strings.TrimSpace(input.Query) != ""
+			queryLower := strings.ToLower(strings.TrimSpace(input.Query))
 
-			for _, workspace := range workspaces {
-				for _, cat := range workspace.Categories {
-					for _, t := range cat.Tasks {
-						if len(output.Tasks) >= 200 {
-							break
-						}
+			output := GetUserActiveTasksOutput{UserID: input.UserID}
 
-						notes := t.Notes
-						if len(notes) > 200 {
-							notes = notes[:200]
+			if hasQuery {
+				// Targeted search: return full-detail matches, capped at 20
+				output.Tasks = make([]ActiveTaskInfo, 0)
+				for _, workspace := range workspaces {
+					for _, cat := range workspace.Categories {
+						for _, t := range cat.Tasks {
+							if len(output.Tasks) >= 20 {
+								break
+							}
+							contentLower := strings.ToLower(t.Content)
+							notesLower := strings.ToLower(t.Notes)
+							if !strings.Contains(contentLower, queryLower) && !strings.Contains(notesLower, queryLower) {
+								continue
+							}
+							notes := t.Notes
+							if len(notes) > 200 {
+								notes = notes[:200]
+							}
+							info := ActiveTaskInfo{
+								ID:             t.ID.Hex(),
+								CategoryID:     cat.ID.Hex(),
+								CategoryName:   cat.Name,
+								Content:        t.Content,
+								Priority:       t.Priority,
+								Value:          t.Value,
+								Recurring:      t.Recurring,
+								RecurFrequency: t.RecurFrequency,
+								Active:         t.Active,
+								Notes:          notes,
+							}
+							if t.Deadline != nil {
+								info.Deadline = t.Deadline.Format(time.RFC3339)
+							}
+							if t.StartDate != nil {
+								info.StartDate = t.StartDate.Format(time.RFC3339)
+							}
+							if t.StartTime != nil {
+								info.StartTime = t.StartTime.Format(time.RFC3339)
+							}
+							if t.TemplateID != nil {
+								info.TemplateID = t.TemplateID.Hex()
+							}
+							output.Tasks = append(output.Tasks, info)
 						}
-
-						info := ActiveTaskInfo{
-							// CategoryID comes from the parent document — always correct.
-							ID:             t.ID.Hex(),
-							CategoryID:     cat.ID.Hex(),
-							CategoryName:   cat.Name,
-							Content:        t.Content,
-							Priority:       t.Priority,
-							Value:          t.Value,
-							Recurring:      t.Recurring,
-							RecurFrequency: t.RecurFrequency,
-							Active:         t.Active,
-							Notes:          notes,
+					}
+				}
+			} else {
+				// Broad fallback: return slim format for all tasks, capped at 200
+				output.SlimTasks = make([]SlimTaskInfo, 0)
+				for _, workspace := range workspaces {
+					for _, cat := range workspace.Categories {
+						for _, t := range cat.Tasks {
+							if len(output.SlimTasks) >= 200 {
+								break
+							}
+							slim := SlimTaskInfo{
+								ID:         t.ID.Hex(),
+								CategoryID: cat.ID.Hex(),
+								Content:    t.Content,
+								Priority:   t.Priority,
+							}
+							if t.Deadline != nil {
+								slim.Deadline = t.Deadline.Format(time.RFC3339)
+							}
+							output.SlimTasks = append(output.SlimTasks, slim)
 						}
-						if t.Deadline != nil {
-							info.Deadline = t.Deadline.Format(time.RFC3339)
-						}
-						if t.StartDate != nil {
-							info.StartDate = t.StartDate.Format(time.RFC3339)
-						}
-						if t.StartTime != nil {
-							info.StartTime = t.StartTime.Format(time.RFC3339)
-						}
-						if t.TemplateID != nil {
-							info.TemplateID = t.TemplateID.Hex()
-						}
-
-						output.Tasks = append(output.Tasks, info)
 					}
 				}
 			}
 
-			// Fetch recurring template tasks
+			// Fetch recurring templates
 			templates, err := taskService.GetTemplatesByUserWithCategory(userID)
 			if err != nil {
-				// Non-fatal: log and continue without templates
 				fmt.Printf("⚠️  getUserActiveTasks: failed to fetch templates: %v\n", err)
-			} else {
-				output.Templates = make([]ActiveTemplateInfo, 0, len(templates))
-				for i, tmpl := range templates {
-					if i >= 200 {
+			} else if hasQuery {
+				output.Templates = make([]ActiveTemplateInfo, 0)
+				for _, tmpl := range templates {
+					if len(output.Templates) >= 20 {
 						break
+					}
+					contentLower := strings.ToLower(tmpl.Content)
+					notesLower := strings.ToLower(tmpl.Notes)
+					if !strings.Contains(contentLower, queryLower) && !strings.Contains(notesLower, queryLower) {
+						continue
 					}
 					notes := tmpl.Notes
 					if len(notes) > 200 {
@@ -296,10 +325,30 @@ func InitTools(g *genkit.Genkit, collections map[string]*mongo.Collection, unspl
 					}
 					output.Templates = append(output.Templates, info)
 				}
+			} else {
+				output.SlimTemplates = make([]SlimTemplateInfo, 0)
+				for i, tmpl := range templates {
+					if i >= 200 {
+						break
+					}
+					slim := SlimTemplateInfo{
+						ID:         tmpl.ID.Hex(),
+						CategoryID: tmpl.CategoryID.Hex(),
+						Content:    tmpl.Content,
+						Priority:   tmpl.Priority,
+					}
+					if tmpl.Deadline != nil {
+						slim.Deadline = tmpl.Deadline.Format(time.RFC3339)
+					}
+					output.SlimTemplates = append(output.SlimTemplates, slim)
+				}
 			}
 
-			output.Total = len(output.Tasks) + len(output.Templates)
-			fmt.Printf("🔍 getUserActiveTasks called for user: %s, found %d tasks + %d templates\n", input.UserID, len(output.Tasks), len(output.Templates))
+			totalTasks := len(output.Tasks) + len(output.SlimTasks)
+			totalTemplates := len(output.Templates) + len(output.SlimTemplates)
+			output.Total = totalTasks + totalTemplates
+			fmt.Printf("🔍 getUserActiveTasks called for user: %s (query=%q), found %d tasks + %d templates\n",
+				input.UserID, input.Query, totalTasks, totalTemplates)
 			return output, nil
 		},
 	)

--- a/backend/internal/gemini/types.go
+++ b/backend/internal/gemini/types.go
@@ -205,14 +205,17 @@ type TaskQueryFiltersOutput struct {
 // --- getUserActiveTasks types ---
 
 type GetUserActiveTasksInput struct {
-	UserID string `json:"userId" jsonschema_description:"The user's ObjectID as a hex string"`
+	UserID string `json:"userId"          jsonschema_description:"The user's ObjectID as a hex string"`
+	Query  string `json:"query,omitempty" jsonschema_description:"Optional keyword search. If provided, returns only tasks whose content or notes match (case-insensitive, max 20 results with full detail). If omitted, returns all tasks in slim format."`
 }
 
 type GetUserActiveTasksOutput struct {
-	UserID    string               `json:"userId"`
-	Tasks     []ActiveTaskInfo     `json:"tasks"     jsonschema_description:"Regular (non-recurring) active tasks"`
-	Templates []ActiveTemplateInfo `json:"templates" jsonschema_description:"Recurring template tasks"`
-	Total     int                  `json:"total"`
+	UserID        string               `json:"userId"`
+	Tasks         []ActiveTaskInfo     `json:"tasks,omitempty"         jsonschema_description:"Full-detail tasks (populated when query is provided)"`
+	Templates     []ActiveTemplateInfo `json:"templates,omitempty"     jsonschema_description:"Full-detail templates (populated when query is provided)"`
+	SlimTasks     []SlimTaskInfo       `json:"slimTasks,omitempty"     jsonschema_description:"Slim tasks with minimal fields (populated when no query)"`
+	SlimTemplates []SlimTemplateInfo   `json:"slimTemplates,omitempty" jsonschema_description:"Slim templates with minimal fields (populated when no query)"`
+	Total         int                  `json:"total"`
 }
 
 // ActiveTaskInfo is a Genkit-safe representation of a task with string IDs.
@@ -251,6 +254,25 @@ type ActiveTemplateInfo struct {
 	StartDate      string  `json:"startDate,omitempty"      jsonschema_description:"ISO8601 start date, absent if none"`
 	StartTime      string  `json:"startTime,omitempty"      jsonschema_description:"ISO8601 start time, absent if none"`
 	Notes          string  `json:"notes,omitempty"          jsonschema_description:"Template notes (truncated to 200 chars)"`
+}
+
+// SlimTaskInfo is a minimal representation of a task for broad/unfocused queries.
+// Contains just enough for the model to identify tasks without consuming excessive tokens.
+type SlimTaskInfo struct {
+	ID         string `json:"id"                    jsonschema_description:"Hex ObjectID of the task"`
+	CategoryID string `json:"categoryId"            jsonschema_description:"Hex ObjectID of the containing category"`
+	Content    string `json:"content"               jsonschema_description:"Task title / description"`
+	Priority   int    `json:"priority"              jsonschema_description:"1=low, 2=medium, 3=high"`
+	Deadline   string `json:"deadline,omitempty"    jsonschema_description:"ISO8601 deadline, absent if none"`
+}
+
+// SlimTemplateInfo is a minimal representation of a recurring template for broad queries.
+type SlimTemplateInfo struct {
+	ID         string `json:"id"                    jsonschema_description:"Hex ObjectID of the template"`
+	CategoryID string `json:"categoryId"            jsonschema_description:"Hex ObjectID of the containing category"`
+	Content    string `json:"content"               jsonschema_description:"Template title / description"`
+	Priority   int    `json:"priority"              jsonschema_description:"1=low, 2=medium, 3=high"`
+	Deadline   string `json:"deadline,omitempty"    jsonschema_description:"ISO8601 deadline, absent if none"`
 }
 
 // --- Edit tasks flow types ---

--- a/backend/internal/handlers/category/service.go
+++ b/backend/internal/handlers/category/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/abhikaboy/Kindred/xutils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -390,6 +391,33 @@ func (s *Service) UpsertWorkspaceMeta(name string, user primitive.ObjectID, icon
 			slog.String("error", err.Error()))
 	}
 	return err
+}
+
+// GetCategoryNamesSummary returns a lightweight text summary of a user's
+// workspace and category structure, suitable for direct injection into an
+// LLM prompt. Each category includes its hex ObjectID so the model can
+// reference it in structured output.
+func (s *Service) GetCategoryNamesSummary(userID primitive.ObjectID) (string, error) {
+	workspaces, err := s.GetCategoriesByUser(userID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch categories: %w", err)
+	}
+
+	if len(workspaces) == 0 {
+		return "No workspaces or categories found.", nil
+	}
+
+	var b strings.Builder
+	for i, ws := range workspaces {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "Workspace %q:\n", ws.Name)
+		for _, cat := range ws.Categories {
+			fmt.Fprintf(&b, "  - %s (id: %s)\n", cat.Name, cat.ID.Hex())
+		}
+	}
+	return b.String(), nil
 }
 
 // UpdateWorkspaceMeta updates only the provided icon/color fields on a workspace document

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -404,6 +404,54 @@ func (s *CategoryServiceTestSuite) TestDeleteWorkspace_WithRecurringTasks() {
 }
 
 // ========================================
+// GetCategoryNamesSummary Tests
+// ========================================
+
+func (s *CategoryServiceTestSuite) TestGetCategoryNamesSummary_WithCategories() {
+	user := s.GetUser(0)
+
+	// Create categories in different workspaces
+	cat1 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Errands",
+		User:          user.ID,
+		WorkspaceName: "Personal",
+		Tasks:         []types.TaskDocument{},
+	}
+	cat2 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Meetings",
+		User:          user.ID,
+		WorkspaceName: "Work",
+		Tasks:         []types.TaskDocument{},
+	}
+
+	_, err := s.service.CreateCategory(cat1)
+	s.NoError(err)
+	_, err = s.service.CreateCategory(cat2)
+	s.NoError(err)
+
+	summary, err := s.service.GetCategoryNamesSummary(user.ID)
+
+	s.NoError(err)
+	s.Contains(summary, "Personal")
+	s.Contains(summary, "Errands")
+	s.Contains(summary, cat1.ID.Hex())
+	s.Contains(summary, "Work")
+	s.Contains(summary, "Meetings")
+	s.Contains(summary, cat2.ID.Hex())
+}
+
+func (s *CategoryServiceTestSuite) TestGetCategoryNamesSummary_NoCategories() {
+	newUserID := primitive.NewObjectID()
+
+	summary, err := s.service.GetCategoryNamesSummary(newUserID)
+
+	s.NoError(err)
+	s.Equal("No workspaces or categories found.", summary)
+}
+
+// ========================================
 // RenameWorkspace Tests
 // ========================================
 

--- a/backend/internal/handlers/task/sse_writer.go
+++ b/backend/internal/handlers/task/sse_writer.go
@@ -1,0 +1,34 @@
+package task
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+)
+
+// SSEWriter writes Server-Sent Events to a buffered writer with flushing.
+type SSEWriter struct {
+	w *bufio.Writer
+}
+
+// NewSSEWriter wraps a bufio.Writer for SSE output.
+func NewSSEWriter(w *bufio.Writer) *SSEWriter {
+	return &SSEWriter{w: w}
+}
+
+// Send writes a single SSE event (event + JSON-encoded data) and flushes.
+func (s *SSEWriter) Send(event string, data interface{}) error {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("sse marshal: %w", err)
+	}
+	if _, err := fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", event, jsonBytes); err != nil {
+		return err
+	}
+	return s.w.Flush()
+}
+
+// SendError writes an error event and flushes.
+func (s *SSEWriter) SendError(message string) error {
+	return s.Send("error", map[string]string{"message": message})
+}

--- a/backend/internal/handlers/task/stream_handlers.go
+++ b/backend/internal/handlers/task/stream_handlers.go
@@ -1,0 +1,458 @@
+package task
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// NewStreamHandler creates a Handler for SSE streaming routes.
+func NewStreamHandler(collections map[string]*mongo.Collection, geminiService any) *Handler {
+	service := newService(collections)
+	return &Handler{
+		service:       service,
+		geminiService: geminiService,
+	}
+}
+
+// nlpStreamBody is the common request body for all NLP streaming endpoints.
+type nlpStreamBody struct {
+	Text     string `json:"text"`
+	Timezone string `json:"timezone,omitempty"`
+}
+
+// parseNLPBody parses the common text/timezone body from a Fiber request.
+func parseNLPBody(c *fiber.Ctx) (nlpStreamBody, error) {
+	var body nlpStreamBody
+	if err := c.BodyParser(&body); err != nil {
+		return body, err
+	}
+	if body.Text == "" {
+		return body, fmt.Errorf("text field is required")
+	}
+	if body.Timezone == "" {
+		body.Timezone = "America/New_York"
+	}
+	return body, nil
+}
+
+// consumeCredit consumes one NL credit and returns a non-nil error (with HTTP response already
+// written) if it fails. The caller should return nil after this returns an error.
+func (h *Handler) consumeNLCredit(c *fiber.Ctx, ctx context.Context, userObjID primitive.ObjectID, userID string) error {
+	err := h.service.Users.ConsumeCredit(ctx, userObjID, types.CreditTypeNaturalLanguage)
+	if err != nil {
+		if err == types.ErrInsufficientCredits {
+			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{
+				"error": "Insufficient credits. You need at least 1 natural language credit to use this feature.",
+			})
+		}
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to consume credit",
+			slog.String("userID", userID),
+			slog.String("error", err.Error()))
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{
+			"error": "Unable to process your credit. Please try again later.",
+		})
+	}
+	return nil
+}
+
+// refundNLCredit refunds one NL credit after a flow failure, logging but not surfacing errors.
+func (h *Handler) refundNLCredit(ctx context.Context, userObjID primitive.ObjectID, userID string) {
+	if refundErr := h.service.Users.AddCredits(ctx, userObjID, types.CreditTypeNaturalLanguage, 1); refundErr != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to refund credit after AI failure",
+			slog.String("userID", userID),
+			slog.String("refundError", refundErr.Error()))
+	} else {
+		slog.LogAttrs(ctx, slog.LevelInfo, "Credit successfully refunded",
+			slog.String("userID", userID))
+	}
+}
+
+// setSSEHeaders sets the required SSE response headers.
+func setSSEHeaders(c *fiber.Ctx) {
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+}
+
+// StreamIntentNaturalLanguage handles POST /api/v1/user/tasks/natural-language/intent/stream
+func (h *Handler) StreamIntentNaturalLanguage(c *fiber.Ctx) error {
+	body, err := parseNLPBody(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	ctx := c.UserContext()
+
+	if err := h.consumeNLCredit(c, ctx, userObjID, userID); err != nil {
+		return nil
+	}
+
+	setSSEHeaders(c)
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		sse := NewSSEWriter(w)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming intent NL routing",
+			slog.String("userID", userID),
+			slog.String("inputText", body.Text),
+			slog.String("timezone", body.Timezone))
+
+		intentOutput, err := h.callGeminiIntentFlow(ctx, userID, body.Text, body.Timezone)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini intent flow failed, retrying",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+
+			intentOutput, err = h.callGeminiIntentFlow(ctx, userID, body.Text, body.Timezone)
+			if err != nil {
+				h.refundNLCredit(ctx, userObjID, userID)
+				sse.SendError("Failed to process natural language intent with AI after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Processing results..."})
+
+		var responseOps []IntentOpResponse
+
+		for _, op := range intentOutput.Ops {
+			switch op.Type {
+			case "edit":
+				if op.EditPayload == nil {
+					continue
+				}
+				editedTasks, editedTemplates, totalEdited := h.applyEditInstructions(ctx, userObjID, userID, op.EditPayload)
+				responseOps = append(responseOps, IntentOpResponse{
+					Type: "edit",
+					EditResult: &EditResultResponse{
+						Tasks:       editedTasks,
+						Templates:   editedTemplates,
+						EditedCount: totalEdited,
+					},
+				})
+
+			case "delete":
+				if op.DeletePayload == nil {
+					continue
+				}
+				filters, err := convertQueryOutput(op.DeletePayload)
+				if err != nil {
+					slog.LogAttrs(ctx, slog.LevelWarn, "Failed to convert delete query output",
+						slog.String("error", err.Error()))
+					continue
+				}
+				tasks, err := h.service.QueryTasksByUser(userObjID, filters)
+				if err != nil {
+					slog.LogAttrs(ctx, slog.LevelWarn, "Failed to query tasks for delete op",
+						slog.String("error", err.Error()))
+					continue
+				}
+				responseOps = append(responseOps, IntentOpResponse{
+					Type:        "delete",
+					DeleteTasks: tasks,
+				})
+
+			case "create":
+				if op.CreatePayload == nil {
+					continue
+				}
+				responseOps = append(responseOps, IntentOpResponse{
+					Type:          "create",
+					CreatePreview: op.CreatePayload,
+				})
+			}
+		}
+
+		if responseOps == nil {
+			responseOps = []IntentOpResponse{}
+		}
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Streaming intent NL routing completed",
+			slog.String("userID", userID),
+			slog.Int("opCount", len(responseOps)))
+
+		sse.Send("result", map[string]interface{}{"ops": responseOps})
+	})
+
+	return nil
+}
+
+// StreamCreateNaturalLanguage handles POST /api/v1/user/tasks/natural-language/stream
+func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
+	body, err := parseNLPBody(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	ctx := c.UserContext()
+
+	if err := h.consumeNLCredit(c, ctx, userObjID, userID); err != nil {
+		return nil
+	}
+
+	setSSEHeaders(c)
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		sse := NewSSEWriter(w)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task creation",
+			slog.String("userID", userID),
+			slog.String("inputText", body.Text),
+			slog.String("timezone", body.Timezone))
+
+		result, err := h.callGeminiFlow(ctx, userID, body.Text, body.Timezone)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini flow failed, retrying",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+
+			result, err = h.callGeminiFlow(ctx, userID, body.Text, body.Timezone)
+			if err != nil {
+				h.refundNLCredit(ctx, userObjID, userID)
+				sse.SendError("Failed to process natural language with AI after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Creating tasks..."})
+
+		newCategoryTasks, newCategoryMetadata, categoriesCreated, newCategoryTaskCount, err := h.processNewCategories(ctx, result.Categories, userObjID)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "Failed to process new categories",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.SendError(err.Error())
+			return
+		}
+
+		existingCategoryTasks, existingCategoryTaskCount, err := h.processExistingCategoryTasks(ctx, result.Tasks, userObjID)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelError, "Failed to process existing category tasks",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.SendError(err.Error())
+			return
+		}
+
+		allTasks := append(newCategoryTasks, existingCategoryTasks...)
+		totalTasks := newCategoryTaskCount + existingCategoryTaskCount
+
+		var message string
+		if totalTasks == 0 {
+			message = "No valid tasks could be created from the provided text"
+		} else if categoriesCreated > 0 {
+			message = fmt.Sprintf("Successfully created %d tasks in %d new categories", totalTasks, categoriesCreated)
+		} else {
+			message = fmt.Sprintf("Successfully created %d tasks in existing categories", totalTasks)
+		}
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Streaming NL task creation completed",
+			slog.String("userID", userID),
+			slog.Int("totalTasks", totalTasks),
+			slog.Int("categoriesCreated", categoriesCreated))
+
+		sse.Send("result", map[string]interface{}{
+			"categoriesCreated": categoriesCreated,
+			"newCategories":     newCategoryMetadata,
+			"tasksCreated":      totalTasks,
+			"tasks":             allTasks,
+			"message":           message,
+		})
+	})
+
+	return nil
+}
+
+// StreamQueryNaturalLanguage handles POST /api/v1/user/tasks/natural-language/query/stream
+func (h *Handler) StreamQueryNaturalLanguage(c *fiber.Ctx) error {
+	body, err := parseNLPBody(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	ctx := c.UserContext()
+
+	if err := h.consumeNLCredit(c, ctx, userObjID, userID); err != nil {
+		return nil
+	}
+
+	setSSEHeaders(c)
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		sse := NewSSEWriter(w)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your query..."})
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task query",
+			slog.String("userID", userID),
+			slog.String("inputText", body.Text),
+			slog.String("timezone", body.Timezone))
+
+		queryOutput, err := h.callGeminiQueryFlow(ctx, userID, body.Text, body.Timezone)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini query flow failed, retrying",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+
+			queryOutput, err = h.callGeminiQueryFlow(ctx, userID, body.Text, body.Timezone)
+			if err != nil {
+				h.refundNLCredit(ctx, userObjID, userID)
+				sse.SendError("Failed to process natural language query with AI after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Querying tasks..."})
+
+		filters, err := convertQueryOutput(queryOutput)
+		if err != nil {
+			slog.Error("Failed to parse AI query response", "userId", userID, "error", err)
+			sse.SendError("The AI response could not be interpreted. Please try rephrasing your query.")
+			return
+		}
+
+		tasks, err := h.service.QueryTasksByUser(userObjID, filters)
+		if err != nil {
+			slog.Error("Failed to execute NL task query", "userId", userID, "error", err)
+			sse.SendError("Unable to query tasks due to a server error. Please try again.")
+			return
+		}
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Streaming NL task query completed",
+			slog.String("userID", userID),
+			slog.Int("taskCount", len(tasks)))
+
+		sse.Send("result", map[string]interface{}{
+			"tasks": tasks,
+			"query": filters,
+		})
+	})
+
+	return nil
+}
+
+// StreamEditNaturalLanguage handles POST /api/v1/user/tasks/natural-language/edit/stream
+func (h *Handler) StreamEditNaturalLanguage(c *fiber.Ctx) error {
+	body, err := parseNLPBody(c)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	ctx := c.UserContext()
+
+	if err := h.consumeNLCredit(c, ctx, userObjID, userID); err != nil {
+		return nil
+	}
+
+	setSSEHeaders(c)
+
+	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+		sse := NewSSEWriter(w)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your edit..."})
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task edit",
+			slog.String("userID", userID),
+			slog.String("inputText", body.Text),
+			slog.String("timezone", body.Timezone))
+
+		editOutput, err := h.callGeminiEditFlow(ctx, userID, body.Text, body.Timezone)
+		if err != nil {
+			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini edit flow failed, retrying",
+				slog.String("userID", userID),
+				slog.String("error", err.Error()))
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+
+			editOutput, err = h.callGeminiEditFlow(ctx, userID, body.Text, body.Timezone)
+			if err != nil {
+				h.refundNLCredit(ctx, userObjID, userID)
+				sse.SendError("Failed to process natural language edit with AI after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Applying edits..."})
+
+		editedTasks, editedTemplates, totalEdited := h.applyEditInstructions(ctx, userObjID, userID, editOutput)
+
+		var message string
+		switch totalEdited {
+		case 0:
+			message = "No matching tasks found"
+		case 1:
+			message = "Successfully edited 1 task"
+		default:
+			message = fmt.Sprintf("Successfully edited %d tasks", totalEdited)
+		}
+
+		slog.LogAttrs(ctx, slog.LevelInfo, "Streaming NL task edit completed",
+			slog.String("userID", userID),
+			slog.Int("editedTasks", len(editedTasks)),
+			slog.Int("editedTemplates", len(editedTemplates)))
+
+		sse.Send("result", map[string]interface{}{
+			"tasks":       editedTasks,
+			"templates":   editedTemplates,
+			"editedCount": totalEdited,
+			"message":     message,
+		})
+	})
+
+	return nil
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -144,6 +144,14 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	activity.Routes(api, collections)
 	profile.Routes(api, collections)
 	task.Routes(api, collections, geminiService)
+
+	// SSE streaming routes for NLP flows (raw Fiber, bypass Huma)
+	taskStreamHandler := task.NewStreamHandler(collections, geminiService)
+	app.Post("/api/v1/user/tasks/natural-language/intent/stream", taskStreamHandler.StreamIntentNaturalLanguage)
+	app.Post("/api/v1/user/tasks/natural-language/stream", taskStreamHandler.StreamCreateNaturalLanguage)
+	app.Post("/api/v1/user/tasks/natural-language/query/stream", taskStreamHandler.StreamQueryNaturalLanguage)
+	app.Post("/api/v1/user/tasks/natural-language/edit/stream", taskStreamHandler.StreamEditNaturalLanguage)
+
 	connection.Routes(api, collections)
 	group.RegisterRoutes(api, collections)
 	post.Routes(api, collections)

--- a/docs/superpowers/plans/2026-05-16-genkit-optimization.md
+++ b/docs/superpowers/plans/2026-05-16-genkit-optimization.md
@@ -1,0 +1,909 @@
+# Genkit Model Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Genkit flows faster and smarter by injecting category context directly into prompts, adding keyword-filtered task search, and normalizing voice input.
+
+**Architecture:** Replace tool-call-based category fetching with a direct service call that injects a text summary into prompts. Upgrade `getUserActiveTasks` tool to support optional keyword search (returning full detail) with a slim fallback for broad queries. Add text normalization rules to task-creation prompts.
+
+**Tech Stack:** Go, Genkit (Firebase), MongoDB, Gemini 2.5 Flash
+
+---
+
+### Task 1: Add `GetCategoryNamesSummary` to Category Service
+
+**Files:**
+- Modify: `backend/internal/handlers/category/service.go` (add method at end)
+- Modify: `backend/internal/handlers/category/service_test.go` (add tests at end)
+
+- [ ] **Step 1: Write the failing test for `GetCategoryNamesSummary`**
+
+Add to the end of `backend/internal/handlers/category/service_test.go`:
+
+```go
+// ========================================
+// GetCategoryNamesSummary Tests
+// ========================================
+
+func (s *CategoryServiceTestSuite) TestGetCategoryNamesSummary_WithCategories() {
+	user := s.GetUser(0)
+
+	// Create categories in different workspaces
+	cat1 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Errands",
+		User:          user.ID,
+		WorkspaceName: "Personal",
+		Tasks:         []types.TaskDocument{},
+	}
+	cat2 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Meetings",
+		User:          user.ID,
+		WorkspaceName: "Work",
+		Tasks:         []types.TaskDocument{},
+	}
+
+	_, err := s.service.CreateCategory(cat1)
+	s.NoError(err)
+	_, err = s.service.CreateCategory(cat2)
+	s.NoError(err)
+
+	summary, err := s.service.GetCategoryNamesSummary(user.ID)
+
+	s.NoError(err)
+	s.Contains(summary, "Personal")
+	s.Contains(summary, "Errands")
+	s.Contains(summary, cat1.ID.Hex())
+	s.Contains(summary, "Work")
+	s.Contains(summary, "Meetings")
+	s.Contains(summary, cat2.ID.Hex())
+}
+
+func (s *CategoryServiceTestSuite) TestGetCategoryNamesSummary_NoCategories() {
+	newUserID := primitive.NewObjectID()
+
+	summary, err := s.service.GetCategoryNamesSummary(newUserID)
+
+	s.NoError(err)
+	s.Equal("No workspaces or categories found.", summary)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && go test ./internal/handlers/category/ -run "TestCategoryService/TestGetCategoryNamesSummary" -v`
+Expected: FAIL — `GetCategoryNamesSummary` not defined
+
+- [ ] **Step 3: Implement `GetCategoryNamesSummary`**
+
+Add to the end of `backend/internal/handlers/category/service.go`:
+
+```go
+// GetCategoryNamesSummary returns a lightweight text summary of a user's
+// workspace and category structure, suitable for direct injection into an
+// LLM prompt. Each category includes its hex ObjectID so the model can
+// reference it in structured output.
+func (s *Service) GetCategoryNamesSummary(userID primitive.ObjectID) (string, error) {
+	workspaces, err := s.GetCategoriesByUser(userID)
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch categories: %w", err)
+	}
+
+	if len(workspaces) == 0 {
+		return "No workspaces or categories found.", nil
+	}
+
+	var b strings.Builder
+	for i, ws := range workspaces {
+		if i > 0 {
+			b.WriteByte('\n')
+		}
+		fmt.Fprintf(&b, "Workspace %q:\n", ws.Name)
+		for _, cat := range ws.Categories {
+			fmt.Fprintf(&b, "  - %s (id: %s)\n", cat.Name, cat.ID.Hex())
+		}
+	}
+	return b.String(), nil
+}
+```
+
+Add `"strings"` to the import block at the top of `service.go` (alongside `"fmt"`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && go test ./internal/handlers/category/ -run "TestCategoryService/TestGetCategoryNamesSummary" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/handlers/category/service.go backend/internal/handlers/category/service_test.go
+git commit -m "feat(category): add GetCategoryNamesSummary for prompt injection"
+```
+
+---
+
+### Task 2: Add Slim Types and Query Param to `GetUserActiveTasksInput`
+
+**Files:**
+- Modify: `backend/internal/gemini/types.go` (add slim types, update input/output structs)
+
+- [ ] **Step 1: Add `SlimTaskInfo` and `SlimTemplateInfo` types**
+
+Add after the `ActiveTemplateInfo` struct (after line 254) in `backend/internal/gemini/types.go`:
+
+```go
+// SlimTaskInfo is a minimal representation of a task for broad/unfocused queries.
+// Contains just enough for the model to identify tasks without consuming excessive tokens.
+type SlimTaskInfo struct {
+	ID         string `json:"id"                    jsonschema_description:"Hex ObjectID of the task"`
+	CategoryID string `json:"categoryId"            jsonschema_description:"Hex ObjectID of the containing category"`
+	Content    string `json:"content"               jsonschema_description:"Task title / description"`
+	Priority   int    `json:"priority"              jsonschema_description:"1=low, 2=medium, 3=high"`
+	Deadline   string `json:"deadline,omitempty"    jsonschema_description:"ISO8601 deadline, absent if none"`
+}
+
+// SlimTemplateInfo is a minimal representation of a recurring template for broad queries.
+type SlimTemplateInfo struct {
+	ID         string `json:"id"                    jsonschema_description:"Hex ObjectID of the template"`
+	CategoryID string `json:"categoryId"            jsonschema_description:"Hex ObjectID of the containing category"`
+	Content    string `json:"content"               jsonschema_description:"Template title / description"`
+	Priority   int    `json:"priority"              jsonschema_description:"1=low, 2=medium, 3=high"`
+	Deadline   string `json:"deadline,omitempty"    jsonschema_description:"ISO8601 deadline, absent if none"`
+}
+```
+
+- [ ] **Step 2: Add `Query` field to `GetUserActiveTasksInput`**
+
+Update the `GetUserActiveTasksInput` struct in `types.go` (around line 207) from:
+
+```go
+type GetUserActiveTasksInput struct {
+	UserID string `json:"userId" jsonschema_description:"The user's ObjectID as a hex string"`
+}
+```
+
+To:
+
+```go
+type GetUserActiveTasksInput struct {
+	UserID string `json:"userId"          jsonschema_description:"The user's ObjectID as a hex string"`
+	Query  string `json:"query,omitempty" jsonschema_description:"Optional keyword search. If provided, returns only tasks whose content or notes match (case-insensitive, max 20 results with full detail). If omitted, returns all tasks in slim format."`
+}
+```
+
+- [ ] **Step 3: Add slim fields to `GetUserActiveTasksOutput`**
+
+Update the `GetUserActiveTasksOutput` struct in `types.go` (around line 211) from:
+
+```go
+type GetUserActiveTasksOutput struct {
+	UserID    string               `json:"userId"`
+	Tasks     []ActiveTaskInfo     `json:"tasks"     jsonschema_description:"Regular (non-recurring) active tasks"`
+	Templates []ActiveTemplateInfo `json:"templates" jsonschema_description:"Recurring template tasks"`
+	Total     int                  `json:"total"`
+}
+```
+
+To:
+
+```go
+type GetUserActiveTasksOutput struct {
+	UserID        string               `json:"userId"`
+	Tasks         []ActiveTaskInfo     `json:"tasks,omitempty"         jsonschema_description:"Full-detail tasks (populated when query is provided)"`
+	Templates     []ActiveTemplateInfo `json:"templates,omitempty"     jsonschema_description:"Full-detail templates (populated when query is provided)"`
+	SlimTasks     []SlimTaskInfo       `json:"slimTasks,omitempty"     jsonschema_description:"Slim tasks with minimal fields (populated when no query)"`
+	SlimTemplates []SlimTemplateInfo   `json:"slimTemplates,omitempty" jsonschema_description:"Slim templates with minimal fields (populated when no query)"`
+	Total         int                  `json:"total"`
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd backend && go build ./...`
+Expected: Compiles successfully (output struct fields changed from required to omitempty, but all existing code populates them so no breakage)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/gemini/types.go
+git commit -m "feat(gemini): add slim task types and query param to active tasks input"
+```
+
+---
+
+### Task 3: Implement Query Filtering in `getUserActiveTasks` Tool
+
+**Files:**
+- Modify: `backend/internal/gemini/tools.go` (update `getUserActiveTasks` tool implementation, lines 195-305)
+
+- [ ] **Step 1: Add `strings` import**
+
+Add `"strings"` to the import block at the top of `tools.go` if not already present.
+
+- [ ] **Step 2: Rewrite the `getUserActiveTasks` tool function body**
+
+Replace the tool function body (the anonymous function inside `genkit.DefineTool` for `getUserActiveTasks`, lines ~199-304) with:
+
+```go
+func(ctx *ai.ToolContext, input GetUserActiveTasksInput) (GetUserActiveTasksOutput, error) {
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return GetUserActiveTasksOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	workspaces, err := categoryService.GetCategoriesByUser(userID)
+	if err != nil {
+		return GetUserActiveTasksOutput{}, fmt.Errorf("failed to fetch categories: %w", err)
+	}
+
+	hasQuery := strings.TrimSpace(input.Query) != ""
+	queryLower := strings.ToLower(strings.TrimSpace(input.Query))
+
+	output := GetUserActiveTasksOutput{UserID: input.UserID}
+
+	if hasQuery {
+		// Targeted search: return full-detail matches, capped at 20
+		output.Tasks = make([]ActiveTaskInfo, 0)
+		for _, workspace := range workspaces {
+			for _, cat := range workspace.Categories {
+				for _, t := range cat.Tasks {
+					if len(output.Tasks) >= 20 {
+						break
+					}
+					contentLower := strings.ToLower(t.Content)
+					notesLower := strings.ToLower(t.Notes)
+					if !strings.Contains(contentLower, queryLower) && !strings.Contains(notesLower, queryLower) {
+						continue
+					}
+					notes := t.Notes
+					if len(notes) > 200 {
+						notes = notes[:200]
+					}
+					info := ActiveTaskInfo{
+						ID:             t.ID.Hex(),
+						CategoryID:     cat.ID.Hex(),
+						CategoryName:   cat.Name,
+						Content:        t.Content,
+						Priority:       t.Priority,
+						Value:          t.Value,
+						Recurring:      t.Recurring,
+						RecurFrequency: t.RecurFrequency,
+						Active:         t.Active,
+						Notes:          notes,
+					}
+					if t.Deadline != nil {
+						info.Deadline = t.Deadline.Format(time.RFC3339)
+					}
+					if t.StartDate != nil {
+						info.StartDate = t.StartDate.Format(time.RFC3339)
+					}
+					if t.StartTime != nil {
+						info.StartTime = t.StartTime.Format(time.RFC3339)
+					}
+					if t.TemplateID != nil {
+						info.TemplateID = t.TemplateID.Hex()
+					}
+					output.Tasks = append(output.Tasks, info)
+				}
+			}
+		}
+	} else {
+		// Broad fallback: return slim format for all tasks, capped at 200
+		output.SlimTasks = make([]SlimTaskInfo, 0)
+		for _, workspace := range workspaces {
+			for _, cat := range workspace.Categories {
+				for _, t := range cat.Tasks {
+					if len(output.SlimTasks) >= 200 {
+						break
+					}
+					slim := SlimTaskInfo{
+						ID:         t.ID.Hex(),
+						CategoryID: cat.ID.Hex(),
+						Content:    t.Content,
+						Priority:   t.Priority,
+					}
+					if t.Deadline != nil {
+						slim.Deadline = t.Deadline.Format(time.RFC3339)
+					}
+					output.SlimTasks = append(output.SlimTasks, slim)
+				}
+			}
+		}
+	}
+
+	// Fetch recurring templates
+	templates, err := taskService.GetTemplatesByUserWithCategory(userID)
+	if err != nil {
+		fmt.Printf("⚠️  getUserActiveTasks: failed to fetch templates: %v\n", err)
+	} else if hasQuery {
+		output.Templates = make([]ActiveTemplateInfo, 0)
+		for _, tmpl := range templates {
+			if len(output.Templates) >= 20 {
+				break
+			}
+			contentLower := strings.ToLower(tmpl.Content)
+			notesLower := strings.ToLower(tmpl.Notes)
+			if !strings.Contains(contentLower, queryLower) && !strings.Contains(notesLower, queryLower) {
+				continue
+			}
+			notes := tmpl.Notes
+			if len(notes) > 200 {
+				notes = notes[:200]
+			}
+			info := ActiveTemplateInfo{
+				ID:             tmpl.ID.Hex(),
+				CategoryID:     tmpl.CategoryID.Hex(),
+				CategoryName:   tmpl.CategoryName,
+				Content:        tmpl.Content,
+				Priority:       tmpl.Priority,
+				Value:          tmpl.Value,
+				Public:         tmpl.Public,
+				RecurFrequency: tmpl.RecurFrequency,
+				RecurType:      tmpl.RecurType,
+				Notes:          notes,
+			}
+			if tmpl.Deadline != nil {
+				info.Deadline = tmpl.Deadline.Format(time.RFC3339)
+			}
+			if tmpl.StartDate != nil {
+				info.StartDate = tmpl.StartDate.Format(time.RFC3339)
+			}
+			if tmpl.StartTime != nil {
+				info.StartTime = tmpl.StartTime.Format(time.RFC3339)
+			}
+			output.Templates = append(output.Templates, info)
+		}
+	} else {
+		output.SlimTemplates = make([]SlimTemplateInfo, 0)
+		for i, tmpl := range templates {
+			if i >= 200 {
+				break
+			}
+			slim := SlimTemplateInfo{
+				ID:         tmpl.ID.Hex(),
+				CategoryID: tmpl.CategoryID.Hex(),
+				Content:    tmpl.Content,
+				Priority:   tmpl.Priority,
+			}
+			if tmpl.Deadline != nil {
+				slim.Deadline = tmpl.Deadline.Format(time.RFC3339)
+			}
+			output.SlimTemplates = append(output.SlimTemplates, slim)
+		}
+	}
+
+	totalTasks := len(output.Tasks) + len(output.SlimTasks)
+	totalTemplates := len(output.Templates) + len(output.SlimTemplates)
+	output.Total = totalTasks + totalTemplates
+	fmt.Printf("🔍 getUserActiveTasks called for user: %s (query=%q), found %d tasks + %d templates\n",
+		input.UserID, input.Query, totalTasks, totalTemplates)
+	return output, nil
+},
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd backend && go build ./...`
+Expected: Compiles successfully
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/gemini/tools.go
+git commit -m "feat(gemini): add keyword search and slim fallback to getUserActiveTasks tool"
+```
+
+---
+
+### Task 4: Wire Category Service into `InitFlows` and `InitGenkit`
+
+**Files:**
+- Modify: `backend/internal/gemini/flows.go` (update `InitFlows` signature, line 30)
+- Modify: `backend/internal/gemini/genkit.go` (pass category service through)
+
+- [ ] **Step 1: Update `InitFlows` signature**
+
+In `backend/internal/gemini/flows.go`, change line 30 from:
+
+```go
+func InitFlows(g *genkit.Genkit, tools *ToolSet) *FlowSet {
+```
+
+To:
+
+```go
+func InitFlows(g *genkit.Genkit, tools *ToolSet, categoryService *Category.Service) *FlowSet {
+```
+
+Add to imports at the top of `flows.go`:
+
+```go
+Category "github.com/abhikaboy/Kindred/internal/handlers/category"
+```
+
+- [ ] **Step 2: Update `InitGenkit` to create and pass category service**
+
+In `backend/internal/gemini/genkit.go`, update the function to:
+
+```go
+package gemini
+
+import (
+	"context"
+
+	Category "github.com/abhikaboy/Kindred/internal/handlers/category"
+	"github.com/abhikaboy/Kindred/internal/unsplash"
+	"github.com/firebase/genkit/go/genkit"
+	"github.com/firebase/genkit/go/plugins/googlegenai"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// InitGenkit initializes the Genkit service with all tools and flows
+func InitGenkit(collections map[string]*mongo.Collection, unsplashClient *unsplash.Client) *GeminiService {
+	// Initialize Genkit with the Google AI plugin
+	g := genkit.Init(context.Background(),
+		genkit.WithPlugins(&googlegenai.GoogleAI{}),
+		genkit.WithDefaultModel("googleai/gemini-2.5-flash"),
+	)
+
+	// Initialize tools
+	tools := InitTools(g, collections, unsplashClient)
+
+	// Initialize category service for prompt injection
+	categoryService := Category.NewService(collections)
+
+	// Initialize flows with tools and category service
+	flows := InitFlows(g, tools, categoryService)
+
+	return &GeminiService{
+		Genkit:                           g,
+		TaskFlow:                         flows.TaskFlow,
+		TaskFromImageFlow:                flows.TaskFromImageFlow,
+		MultiTaskFromTextFlow:            flows.MultiTaskFromTextFlow,
+		MultiTaskFromTextFlowWithContext: flows.MultiTaskFromTextFlowWithContext,
+		AnalyticsReportFlow:              flows.AnalyticsReportFlow,
+		GenerateBlueprintFlow:            flows.GenerateBlueprintFlow,
+		QueryTasksFlow:                   flows.QueryTasksFlow,
+		EditTasksFlow:                    flows.EditTasksFlow,
+		IntentRouterFlow:                 flows.IntentRouterFlow,
+		Tools:                            tools,
+	}
+}
+```
+
+- [ ] **Step 3: Verify it compiles**
+
+Run: `cd backend && go build ./...`
+Expected: Compiles (flows.go now receives `categoryService` but doesn't use it yet — that's Task 5)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/gemini/flows.go backend/internal/gemini/genkit.go
+git commit -m "feat(gemini): wire category service into InitFlows for prompt injection"
+```
+
+---
+
+### Task 5: Update Flow Prompts — Inject Categories, Add Normalization, Remove Tool
+
+This is the core task. Each flow gets its prompt rewritten to:
+1. Inject the category summary directly
+2. Use the smarter `getUserActiveTasks` tool (query-based)
+3. Remove `getUserCategories` from `ai.WithTools(...)` where applicable
+4. Add text normalization rules to create flows
+
+**Files:**
+- Modify: `backend/internal/gemini/flows.go` (rewrite prompt strings + tool lists in 5 flows)
+
+- [ ] **Step 1: Update `multiTaskFromTextFlowWithContext` (lines 79-109)**
+
+Replace the flow function body (inside `genkit.DefineFlow`) with:
+
+```go
+func(ctx context.Context, input MultiTaskFromTextInputWithUser) (MultiTaskFromTextOutput, error) {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return MultiTaskFromTextOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+	if err != nil {
+		return MultiTaskFromTextOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+	}
+
+	prompt := fmt.Sprintf(`You are a task organization assistant. Generate a set of categories and tasks based on the user's input text.
+
+The user's existing workspaces and categories:
+%s
+
+Current time: %s
+User input: %s
+
+TEXT NORMALIZATION (apply to all task content you generate):
+- Fix capitalization: sentence case for task names ("buy groceries" -> "Buy groceries")
+- Remove filler words from voice input (um, uh, like, you know, so basically, i guess)
+- Keep the user's phrasing — do NOT significantly rewrite or paraphrase their words
+- Split compound sentences into separate tasks when they describe distinct actions
+  Example: "call mom and also buy groceries" -> two tasks: "Call mom", "Buy groceries"
+- Infer deadlines from context: "finish the report by friday" -> set deadline to this Friday
+- Infer priorities from urgency cues: "urgently fix the bug" -> priority 3, "maybe clean my desk" -> priority 1
+- When no priority cue exists, default to priority 2
+- When no deadline is mentioned, omit it — do not guess
+
+Your response should include:
+1. categories: An array of category objects with "name" and "workspaceName" fields. New categories should include tasks in the tasks array.
+2. tasks: An array of categoryTaskPair objects, each with appropriate fields. The categoryId should be the ID of the existing category from the list above. These are exclusively for tasks that belong to existing categories.
+
+When choosing category names, prefer existing categories from the list above when the task fits. Only create new categories when the task doesn't match any existing category.`, categorySummary, currentTime, input.Text)
+
+	ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.MultiTaskFromTextWithContext")
+	defer span.End()
+	resp, _, err := genkit.GenerateData[MultiTaskFromTextOutput](ctx, g,
+		ai.WithPrompt(prompt),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return MultiTaskFromTextOutput{}, err
+	}
+	return *resp, nil
+},
+```
+
+Note: `ai.WithTools(tools.GetUserCategories)` is **removed** — no tool call needed.
+
+Add `"go.mongodb.org/mongo-driver/bson/primitive"` to the imports in `flows.go`.
+
+- [ ] **Step 2: Update `queryTasksFlow` (lines 258-296)**
+
+Replace the flow function body with:
+
+```go
+func(ctx context.Context, input QueryTasksFlowInput) (TaskQueryFiltersOutput, error) {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return TaskQueryFiltersOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+	if err != nil {
+		return TaskQueryFiltersOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+	}
+
+	prompt := fmt.Sprintf(`You are a task search assistant. Convert the user's natural language query into structured filter parameters for searching their tasks.
+
+The user's existing workspaces and categories:
+%s
+
+Current time: %s
+User's timezone: %s
+
+User query: "%s"
+
+Return a TaskQueryFiltersOutput with the appropriate filters:
+- categoryIds: IDs of relevant categories (match by name from the list above). Leave empty if no specific category is mentioned.
+- priorities: relevant priority values (1=low, 2=medium, 3=high). E.g. [3] for "high priority", [1,2] for "low and medium priority".
+- deadlineFrom/deadlineTo: ISO8601 datetime range for deadline filter. E.g. for "due this week", set deadlineFrom to start of current week and deadlineTo to end of current week in the user's timezone.
+- startTimeFrom/startTimeTo: ISO8601 datetime range for start date filter.
+- hasDeadline: set to true if user says "with deadline" or "due", false if "without deadline".
+- hasStartTime: set to true if user says "scheduled" or "with start date", false if "unscheduled".
+- sortBy: appropriate sorting field (timestamp, priority, value, deadline). Default to "timestamp".
+- sortDir: -1 for "newest/latest/most recent", 1 for "oldest". Default to -1.
+
+Be precise with date ranges based on the user's timezone. Only set filters that are clearly implied by the query.`,
+		categorySummary, currentTime, input.Timezone, input.Text)
+
+	ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.QueryTasks")
+	defer span.End()
+	resp, _, err := genkit.GenerateData[TaskQueryFiltersOutput](ctx, g,
+		ai.WithPrompt(prompt),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return TaskQueryFiltersOutput{}, err
+	}
+	return *resp, nil
+},
+```
+
+Note: `ai.WithTools(tools.GetUserCategories)` is **removed**.
+
+- [ ] **Step 3: Update `editTasksFlow` (lines 299-345)**
+
+Replace the flow function body with:
+
+```go
+func(ctx context.Context, input EditTasksFlowInput) (EditTasksFlowOutput, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return EditTasksFlowOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+	if err != nil {
+		return EditTasksFlowOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+	}
+
+	prompt := fmt.Sprintf(`You are a task editing assistant. The user wants to edit one or more of their tasks or recurring templates.
+
+The user's existing workspaces and categories:
+%s
+
+STEP 1: Call getUserActiveTasks with userId "%s" and a query keyword extracted from the user's instruction to find the relevant tasks. If the instruction is broad (e.g., "change all my tasks"), call it without a query to get a slim overview of all tasks.
+STEP 2: Identify which item(s) the user is referring to by matching their description to content/notes.
+         If the user mentions something recurring or a "template", look in templates first.
+STEP 3: Construct edit instructions for each matched item.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an EditTasksFlowOutput with two arrays:
+- instructions: edits for regular tasks. Each entry must have:
+    - taskId: exact hex ID from the results
+    - categoryId: exact hex categoryId from the results
+    - updates: only include fields that should change
+- templateInstructions: edits for recurring templates. Each entry must have:
+    - taskId: exact hex ID from the results
+    - categoryId: exact hex categoryId from the results
+    - updates: only include fields that should change
+
+For time fields in updates:
+    - Omit entirely to leave unchanged
+    - ISO8601 string to set a new value (interpret relative times like "next Friday" using current time + timezone)
+    - Empty string "" to explicitly clear/remove the field
+
+If the user's instruction doesn't match anything, return empty arrays for both.`,
+		categorySummary, input.UserID, now, input.Timezone, input.Text)
+
+	ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.EditTasks")
+	defer span.End()
+	resp, _, err := genkit.GenerateData[EditTasksFlowOutput](ctx, g,
+		ai.WithPrompt(prompt),
+		ai.WithTools(tools.GetUserActiveTasks),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return EditTasksFlowOutput{}, err
+	}
+	return *resp, nil
+},
+```
+
+- [ ] **Step 4: Update `intentRouterFlow` (lines 350-413)**
+
+Replace the flow function body with:
+
+```go
+func(ctx context.Context, input IntentRouterInput) (IntentRouterOutput, error) {
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return IntentRouterOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+	if err != nil {
+		return IntentRouterOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+	}
+
+	prompt := fmt.Sprintf(`You are a task management assistant. The user has given you a natural language instruction that may contain one or more operations: creating new tasks, editing existing tasks, or deleting existing tasks.
+
+The user's existing workspaces and categories:
+%s
+
+STEP 1: If the instruction involves editing or deleting specific tasks, call getUserActiveTasks with userId "%s" and a query keyword to find the relevant tasks. If the instruction is broad, call it without a query for a slim overview.
+STEP 2: Decompose the user's instruction into one or more typed operations.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+TEXT NORMALIZATION (apply to all task content you create):
+- Fix capitalization: sentence case for task names ("buy groceries" -> "Buy groceries")
+- Remove filler words from voice input (um, uh, like, you know, so basically, i guess)
+- Keep the user's phrasing — do NOT significantly rewrite or paraphrase their words
+- Split compound sentences into separate tasks when they describe distinct actions
+  Example: "call mom and also buy groceries" -> two tasks: "Call mom", "Buy groceries"
+- Infer deadlines from context: "finish the report by friday" -> set deadline to this Friday
+- Infer priorities from urgency cues: "urgently fix the bug" -> priority 3, "maybe clean my desk" -> priority 1
+- When no priority cue exists, default to priority 2
+- When no deadline is mentioned, omit it — do not guess
+
+Return an IntentRouterOutput with an "ops" array. Each element must have:
+- "type": one of "create", "edit", or "delete"
+- Exactly one payload field matching the type:
+  - For "create": populate "createPayload" with:
+      { "categories": [...new categories with tasks...], "tasks": [...tasks for existing categories...] }
+      Use the categoryIds from the list above when assigning tasks to existing categories.
+  - For "edit": populate "editPayload" with:
+      { "instructions": [...], "templateInstructions": [...] }
+      Use exact hex IDs from getUserActiveTasks results.
+  - For "delete": populate "deletePayload" with query filters to match the tasks the user wants to delete.
+      ONLY these fields are allowed — do NOT include any other fields:
+        - "categoryIds": string array of category IDs (from the list above)
+        - "priorities": integer array of priority values (1=low, 2=medium, 3=high)
+        - "deadlineFrom": ISO8601 datetime string (start of deadline range, optional)
+        - "deadlineTo": ISO8601 datetime string (end of deadline range, optional)
+        - "startTimeFrom": ISO8601 datetime string (start of start-time range, optional)
+        - "startTimeTo": ISO8601 datetime string (end of start-time range, optional)
+        - "hasDeadline": boolean (true = only tasks with a deadline, optional)
+        - "hasStartTime": boolean (true = only scheduled tasks, optional)
+        - "sortBy": one of "timestamp", "priority", "value", "deadline" (optional)
+        - "sortDir": -1 (newest first) or 1 (oldest first) (optional)
+      IMPORTANT: Do NOT include "taskIds", "ids", "taskId", or any direct task identifiers.
+
+ORDERING RULES (important):
+1. Edit operations first (non-destructive, applied immediately server-side)
+2. Delete operations second (destructive, user will confirm in UI)
+3. Create operations last (additive, user will preview in UI)
+
+If the instruction contains only one type of operation, return a single-element "ops" array.
+If no matching tasks are found for an edit or delete, return an empty "ops" array rather than guessing.
+Only include operations that are clearly implied by the user's instruction.`,
+		categorySummary, input.UserID, now, input.Timezone, input.Text)
+
+	ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.IntentRouter")
+	defer span.End()
+	resp, _, err := genkit.GenerateData[IntentRouterOutput](ctx, g,
+		ai.WithPrompt(prompt),
+		ai.WithTools(tools.GetUserActiveTasks),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return IntentRouterOutput{}, err
+	}
+	if resp == nil {
+		return IntentRouterOutput{Ops: []IntentOp{}}, nil
+	}
+	return *resp, nil
+},
+```
+
+Note: `tools.GetUserCategories` removed from `ai.WithTools`. Only `tools.GetUserActiveTasks` remains.
+
+- [ ] **Step 5: Update `generateBlueprintFlow` (lines 178-255)**
+
+Replace the flow function body with:
+
+```go
+func(ctx context.Context, input GenerateBlueprintInput) (GenerateBlueprintOutput, error) {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+
+	userID, err := primitive.ObjectIDFromHex(input.UserID)
+	if err != nil {
+		return GenerateBlueprintOutput{}, fmt.Errorf("invalid user ID: %w", err)
+	}
+
+	categorySummary, err := categoryService.GetCategoryNamesSummary(userID)
+	if err != nil {
+		return GenerateBlueprintOutput{}, fmt.Errorf("failed to get category summary: %w", err)
+	}
+
+	prompt := fmt.Sprintf(`You are a blueprint creation assistant. Generate a comprehensive, well-structured blueprint based on the user's description.
+
+Description: %s
+Current time: %s
+
+The user's existing workspaces and categories:
+%s
+
+IMPORTANT INSTRUCTIONS:
+
+1. CALL fetchUnsplashImage tool with a relevant search query based on the blueprint theme to get a beautiful banner image. For example:
+   - For a "Morning Routine" blueprint, use query "morning sunrise coffee"
+   - For a "Workout Plan" blueprint, use query "fitness gym workout"
+   - For a "Meal Prep" blueprint, use query "healthy food meal prep"
+   Choose a descriptive query that matches the blueprint's theme. Use the returned URL for the banner field.
+
+2. Create a complete blueprint with the following structure:
+   - name: A clear, concise name for the blueprint (e.g., "Morning Productivity Routine", "Weekly Meal Prep Plan")
+   - description: A detailed description explaining the purpose and benefits of this blueprint
+   - banner: Use the image URL returned from fetchUnsplashImage tool
+   - tags: An array of 3-5 relevant tags for categorization (e.g., ["productivity", "morning", "health"])
+   - duration: Estimated total time to complete all tasks (e.g., "45m", "1h 30m", "2h")
+   - category: Primary category type (e.g., "productivity", "health", "learning", "lifestyle")
+   - categories: An array of category objects, each containing:
+     * name: Category name within the blueprint
+     * workspaceName: Should match the blueprint name
+     * tasks: Array of task objects with these fields:
+       - content: Clear, actionable task description
+       - priority: 1 (low), 2 (medium), or 3 (high)
+       - value: Numeric value representing task importance (1.0-3.0)
+       - recurring: Boolean indicating if task repeats
+       - public: Boolean (default false for blueprint tasks)
+       - active: Boolean (default false for blueprint tasks)
+       - startDate: ISO timestamp for when task should start (optional)
+       - startTime: ISO timestamp for specific time (optional)
+       - deadline: ISO timestamp for due date (optional)
+       - notes: Additional task details (optional)
+       - checklist: Array of checklist items (optional)
+       - reminders: Array of reminder objects (optional)
+
+3. BLUEPRINT DESIGN GUIDELINES:
+   - Create 2-5 categories that logically organize the tasks
+   - Each category should have 3-8 tasks
+   - Tasks should be specific, actionable, and ordered logically
+   - Set appropriate priorities based on task importance
+   - Include time-based fields (startDate, startTime, deadline) where relevant
+   - For recurring tasks, consider daily/weekly patterns
+   - Add helpful notes for tasks that need clarification
+
+4. QUALITY STANDARDS:
+   - Ensure tasks are complete and actionable
+   - Order tasks in a logical sequence
+   - Balance task priorities across the blueprint
+   - Make the blueprint immediately useful and practical
+   - Consider the user's existing workspace patterns from the category list above
+   - Use high-quality, relevant banner images from Unsplash
+
+Generate a high-quality, comprehensive blueprint that the user can immediately subscribe to and start using.`, input.Description, currentTime, categorySummary)
+
+	ctx, span := otel.Tracer("kindred").Start(ctx, "gemini.GenerateBlueprint")
+	defer span.End()
+	resp, _, err := genkit.GenerateData[GenerateBlueprintOutput](ctx, g,
+		ai.WithPrompt(prompt),
+		ai.WithTools(tools.FetchUnsplashImage),
+	)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return GenerateBlueprintOutput{}, err
+	}
+
+	return *resp, nil
+},
+```
+
+Note: `tools.GetUserCategories` removed from `ai.WithTools`. Only `tools.FetchUnsplashImage` remains.
+
+- [ ] **Step 6: Verify it compiles**
+
+Run: `cd backend && go build ./...`
+Expected: Compiles successfully
+
+- [ ] **Step 7: Run existing tests to verify nothing is broken**
+
+Run: `cd backend && go test ./internal/handlers/category/ -v`
+Expected: All existing tests pass
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/internal/gemini/flows.go
+git commit -m "feat(gemini): inject category context into prompts, add text normalization, use query-based task search"
+```
+
+---
+
+### Task 6: Verify End-to-End Compilation and Tests
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full build**
+
+Run: `cd backend && go build ./...`
+Expected: Clean compile, no errors
+
+- [ ] **Step 2: Run all tests**
+
+Run: `cd backend && go test ./... -v -count=1`
+Expected: All tests pass
+
+- [ ] **Step 3: Run vet and check for issues**
+
+Run: `cd backend && go vet ./...`
+Expected: No issues

--- a/docs/superpowers/plans/2026-05-16-genkit-sse-streaming.md
+++ b/docs/superpowers/plans/2026-05-16-genkit-sse-streaming.md
@@ -1,0 +1,1198 @@
+# Genkit SSE Streaming Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Server-Sent Events streaming to the four main Genkit NLP flows so the frontend gets real-time progress events instead of waiting for the full LLM response.
+
+**Architecture:** New raw Fiber SSE handlers sit alongside the existing Huma endpoints. They share the same auth middleware and reuse the existing Genkit `GenerateData[T]()` calls, but emit SSE events between stages. The frontend gets a new `useSSEStream` hook that reads the event stream and feeds progress into the existing UI components.
+
+**Tech Stack:** Go (Fiber SSE via `c.Context().SetBodyStreamWriter`), Genkit Go v1.0.2, React Native (Expo 55 fetch ReadableStream), TypeScript
+
+---
+
+## File Structure
+
+### Backend (new files)
+| File | Responsibility |
+|------|---------------|
+| `backend/internal/handlers/task/sse_writer.go` | `SSEWriter` struct: formats and flushes SSE frames to a Fiber response |
+| `backend/internal/handlers/task/stream_handlers.go` | Raw Fiber SSE handlers for intent/create/query/edit streaming |
+| `backend/internal/gemini/prompts.go` | Extracted prompt-building functions (shared by flows and stream handlers) |
+
+### Backend (modified files)
+| File | Change |
+|------|--------|
+| `backend/internal/gemini/flows.go` | Call extracted prompt helpers instead of inline strings |
+| `backend/internal/server/server.go` | Register raw Fiber SSE routes |
+
+### Frontend (new files)
+| File | Responsibility |
+|------|---------------|
+| `frontend/hooks/useSSEStream.ts` | Generic SSE fetch + parse hook returning `{ stage, message, result, error, isStreaming }` |
+| `frontend/api/stream.ts` | Streaming API functions that use fetch with ReadableStream |
+
+### Frontend (modified files)
+| File | Change |
+|------|--------|
+| `frontend/hooks/useIntentRouterFlow.ts` | Use streaming endpoint, expose `stage`/`message` state |
+| `frontend/components/TaskGenerationLoading.tsx` | Accept and display streaming `message` updates |
+| `frontend/components/ui/fab/VoiceInputOverlay.tsx` | Pass streaming state to loading component |
+| `frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx` | Switch to streaming API |
+
+---
+
+## Task 1: SSEWriter utility
+
+**Files:**
+- Create: `backend/internal/handlers/task/sse_writer.go`
+
+- [ ] **Step 1: Write the SSEWriter struct and Send method**
+
+```go
+package task
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+)
+
+// SSEWriter writes Server-Sent Events to a buffered writer with flushing.
+type SSEWriter struct {
+	w *bufio.Writer
+}
+
+// NewSSEWriter wraps a bufio.Writer for SSE output.
+func NewSSEWriter(w *bufio.Writer) *SSEWriter {
+	return &SSEWriter{w: w}
+}
+
+// Send writes a single SSE event (event + JSON-encoded data) and flushes.
+func (s *SSEWriter) Send(event string, data interface{}) error {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("sse marshal: %w", err)
+	}
+	// Write SSE frame: "event: <type>\ndata: <json>\n\n"
+	if _, err := fmt.Fprintf(s.w, "event: %s\ndata: %s\n\n", event, jsonBytes); err != nil {
+		return err
+	}
+	return s.w.Flush()
+}
+
+// SendError writes an error event and flushes.
+func (s *SSEWriter) SendError(message string) error {
+	return s.Send("error", map[string]string{"message": message})
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: PASS (no errors)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/handlers/task/sse_writer.go
+git commit -m "feat(sse): add SSEWriter utility for streaming events"
+```
+
+---
+
+## Task 2: Extract prompt-building functions from flows
+
+**Files:**
+- Create: `backend/internal/gemini/prompts.go`
+- Modify: `backend/internal/gemini/flows.go`
+
+- [ ] **Step 1: Create prompts.go with extracted prompt builders**
+
+Extract the four prompt-building sections from `flows.go` into standalone functions. Each function takes the flow's input type and returns the prompt string.
+
+```go
+package gemini
+
+import (
+	"fmt"
+	"time"
+)
+
+// BuildMultiTaskWithContextPrompt builds the prompt for the multiTaskFromTextFlowWithContext flow.
+func BuildMultiTaskWithContextPrompt(userID, text, timezone string) string {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task organization assistant. Generate a set of categories and tasks based on the user's input text.
+
+IMPORTANT: Before creating categories, call the getUserCategories tool with userId "%s" to see what categories the user already has. Try to assign tasks to existing categories when appropriate, or create new categories only when needed.
+
+Current time: %s
+User input: %s
+
+Your response should include:
+1. categories: An array of category objects with "name" and "workspaceName" fields. New categories should include tasks in the tasks array.
+2. tasks: An array of categoryTaskPair objects, each with appropriate fields. The categoryId should be the ID of the existing category in the user's database. These are exlusively for tasks that belong to existing categories.
+
+When choosing category names, prefer existing categories from the user's database when the task fits. Only create new categories when the task doesn't match any existing category.`, userID, currentTime, text)
+}
+
+// BuildQueryTasksPrompt builds the prompt for the queryTasksFlow.
+func BuildQueryTasksPrompt(userID, text, timezone string) string {
+	currentTime := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task search assistant. Convert the user's natural language query into structured filter parameters for searching their tasks.
+
+IMPORTANT: Call the getUserCategories tool with userId "%s" to see what categories/workspaces exist. Use the returned category IDs when the user refers to a specific category or workspace by name.
+
+Current time: %s
+User's timezone: %s
+
+User query: "%s"
+
+Return a TaskQueryFiltersOutput with the appropriate filters:
+- categoryIds: IDs of relevant categories (match by name from getUserCategories results). Leave empty if no specific category is mentioned.
+- priorities: relevant priority values (1=low, 2=medium, 3=high). E.g. [3] for "high priority", [1,2] for "low and medium priority".
+- deadlineFrom/deadlineTo: ISO8601 datetime range for deadline filter. E.g. for "due this week", set deadlineFrom to start of current week and deadlineTo to end of current week in the user's timezone.
+- startTimeFrom/startTimeTo: ISO8601 datetime range for start date filter.
+- hasDeadline: set to true if user says "with deadline" or "due", false if "without deadline".
+- hasStartTime: set to true if user says "scheduled" or "with start date", false if "unscheduled".
+- sortBy: appropriate sorting field (timestamp, priority, value, deadline). Default to "timestamp".
+- sortDir: -1 for "newest/latest/most recent", 1 for "oldest". Default to -1.
+
+Be precise with date ranges based on the user's timezone. Only set filters that are clearly implied by the query.`,
+		userID, currentTime, timezone, text)
+}
+
+// BuildEditTasksPrompt builds the prompt for the editTasksFlow.
+func BuildEditTasksPrompt(userID, text, timezone string) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task editing assistant. The user wants to edit one or more of their tasks or recurring templates.
+
+STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and recurring templates.
+         The result contains two arrays: "tasks" (regular one-off tasks) and "templates" (recurring task templates).
+STEP 2: Identify which item(s) the user is referring to by matching their description to content/notes.
+         If the user mentions something recurring or a "template", look in templates first.
+STEP 3: Construct edit instructions for each matched item.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an EditTasksFlowOutput with two arrays:
+- instructions: edits for regular tasks. Each entry must have:
+    - taskId: exact hex ID from the "tasks" array
+    - categoryId: exact hex categoryId from the "tasks" array
+    - updates: only include fields that should change
+- templateInstructions: edits for recurring templates. Each entry must have:
+    - taskId: exact hex ID from the "templates" array
+    - categoryId: exact hex categoryId from the "templates" array
+    - updates: only include fields that should change
+
+For time fields in updates:
+    - Omit entirely to leave unchanged
+    - ISO8601 string to set a new value (interpret relative times like "next Friday" using current time + timezone)
+    - Empty string "" to explicitly clear/remove the field
+
+If the user's instruction doesn't match anything, return empty arrays for both.`,
+		userID, now, timezone, text)
+}
+
+// BuildIntentRouterPrompt builds the prompt for the intentRouterFlow.
+func BuildIntentRouterPrompt(userID, text, timezone string) string {
+	now := time.Now().UTC().Format(time.RFC3339)
+	return fmt.Sprintf(`You are a task management assistant. The user has given you a natural language instruction that may contain one or more operations: creating new tasks, editing existing tasks, or deleting existing tasks.
+
+STEP 1: Call getUserActiveTasks with userId "%s" to see all their current tasks and templates (needed for edit and delete operations).
+STEP 2: Call getUserCategories with userId "%s" to see their existing categories and workspaces (needed for create operations).
+STEP 3: Decompose the user's instruction into one or more typed operations.
+
+Current time: %s
+User's timezone: %s
+User instruction: "%s"
+
+Return an IntentRouterOutput with an "ops" array. Each element must have:
+- "type": one of "create", "edit", or "delete"
+- Exactly one payload field matching the type:
+  - For "create": populate "createPayload" with the same structure as multiTaskFromTextFlowWithContext output:
+      { "categories": [...new categories with tasks...], "tasks": [...tasks for existing categories...] }
+      Use the categoryIds from getUserCategories when assigning tasks to existing categories.
+  - For "edit": populate "editPayload" with the same structure as editTasksFlow output:
+      { "instructions": [...], "templateInstructions": [...] }
+      Use exact hex IDs from getUserActiveTasks results.
+  - For "delete": populate "deletePayload" with query filters to match the tasks the user wants to delete.
+      ONLY these fields are allowed — do NOT include any other fields:
+        - "categoryIds": string array of category IDs (from getUserCategories)
+        - "priorities": integer array of priority values (1=low, 2=medium, 3=high)
+        - "deadlineFrom": ISO8601 datetime string (start of deadline range, optional)
+        - "deadlineTo": ISO8601 datetime string (end of deadline range, optional)
+        - "startTimeFrom": ISO8601 datetime string (start of start-time range, optional)
+        - "startTimeTo": ISO8601 datetime string (end of start-time range, optional)
+        - "hasDeadline": boolean (true = only tasks with a deadline, optional)
+        - "hasStartTime": boolean (true = only scheduled tasks, optional)
+        - "sortBy": one of "timestamp", "priority", "value", "deadline" (optional)
+        - "sortDir": -1 (newest first) or 1 (oldest first) (optional)
+      IMPORTANT: Do NOT include "taskIds", "ids", "taskId", or any direct task identifiers.
+      Use only the filter fields above to describe which tasks to delete.
+
+ORDERING RULES (important):
+1. Edit operations first (non-destructive, applied immediately server-side)
+2. Delete operations second (destructive, user will confirm in UI)
+3. Create operations last (additive, user will preview in UI)
+
+If the instruction contains only one type of operation, return a single-element "ops" array.
+If no matching tasks are found for an edit or delete, return an empty "ops" array rather than guessing.
+Only include operations that are clearly implied by the user's instruction.`,
+		userID, userID, now, timezone, text)
+}
+```
+
+- [ ] **Step 2: Update flows.go to use extracted prompt builders**
+
+Replace the inline prompt strings in each flow with calls to the new functions. For example, in the `multiTaskFromTextFlowWithContext` flow (line 84-95 of flows.go), replace the `prompt := fmt.Sprintf(...)` block with:
+
+```go
+prompt := BuildMultiTaskWithContextPrompt(input.UserID, input.Text, input.Timezone)
+```
+
+Do the same for:
+- `queryTasksFlow` (line 262-282) → `BuildQueryTasksPrompt(input.UserID, input.Text, input.Timezone)`
+- `editTasksFlow` (line 303-330) → `BuildEditTasksPrompt(input.UserID, input.Text, input.Timezone)`
+- `intentRouterFlow` (line 354-395) → `BuildIntentRouterPrompt(input.UserID, input.Text, input.Timezone)`
+
+- [ ] **Step 3: Verify it compiles and existing flows still work**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/gemini/prompts.go backend/internal/gemini/flows.go
+git commit -m "refactor(gemini): extract prompt builders for reuse by stream handlers"
+```
+
+---
+
+## Task 3: Backend streaming handlers
+
+**Files:**
+- Create: `backend/internal/handlers/task/stream_handlers.go`
+- Modify: `backend/internal/server/server.go`
+
+This is the core backend task. The streaming handlers bypass Huma (which doesn't support SSE) and use raw Fiber handlers. Auth is already applied at the `/v1/user` prefix via Fiber middleware, so the handlers get `userID` from `c.Locals`.
+
+- [ ] **Step 1: Create stream_handlers.go with the intent streaming handler**
+
+Start with the intent router (slowest, most impactful). The pattern will be reused for the other three.
+
+```go
+package task
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"reflect"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/gofiber/fiber/v2"
+	"github.com/valyala/fasthttp"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// StreamIntentNaturalLanguage handles POST /v1/user/tasks/natural-language/intent/stream
+// It streams SSE events during the intent router flow.
+func (h *Handler) StreamIntentNaturalLanguage(c *fiber.Ctx) error {
+	// Parse request body
+	var body struct {
+		Text     string `json:"text"`
+		Timezone string `json:"timezone"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Text == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "text field is required"})
+	}
+
+	// Get authenticated user from Fiber locals (set by auth middleware)
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(401).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	// Consume credit
+	err = h.service.Users.ConsumeCredit(c.UserContext(), userObjID, types.CreditTypeNaturalLanguage)
+	if err != nil {
+		if err == types.ErrInsufficientCredits {
+			return c.Status(403).JSON(fiber.Map{"error": "Insufficient credits"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "Unable to process your credit"})
+	}
+
+	timezone := body.Timezone
+	if timezone == "" {
+		timezone = "America/New_York"
+	}
+
+	slog.LogAttrs(c.UserContext(), slog.LevelInfo, "Starting streaming intent routing",
+		slog.String("userID", userID),
+		slog.String("inputText", body.Text))
+
+	// Set SSE headers
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	// Capture values for the closure
+	text := body.Text
+	geminiService := h.geminiService
+	handler := h
+
+	c.Context().SetBodyStreamWriter(func(w *fasthttp.RequestCtx) {
+		bw := bufio.NewWriter(w)
+		sse := NewSSEWriter(bw)
+
+		// Run the intent flow with SSE events
+		result, err := handler.runIntentFlowWithSSE(context.Background(), sse, geminiService, userID, text, timezone)
+		if err != nil {
+			slog.Error("Streaming intent flow failed", "userID", userID, "error", err)
+			sse.SendError(err.Error())
+
+			// Refund credit on failure
+			refundErr := handler.service.Users.AddCredits(context.Background(), userObjID, types.CreditTypeNaturalLanguage, 1)
+			if refundErr != nil {
+				slog.Error("Failed to refund credit", "userID", userID, "error", refundErr)
+			}
+			return
+		}
+
+		// Process the ops (apply edits, resolve deletes) same as non-streaming handler
+		responseOps := handler.processIntentOps(context.Background(), userObjID, userID, result)
+		sse.Send("result", map[string]interface{}{"ops": responseOps})
+	})
+
+	return nil
+}
+
+// runIntentFlowWithSSE runs the intent router Genkit flow, emitting SSE events at each stage.
+func (h *Handler) runIntentFlowWithSSE(ctx context.Context, sse *SSEWriter, geminiService any, userID, text, timezone string) (*IntentRouterOutputLocal, error) {
+	sse.Send("status", map[string]string{
+		"stage":   "starting",
+		"message": "Processing your request...",
+	})
+
+	// Call the Gemini intent flow (same reflection approach as callGeminiIntentFlow)
+	result, err := h.callGeminiIntentFlow(ctx, userID, text, timezone)
+	if err != nil {
+		// Retry once
+		sse.Send("status", map[string]string{
+			"stage":   "retrying",
+			"message": "Retrying...",
+		})
+		result, err = h.callGeminiIntentFlow(ctx, userID, text, timezone)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sse.Send("status", map[string]string{
+		"stage":   "processing_results",
+		"message": "Preparing your results...",
+	})
+
+	return result, nil
+}
+
+// processIntentOps processes the raw Genkit intent output into response ops.
+// This is the same logic as IntentTaskNaturalLanguage but extracted for reuse.
+func (h *Handler) processIntentOps(ctx context.Context, userObjID primitive.ObjectID, userID string, intentOutput *IntentRouterOutputLocal) []IntentOpResponse {
+	var responseOps []IntentOpResponse
+
+	for _, op := range intentOutput.Ops {
+		switch op.Type {
+		case "edit":
+			if op.EditPayload == nil {
+				continue
+			}
+			editedTasks, editedTemplates, totalEdited := h.applyEditInstructions(ctx, userObjID, userID, op.EditPayload)
+			responseOps = append(responseOps, IntentOpResponse{
+				Type: "edit",
+				EditResult: &EditResultResponse{
+					Tasks:       editedTasks,
+					Templates:   editedTemplates,
+					EditedCount: totalEdited,
+				},
+			})
+
+		case "delete":
+			if op.DeletePayload == nil {
+				continue
+			}
+			filters, err := convertQueryOutput(op.DeletePayload)
+			if err != nil {
+				slog.Warn("Failed to convert delete query output", "error", err)
+				continue
+			}
+			tasks, err := h.service.QueryTasksByUser(userObjID, filters)
+			if err != nil {
+				slog.Warn("Failed to query tasks for delete op", "error", err)
+				continue
+			}
+			responseOps = append(responseOps, IntentOpResponse{
+				Type:        "delete",
+				DeleteTasks: tasks,
+			})
+
+		case "create":
+			if op.CreatePayload == nil {
+				continue
+			}
+			responseOps = append(responseOps, IntentOpResponse{
+				Type:          "create",
+				CreatePreview: op.CreatePayload,
+			})
+		}
+	}
+
+	if responseOps == nil {
+		responseOps = []IntentOpResponse{}
+	}
+	return responseOps
+}
+
+// StreamCreateNaturalLanguage handles POST /v1/user/tasks/natural-language/stream
+func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
+	var body struct {
+		Text     string `json:"text"`
+		Timezone string `json:"timezone"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Text == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "text field is required"})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(401).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	err = h.service.Users.ConsumeCredit(c.UserContext(), userObjID, types.CreditTypeNaturalLanguage)
+	if err != nil {
+		if err == types.ErrInsufficientCredits {
+			return c.Status(403).JSON(fiber.Map{"error": "Insufficient credits"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "Unable to process your credit"})
+	}
+
+	timezone := body.Timezone
+	if timezone == "" {
+		timezone = "America/New_York"
+	}
+
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	text := body.Text
+	handler := h
+
+	c.Context().SetBodyStreamWriter(func(w *fasthttp.RequestCtx) {
+		bw := bufio.NewWriter(w)
+		sse := NewSSEWriter(bw)
+
+		sse.Send("status", map[string]string{
+			"stage":   "starting",
+			"message": "Processing your request...",
+		})
+
+		result, err := handler.callGeminiFlow(context.Background(), userID, text, timezone)
+		if err != nil {
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying..."})
+			result, err = handler.callGeminiFlow(context.Background(), userID, text, timezone)
+			if err != nil {
+				handler.service.Users.AddCredits(context.Background(), userObjID, types.CreditTypeNaturalLanguage, 1)
+				sse.SendError("Failed to process with AI after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Preparing your results..."})
+
+		// Process and create tasks (same as CreateTaskNaturalLanguage)
+		newCategoryTasks, newCategoryMetadata, categoriesCreated, newCategoryTaskCount, err := handler.processNewCategories(context.Background(), result.Categories, userObjID)
+		if err != nil {
+			sse.SendError(err.Error())
+			return
+		}
+		existingCategoryTasks, existingCategoryTaskCount, err := handler.processExistingCategoryTasks(context.Background(), result.Tasks, userObjID)
+		if err != nil {
+			sse.SendError(err.Error())
+			return
+		}
+
+		allTasks := append(newCategoryTasks, existingCategoryTasks...)
+		totalTasks := newCategoryTaskCount + existingCategoryTaskCount
+
+		var message string
+		if totalTasks == 0 {
+			message = "No valid tasks could be created from the provided text"
+		} else if categoriesCreated > 0 {
+			message = fmt.Sprintf("Successfully created %d tasks in %d new categories", totalTasks, categoriesCreated)
+		} else {
+			message = fmt.Sprintf("Successfully created %d tasks in existing categories", totalTasks)
+		}
+
+		sse.Send("result", map[string]interface{}{
+			"categoriesCreated": categoriesCreated,
+			"newCategories":     newCategoryMetadata,
+			"tasksCreated":      totalTasks,
+			"tasks":             allTasks,
+			"message":           message,
+		})
+	})
+
+	return nil
+}
+
+// StreamQueryNaturalLanguage handles POST /v1/user/tasks/natural-language/query/stream
+func (h *Handler) StreamQueryNaturalLanguage(c *fiber.Ctx) error {
+	var body struct {
+		Text     string `json:"text"`
+		Timezone string `json:"timezone"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Text == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "text field is required"})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(401).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	err = h.service.Users.ConsumeCredit(c.UserContext(), userObjID, types.CreditTypeNaturalLanguage)
+	if err != nil {
+		if err == types.ErrInsufficientCredits {
+			return c.Status(403).JSON(fiber.Map{"error": "Insufficient credits"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "Unable to process your credit"})
+	}
+
+	timezone := body.Timezone
+	if timezone == "" {
+		timezone = "America/New_York"
+	}
+
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	text := body.Text
+	handler := h
+
+	c.Context().SetBodyStreamWriter(func(w *fasthttp.RequestCtx) {
+		bw := bufio.NewWriter(w)
+		sse := NewSSEWriter(bw)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your query..."})
+
+		queryOutput, err := handler.callGeminiQueryFlow(context.Background(), userID, text, timezone)
+		if err != nil {
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying..."})
+			queryOutput, err = handler.callGeminiQueryFlow(context.Background(), userID, text, timezone)
+			if err != nil {
+				handler.service.Users.AddCredits(context.Background(), userObjID, types.CreditTypeNaturalLanguage, 1)
+				sse.SendError("Failed to process query after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "querying_tasks", "message": "Finding matching tasks..."})
+
+		filters, err := convertQueryOutput(queryOutput)
+		if err != nil {
+			sse.SendError("The AI response could not be interpreted. Please try rephrasing your query.")
+			return
+		}
+
+		tasks, err := handler.service.QueryTasksByUser(userObjID, filters)
+		if err != nil {
+			sse.SendError("Unable to query tasks due to a server error.")
+			return
+		}
+
+		sse.Send("result", map[string]interface{}{
+			"tasks": tasks,
+			"query": filters,
+		})
+	})
+
+	return nil
+}
+
+// StreamEditNaturalLanguage handles POST /v1/user/tasks/natural-language/edit/stream
+func (h *Handler) StreamEditNaturalLanguage(c *fiber.Ctx) error {
+	var body struct {
+		Text     string `json:"text"`
+		Timezone string `json:"timezone"`
+	}
+	if err := c.BodyParser(&body); err != nil || body.Text == "" {
+		return c.Status(400).JSON(fiber.Map{"error": "text field is required"})
+	}
+
+	userID, err := auth.RequireAuthFiber(c)
+	if err != nil {
+		return c.Status(401).JSON(fiber.Map{"error": "Please log in to continue"})
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return c.Status(400).JSON(fiber.Map{"error": "Invalid user ID format"})
+	}
+
+	err = h.service.Users.ConsumeCredit(c.UserContext(), userObjID, types.CreditTypeNaturalLanguage)
+	if err != nil {
+		if err == types.ErrInsufficientCredits {
+			return c.Status(403).JSON(fiber.Map{"error": "Insufficient credits"})
+		}
+		return c.Status(500).JSON(fiber.Map{"error": "Unable to process your credit"})
+	}
+
+	timezone := body.Timezone
+	if timezone == "" {
+		timezone = "America/New_York"
+	}
+
+	c.Set("Content-Type", "text/event-stream")
+	c.Set("Cache-Control", "no-cache")
+	c.Set("Connection", "keep-alive")
+	c.Set("X-Accel-Buffering", "no")
+
+	text := body.Text
+	handler := h
+
+	c.Context().SetBodyStreamWriter(func(w *fasthttp.RequestCtx) {
+		bw := bufio.NewWriter(w)
+		sse := NewSSEWriter(bw)
+
+		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your edit..."})
+
+		editOutput, err := handler.callGeminiEditFlow(context.Background(), userID, text, timezone)
+		if err != nil {
+			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying..."})
+			editOutput, err = handler.callGeminiEditFlow(context.Background(), userID, text, timezone)
+			if err != nil {
+				handler.service.Users.AddCredits(context.Background(), userObjID, types.CreditTypeNaturalLanguage, 1)
+				sse.SendError("Failed to process edit after retry. Your credit has been refunded.")
+				return
+			}
+		}
+
+		sse.Send("status", map[string]string{"stage": "applying_edits", "message": "Applying changes..."})
+
+		if len(editOutput.Instructions) == 0 && len(editOutput.TemplateInstructions) == 0 {
+			sse.Send("result", map[string]interface{}{
+				"tasks":       []TaskDocument{},
+				"templates":   []TemplateTaskDocument{},
+				"editedCount": 0,
+				"message":     "No matching tasks found",
+			})
+			return
+		}
+
+		editedTasks, editedTemplates, totalEdited := handler.applyEditInstructions(
+			context.Background(), userObjID, userID, editOutput,
+		)
+
+		var message string
+		switch totalEdited {
+		case 0:
+			message = "No matching tasks found"
+		case 1:
+			message = "Successfully edited 1 task"
+		default:
+			message = fmt.Sprintf("Successfully edited %d tasks", totalEdited)
+		}
+
+		sse.Send("result", map[string]interface{}{
+			"tasks":       editedTasks,
+			"templates":   editedTemplates,
+			"editedCount": totalEdited,
+			"message":     message,
+		})
+	})
+
+	return nil
+}
+```
+
+Note: The `reflect` and `json` imports may already be used — remove any unused imports after writing the file.
+
+- [ ] **Step 2: Fix the SetBodyStreamWriter signature**
+
+The `fasthttp.RequestCtx.SetBodyStreamWriter` callback signature is `func(w *bufio.Writer)`. Update accordingly:
+
+```go
+c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
+    sse := NewSSEWriter(w)
+    // ... rest of handler
+})
+```
+
+Remove the `bufio.NewWriter(w)` wrapping since `w` is already a `*bufio.Writer`.
+
+- [ ] **Step 3: Register the streaming routes in server.go**
+
+Add raw Fiber routes after the Huma API registration. These go after `task.Routes(api, collections, geminiService)` in `server.go`:
+
+```go
+// Register raw Fiber SSE streaming routes for NLP flows
+// These bypass Huma since SSE requires raw streaming responses.
+// Auth is already applied by the /v1/user middleware above.
+taskHandler := task.NewStreamHandler(collections, geminiService)
+app.Post("/api/v1/user/tasks/natural-language/intent/stream", taskHandler.StreamIntentNaturalLanguage)
+app.Post("/api/v1/user/tasks/natural-language/stream", taskHandler.StreamCreateNaturalLanguage)
+app.Post("/api/v1/user/tasks/natural-language/query/stream", taskHandler.StreamQueryNaturalLanguage)
+app.Post("/api/v1/user/tasks/natural-language/edit/stream", taskHandler.StreamEditNaturalLanguage)
+```
+
+Note: The `/api` prefix is needed because Huma's base URL includes `/api`, but raw Fiber routes are registered directly on the app. Check the actual path by looking at how `baseClient` in the frontend constructs URLs: `baseUrl: (process.env.EXPO_PUBLIC_URL ?? "") + "/api"` — so the Fiber routes need the `/api` prefix to match.
+
+Also add a constructor for the stream handler in `stream_handlers.go`:
+
+```go
+// NewStreamHandler creates a Handler for SSE streaming routes.
+func NewStreamHandler(collections map[string]*mongo.Collection, geminiService any) *Handler {
+    service := newService(collections)
+    return &Handler{
+        service:       service,
+        geminiService: geminiService,
+    }
+}
+```
+
+- [ ] **Step 4: Verify it compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: PASS
+
+Fix any compilation errors (unused imports, signature mismatches, etc.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/internal/handlers/task/stream_handlers.go backend/internal/server/server.go
+git commit -m "feat(sse): add streaming SSE handlers for NLP flows"
+```
+
+---
+
+## Task 4: Frontend SSE stream hook and API functions
+
+**Files:**
+- Create: `frontend/api/stream.ts`
+- Create: `frontend/hooks/useSSEStream.ts`
+
+- [ ] **Step 1: Create the SSE API utility in stream.ts**
+
+```typescript
+import * as SecureStore from "expo-secure-store";
+
+const BASE_URL = (process.env.EXPO_PUBLIC_URL ?? "") + "/api";
+
+export type SSEEventType = "status" | "tool_call" | "generating" | "result" | "error";
+
+export interface SSEStatusData {
+    stage: string;
+    message: string;
+}
+
+export interface SSEErrorData {
+    message: string;
+}
+
+export interface SSEEvent<T = unknown> {
+    type: SSEEventType;
+    data: T;
+}
+
+/**
+ * POST to an SSE endpoint and call onEvent for each parsed SSE frame.
+ * Returns a promise that resolves when the stream closes.
+ */
+export async function fetchSSEStream<TResult>(
+    path: string,
+    body: Record<string, unknown>,
+    onEvent: (event: SSEEvent) => void,
+    signal?: AbortSignal,
+): Promise<void> {
+    // Get auth token
+    const authData = await SecureStore.getItemAsync("auth_data");
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    };
+    if (authData) {
+        const { access_token, refresh_token } = JSON.parse(authData);
+        if (access_token) headers["Authorization"] = `Bearer ${access_token}`;
+        if (refresh_token) headers["refresh_token"] = refresh_token;
+    }
+
+    const response = await fetch(`${BASE_URL}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal,
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || `HTTP ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body stream");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        // Parse SSE frames: split on double newlines
+        const frames = buffer.split("\n\n");
+        // Last element is either empty or an incomplete frame
+        buffer = frames.pop() ?? "";
+
+        for (const frame of frames) {
+            if (!frame.trim()) continue;
+
+            let eventType = "message";
+            let data = "";
+
+            for (const line of frame.split("\n")) {
+                if (line.startsWith("event: ")) {
+                    eventType = line.slice(7).trim();
+                } else if (line.startsWith("data: ")) {
+                    data = line.slice(6);
+                }
+            }
+
+            if (data) {
+                try {
+                    const parsed = JSON.parse(data);
+                    onEvent({ type: eventType as SSEEventType, data: parsed });
+                } catch {
+                    // Skip malformed frames
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Create the useSSEStream hook**
+
+```typescript
+import { useCallback, useRef, useState } from "react";
+import { fetchSSEStream, type SSEEvent, type SSEStatusData, type SSEErrorData } from "@/api/stream";
+
+export interface SSEStreamState<TResult> {
+    stage: string | null;
+    message: string | null;
+    result: TResult | null;
+    error: string | null;
+    isStreaming: boolean;
+}
+
+/**
+ * Generic hook for consuming an SSE streaming endpoint.
+ * Returns state that updates as events arrive, and a `start` function.
+ */
+export function useSSEStream<TResult>() {
+    const [stage, setStage] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [result, setResult] = useState<TResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isStreaming, setIsStreaming] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+
+    const start = useCallback(
+        async (path: string, body: Record<string, unknown>): Promise<TResult | null> => {
+            // Cancel any in-progress stream
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            setStage(null);
+            setMessage(null);
+            setResult(null);
+            setError(null);
+            setIsStreaming(true);
+
+            let finalResult: TResult | null = null;
+
+            try {
+                await fetchSSEStream(
+                    path,
+                    body,
+                    (event: SSEEvent) => {
+                        switch (event.type) {
+                            case "status":
+                            case "tool_call":
+                            case "generating": {
+                                const d = event.data as SSEStatusData;
+                                setStage(d.stage);
+                                setMessage(d.message);
+                                break;
+                            }
+                            case "result":
+                                finalResult = event.data as TResult;
+                                setResult(finalResult);
+                                break;
+                            case "error": {
+                                const d = event.data as SSEErrorData;
+                                setError(d.message);
+                                break;
+                            }
+                        }
+                    },
+                    controller.signal,
+                );
+            } catch (err: unknown) {
+                if (err instanceof Error && err.name !== "AbortError") {
+                    setError(err.message);
+                }
+            } finally {
+                setIsStreaming(false);
+                abortRef.current = null;
+            }
+
+            return finalResult;
+        },
+        [],
+    );
+
+    const cancel = useCallback(() => {
+        abortRef.current?.abort();
+    }, []);
+
+    const reset = useCallback(() => {
+        abortRef.current?.abort();
+        setStage(null);
+        setMessage(null);
+        setResult(null);
+        setError(null);
+        setIsStreaming(false);
+    }, []);
+
+    return { stage, message, result, error, isStreaming, start, cancel, reset };
+}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No new errors (existing errors unrelated to this work are OK)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/api/stream.ts frontend/hooks/useSSEStream.ts
+git commit -m "feat(frontend): add SSE stream hook and API utilities"
+```
+
+---
+
+## Task 5: Integrate streaming into useIntentRouterFlow
+
+**Files:**
+- Modify: `frontend/hooks/useIntentRouterFlow.ts`
+
+- [ ] **Step 1: Add streaming state and use the SSE hook**
+
+Update `useIntentRouterFlow` to use the streaming endpoint and expose `stage`/`message`:
+
+Replace the current `processText` implementation. The hook should:
+1. Import and use `useSSEStream`
+2. In `processText`, call `sseStream.start("/v1/user/tasks/natural-language/intent/stream", { text, timezone })`
+3. When the `result` arrives via the stream, process it the same way as the current `intentTaskNaturalLanguageAPI` response
+4. Expose `streamStage` and `streamMessage` from the SSE hook state
+5. Keep the existing fallback: if the stream fails, try the non-streaming endpoint
+
+Add to the return type:
+```typescript
+streamStage: string | null;
+streamMessage: string | null;
+```
+
+The key change is in `processText`:
+```typescript
+const processText = useCallback(
+    async (text: string, timezone?: string) => {
+        if (!text.trim()) return;
+        clearError();
+        setIsPreviewing(true);
+        try {
+            const resolvedTimezone =
+                timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+            // Try streaming endpoint first
+            const streamResult = await sseStream.start(
+                "/v1/user/tasks/natural-language/intent/stream",
+                { text: text.trim(), timezone: resolvedTimezone },
+            );
+
+            if (sseStream.error) {
+                throw new Error(sseStream.error);
+            }
+
+            const ops = (streamResult as any)?.ops ?? [];
+            if (ops.length === 0) {
+                setError("Nothing to do", [
+                    "No matching tasks or instructions found. Try rephrasing.",
+                ]);
+                setIsPreviewing(false);
+                return;
+            }
+            setPendingOps(ops);
+            currentOpIndexRef.current = 0;
+            advanceToNextOp(ops, 0);
+        } catch (error) {
+            // Fallback to non-streaming endpoint
+            try {
+                const result = await intentTaskNaturalLanguageAPI(text.trim(), timezone || Intl.DateTimeFormat().resolvedOptions().timeZone);
+                const ops = result.ops ?? [];
+                if (ops.length === 0) {
+                    setError("Nothing to do", ["No matching tasks or instructions found. Try rephrasing."]);
+                    setIsPreviewing(false);
+                    return;
+                }
+                setPendingOps(ops);
+                currentOpIndexRef.current = 0;
+                advanceToNextOp(ops, 0);
+            } catch (fallbackError) {
+                setErrorFromModel(fallbackError, "Couldn't Process Request", "Please try again.");
+            }
+        } finally {
+            setIsPreviewing(false);
+            sseStream.reset();
+        }
+    },
+    [advanceToNextOp, clearError, setError, setErrorFromModel, sseStream],
+);
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useIntentRouterFlow.ts
+git commit -m "feat(frontend): integrate SSE streaming into intent router hook"
+```
+
+---
+
+## Task 6: Update TaskGenerationLoading to show streaming messages
+
+**Files:**
+- Modify: `frontend/components/TaskGenerationLoading.tsx`
+
+- [ ] **Step 1: Make the component react to changing messages**
+
+The component already accepts `message` and `submessage` props (lines 8-10). No structural changes needed — the parent just needs to pass the streaming `message` as the `submessage` prop. The `message` prop stays as "Processing with AI..." and `submessage` shows the real-time status.
+
+If the streaming message is available, pass it as `submessage`:
+
+```tsx
+<TaskGenerationLoading
+    submessage={streamMessage ?? "This may take a few moments"}
+/>
+```
+
+This change happens in the parent components (VoiceInputOverlay, text-dump), not in TaskGenerationLoading itself. No change needed to this file unless the animation should change based on stage — which we're deferring.
+
+Mark this as done — the component already supports dynamic messages via props.
+
+- [ ] **Step 2: Commit (if any changes were made)**
+
+No commit needed for this task — the component already accepts the props.
+
+---
+
+## Task 7: Wire streaming into VoiceInputOverlay and TextDump
+
+**Files:**
+- Modify: `frontend/components/ui/fab/VoiceInputOverlay.tsx`
+- Modify: `frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx`
+
+- [ ] **Step 1: Update VoiceInputOverlay to pass streaming state**
+
+The VoiceInputOverlay uses `useIntentRouterFlow` (line 98-122 in VoiceInputOverlay.tsx). After Task 5, the hook exposes `streamStage` and `streamMessage`. Find where the loading/reading animation is shown during `isPreviewing` and pass the `streamMessage` to the UI.
+
+In the section where the reading animation plays (around lines 387-412), add the streaming message display. If `streamMessage` is non-null, show it below the word-by-word animation as a status line.
+
+- [ ] **Step 2: Update text-dump.tsx to use streaming**
+
+The text-dump component currently uses `createTasksFromNaturalLanguageAPI` directly (line 55). Update it to use the streaming intent flow instead. Import `useIntentRouterFlow` (or `useSSEStream` directly) and pass `streamMessage` to `TaskGenerationLoading`.
+
+- [ ] **Step 3: Verify the app compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No new errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/ui/fab/VoiceInputOverlay.tsx frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx
+git commit -m "feat(frontend): wire streaming status messages into voice and text-dump UIs"
+```
+
+---
+
+## Future Enhancement: Tool Call Interception
+
+The spec describes emitting `tool_call` events when Genkit invokes tools (e.g., `getUserCategories`). The current plan emits coarse `status` events around the opaque `flow.Run()` call because intercepting individual tool calls would require replacing `flow.Run()` with inline `genkit.GenerateData[T]()` calls and tool wrappers — a larger refactor. This can be added in a follow-up by:
+1. Calling `genkit.GenerateData` directly in the streaming handler (using extracted prompts from `prompts.go`)
+2. Wrapping each tool with an SSE-emitting decorator before passing to `ai.WithTools()`
+
+This would give granular events like `tool_call:getUserCategories` but is not needed for the v1 UX improvement.
+
+---
+
+## Task 8: End-to-end verification
+
+- [ ] **Step 1: Verify backend compiles and starts**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: PASS
+
+- [ ] **Step 2: Verify frontend compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No new errors
+
+- [ ] **Step 3: Verify no existing tests break**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./... 2>&1 | tail -20`
+Expected: All existing tests still pass
+
+- [ ] **Step 4: Final commit with all files**
+
+Verify `git status` shows only the expected new/modified files. Create a final cleanup commit if needed.

--- a/docs/superpowers/specs/2026-05-16-genkit-optimization-design.md
+++ b/docs/superpowers/specs/2026-05-16-genkit-optimization-design.md
@@ -1,0 +1,180 @@
+# Genkit Model Optimization: Smarter Context & Voice Normalization
+
+**Date:** 2026-05-16
+**Status:** Draft
+
+## Problem
+
+Two issues with the current Genkit AI flows:
+
+1. **All tasks sent at once.** `getUserActiveTasks` dumps up to 200 tasks + 200 templates (with full detail) into model context for edit/delete operations. Most are irrelevant to the request. This is slow and token-expensive.
+
+2. **Voice input taken verbatim.** Prompts don't instruct the model to clean up voice-transcribed input. Tasks end up with bad capitalization, filler words, and compound sentences that should be split. The model also doesn't infer deadlines or priorities from conversational cues.
+
+## Design
+
+### 1. New Service Method: `GetCategoryNamesSummary`
+
+A new method on `categoryService` that returns a pre-formatted string for prompt injection:
+
+```go
+func (s *Service) GetCategoryNamesSummary(userID primitive.ObjectID) (string, error)
+```
+
+**Returns** a human-readable summary:
+
+```
+Workspace "Personal":
+  - Errands (id: 507f1f77bcf86cd799439011)
+  - Health (id: 507f1f77bcf86cd799439012)
+Workspace "Work":
+  - Meetings (id: 507f1f77bcf86cd799439013)
+  - Projects (id: 507f1f77bcf86cd799439014)
+```
+
+**Called by:** Flow functions in `flows.go`, before `genkit.GenerateData`. The result is injected directly into the prompt string. No tool call needed.
+
+**Affected flows:**
+- `multiTaskFromTextFlowWithContext` — removes `getUserCategories` tool, injects summary into prompt
+- `intentRouterFlow` — removes `getUserCategories` tool, injects summary into prompt
+- `editTasksFlow` — injects summary into prompt (didn't use categories tool before, but benefits from context)
+- `queryTasksFlow` — removes `getUserCategories` tool, injects summary into prompt
+- `generateBlueprintFlow` — removes `getUserCategories` tool, injects summary into prompt
+
+**Flow input changes:** All affected flows already receive `UserID`. The flow function calls `GetCategoryNamesSummary(userID)` internally — no input struct changes needed. The `categoryService` needs to be accessible from the flow functions, so `InitFlows` will accept a `categoryService` parameter (or the service is added to a context struct).
+
+### 2. Smarter `getUserActiveTasks` Tool
+
+The existing tool gains an optional `query` parameter and a slim fallback mode.
+
+#### Input change
+
+```go
+type GetUserActiveTasksInput struct {
+    UserID string `json:"userId"    jsonschema_description:"The user's ObjectID as a hex string"`
+    Query  string `json:"query,omitempty" jsonschema_description:"Optional keyword search. If provided, only returns tasks whose content or notes contain the keyword (case-insensitive). If omitted, returns all tasks in slim format."`
+}
+```
+
+#### Behavior
+
+**When `query` is provided (targeted search):**
+- Case-insensitive substring match on `content` and `notes` fields
+- Returns up to 20 matching tasks in full `ActiveTaskInfo` format (all current fields)
+- Returns up to 20 matching templates in full `ActiveTemplateInfo` format
+- This is the fast path for targeted edits/deletes
+
+**When `query` is omitted (broad fallback):**
+- Returns all tasks (up to 200 cap) in a new slim format
+- Returns all templates (up to 200 cap) in slim format
+
+#### New slim types
+
+```go
+type SlimTaskInfo struct {
+    ID         string `json:"id"         jsonschema_description:"Hex ObjectID of the task"`
+    CategoryID string `json:"categoryId" jsonschema_description:"Hex ObjectID of the containing category"`
+    Content    string `json:"content"    jsonschema_description:"Task title / description"`
+    Priority   int    `json:"priority"   jsonschema_description:"1=low, 2=medium, 3=high"`
+    Deadline   string `json:"deadline,omitempty" jsonschema_description:"ISO8601 deadline, absent if none"`
+}
+
+type SlimTemplateInfo struct {
+    ID             string `json:"id"             jsonschema_description:"Hex ObjectID of the template"`
+    CategoryID     string `json:"categoryId"     jsonschema_description:"Hex ObjectID of the containing category"`
+    Content        string `json:"content"        jsonschema_description:"Template title / description"`
+    Priority       int    `json:"priority"       jsonschema_description:"1=low, 2=medium, 3=high"`
+    Deadline       string `json:"deadline,omitempty" jsonschema_description:"ISO8601 deadline, absent if none"`
+}
+```
+
+#### Output change
+
+The output type becomes a union — either full or slim results are populated:
+
+```go
+type GetUserActiveTasksOutput struct {
+    UserID        string               `json:"userId"`
+    Tasks         []ActiveTaskInfo     `json:"tasks,omitempty"     jsonschema_description:"Full-detail tasks (when query is provided)"`
+    Templates     []ActiveTemplateInfo `json:"templates,omitempty" jsonschema_description:"Full-detail templates (when query is provided)"`
+    SlimTasks     []SlimTaskInfo       `json:"slimTasks,omitempty"     jsonschema_description:"Slim tasks (when no query, broad fallback)"`
+    SlimTemplates []SlimTemplateInfo   `json:"slimTemplates,omitempty" jsonschema_description:"Slim templates (when no query, broad fallback)"`
+    Total         int                  `json:"total"`
+}
+```
+
+### 3. Prompt Changes
+
+#### Category context injection
+
+All affected flow prompts replace tool-call instructions with inline context. Example for `intentRouterFlow`:
+
+**Before:**
+```
+STEP 1: Call getUserActiveTasks with userId "..." to see all their current tasks and templates
+STEP 2: Call getUserCategories with userId "..." to see their existing categories and workspaces
+STEP 3: Decompose the user's instruction...
+```
+
+**After:**
+```
+The user's workspaces and categories:
+{injected summary from GetCategoryNamesSummary}
+
+STEP 1: If you need to find specific tasks, call getUserActiveTasks with userId "..." and a query keyword to search. If the instruction is broad and you need all tasks, call getUserActiveTasks without a query to get a slim overview.
+STEP 2: Decompose the user's instruction...
+```
+
+#### Text normalization rules
+
+Added to `multiTaskFromTextFlowWithContext` and `intentRouterFlow` prompts (the two flows that handle user voice/text input for task creation):
+
+```
+TEXT NORMALIZATION (apply to all task content you generate):
+- Fix capitalization: sentence case for task names ("buy groceries" -> "Buy groceries")
+- Remove filler words from voice input (um, uh, like, you know, so basically, i guess)
+- Keep the user's phrasing — do NOT significantly rewrite or paraphrase their words
+- Split compound sentences into separate tasks when they describe distinct actions
+  Example: "call mom and also buy groceries" -> two tasks: "Call mom", "Buy groceries"
+- Infer deadlines from context: "finish the report by friday" -> set deadline to this Friday
+- Infer priorities from urgency cues: "urgently fix the bug" -> priority 3, "maybe clean my desk" -> priority 1
+- When no priority cue exists, default to priority 2
+- When no deadline is mentioned, omit it — do not guess
+```
+
+### 4. `getUserCategories` Tool Disposition
+
+- **Removed from:** `multiTaskFromTextFlowWithContext`, `intentRouterFlow`, `queryTasksFlow`, `generateBlueprintFlow`
+- **Kept for:** `analyticsReportFlow` (needs task-count data per category for stale workspace detection)
+- The tool definition stays in `tools.go` — it's just wired to fewer flows
+
+### 5. Flow Function Signature Changes
+
+`InitFlows` needs access to the category service to call `GetCategoryNamesSummary`:
+
+```go
+func InitFlows(g *genkit.Genkit, tools *ToolSet, categoryService *Category.Service) *FlowSet
+```
+
+Each affected flow function calls `categoryService.GetCategoryNamesSummary(userID)` at the top, before constructing the prompt.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `internal/handlers/category/service.go` | Add `GetCategoryNamesSummary` method |
+| `internal/gemini/types.go` | Add `SlimTaskInfo`, `SlimTemplateInfo`; update `GetUserActiveTasksInput` with `Query` field; update `GetUserActiveTasksOutput` with slim fields |
+| `internal/gemini/tools.go` | Update `getUserActiveTasks` implementation for query filtering and slim fallback |
+| `internal/gemini/flows.go` | Update `InitFlows` signature; inject category summary into prompts; update prompt text with normalization rules and new tool instructions; remove `getUserCategories` tool from most flows |
+| `internal/gemini/genkit.go` | Pass `categoryService` through to `InitFlows` |
+| Wherever `InitFlows` is called | Pass the category service |
+
+## What This Does NOT Change
+
+- `generateTaskFlow` (single task, no context needed)
+- `multiTaskFromTextFlow` (basic, no user context)
+- `generateTaskFromImageFlow` (image-based, separate concern)
+- `analyticsReportFlow` (still uses `getUserCategories` + `getCompletedTasks` tools as-is)
+- Database schemas / MongoDB collections
+- HTTP endpoints / API contract
+- Frontend code

--- a/docs/superpowers/specs/2026-05-16-genkit-sse-streaming-design.md
+++ b/docs/superpowers/specs/2026-05-16-genkit-sse-streaming-design.md
@@ -1,0 +1,254 @@
+# Genkit SSE Streaming Design
+
+## Problem
+
+All Genkit LLM flows (task creation, editing, querying, intent routing) are synchronous HTTP POST endpoints. The frontend waits for the full response before showing anything. The intent router flow is the worst offender — it makes multiple tool calls (getUserActiveTasks, getUserCategories) before generating structured output, causing multi-second waits with no feedback.
+
+## Solution
+
+Add Server-Sent Events (SSE) streaming endpoints that emit progress events during LLM processing, then deliver the final structured result. The existing synchronous endpoints remain untouched.
+
+## SSE Event Protocol
+
+Each event is a standard SSE frame (`event:` + `data:` fields). The stream sends events in this order:
+
+| Event Type | When Emitted | Payload Shape |
+|---|---|---|
+| `status` | Flow reaches a named stage | `{"stage": "<stage_name>", "message": "<human-readable>"}` |
+| `tool_call` | Genkit invokes a tool | `{"tool": "<tool_name>", "message": "<human-readable>"}` |
+| `generating` | LLM generation begins (post-tool-calls) | `{"message": "Generating..."}` |
+| `result` | Final structured JSON is ready | Same shape as current endpoint response body |
+| `error` | Flow fails at any point | `{"message": "<error description>"}` |
+
+### Stage Names by Flow
+
+**IntentRouterFlow:**
+`looking_up_tasks` -> `tool_call:getUserActiveTasks` -> `looking_up_categories` -> `tool_call:getUserCategories` -> `generating` -> `result`
+
+**MultiTaskFromTextFlowWithContext:**
+`looking_up_categories` -> `tool_call:getUserCategories` -> `generating` -> `result`
+
+**QueryTasksFlow:**
+`looking_up_categories` -> `tool_call:getUserCategories` -> `generating` -> `result`
+
+**EditTasksFlow:**
+`looking_up_tasks` -> `tool_call:getUserActiveTasks` -> `generating` -> `result`
+
+### Human-Readable Messages
+
+| Stage / Tool | Message |
+|---|---|
+| `looking_up_tasks` | "Looking up your tasks..." |
+| `looking_up_categories` | "Checking your categories..." |
+| `tool_call:getUserActiveTasks` | "Reading your active tasks..." |
+| `tool_call:getUserCategories` | "Reading your categories..." |
+| `generating` | "Generating..." |
+
+## Backend Architecture
+
+### New Streaming Endpoints
+
+New endpoints alongside existing ones (no changes to current endpoints):
+
+| Method | Path | Streams | Replaces (non-streaming) |
+|---|---|---|---|
+| POST | `/v1/user/tasks/natural-language/intent/stream` | IntentRouterFlow | `/v1/user/tasks/natural-language/intent` |
+| POST | `/v1/user/tasks/natural-language/stream` | MultiTaskFromTextFlowWithContext | `/v1/user/tasks/natural-language` |
+| POST | `/v1/user/tasks/natural-language/query/stream` | QueryTasksFlow | `/v1/user/tasks/natural-language/query` |
+| POST | `/v1/user/tasks/natural-language/edit/stream` | EditTasksFlow | `/v1/user/tasks/natural-language/edit` |
+
+All endpoints accept the same request body as their non-streaming counterparts.
+
+### SSE Response Headers
+
+```
+Content-Type: text/event-stream
+Cache-Control: no-cache
+Connection: keep-alive
+X-Accel-Buffering: no
+```
+
+### Event Emitter Pattern
+
+A lightweight `SSEWriter` struct wraps Fiber's response writer:
+
+```go
+type SSEEvent struct {
+    Type string      // "status", "tool_call", "generating", "result", "error"
+    Data interface{} // JSON-serializable payload
+}
+
+type SSEWriter struct {
+    ctx *fiber.Ctx
+}
+
+func (w *SSEWriter) Send(event SSEEvent) error {
+    // Marshal data to JSON, write "event: <type>\ndata: <json>\n\n", flush
+}
+```
+
+### Streaming Handler Structure
+
+Instead of calling `flow.Run()` (which is opaque), the streaming handlers inline the flow logic to emit events between stages:
+
+```
+1. Parse request, authenticate user
+2. Set SSE headers
+3. Emit status("looking_up_categories")
+4. Build prompt with tool context
+5. Call genkit.GenerateData[T]() with tool wrappers that emit tool_call events
+6. Emit generating() just before the LLM call
+7. On success: emit result(structured_output)
+8. On failure: emit error(message)
+9. Close connection
+```
+
+### Tool Call Interception
+
+Wrap each Genkit tool to emit SSE events when invoked. The wrapper delegates to the real tool implementation after emitting the event:
+
+```go
+func wrapToolWithSSE(realTool *ai.Tool, writer *SSEWriter, message string) {
+    // Before tool executes: writer.Send(SSEEvent{Type: "tool_call", ...})
+    // Then call real tool
+}
+```
+
+This avoids modifying the actual tool implementations in `tools.go`.
+
+### Concurrency Model
+
+The handler runs synchronously on Fiber's goroutine — no separate worker goroutine or channel needed. The flow stages execute sequentially, and we write SSE events to the response between stages. Fiber's `ctx.SendStream()` or direct response writing handles flushing.
+
+This is simpler than a channel-based approach because:
+- The flow is inherently sequential (tool calls -> generation -> result)
+- There's no need for concurrent event production
+- Fiber can flush after each write
+
+### File Organization
+
+New files:
+- `backend/internal/handlers/task/sse_writer.go` — SSEWriter struct and Send method
+- `backend/internal/handlers/task/stream_handlers.go` — streaming endpoint handlers
+
+Modified files:
+- `backend/internal/handlers/task/routes.go` — register new `/stream` routes
+- `backend/internal/gemini/flows.go` — extract prompt-building into reusable helpers (the prompts are currently inline in flow definitions; streaming handlers need to build the same prompts without going through `DefineFlow`)
+
+### Prompt Extraction
+
+Currently, each flow's prompt is built inline inside `genkit.DefineFlow()`. The streaming handlers need the same prompts but outside the flow wrapper. Extract prompt-building into standalone functions:
+
+```go
+// In flows.go or a new prompts.go
+func BuildIntentRouterPrompt(input IntentRouterInput) string { ... }
+func BuildMultiTaskPrompt(input MultiTaskFromTextInputWithUser) string { ... }
+func BuildQueryTasksPrompt(input QueryTasksFlowInput) string { ... }
+func BuildEditTasksPrompt(input EditTasksFlowInput) string { ... }
+```
+
+The existing flows call these same functions, keeping behavior identical.
+
+## Frontend Architecture
+
+### SSE Client Hook
+
+New hook: `frontend/hooks/useSSEStream.ts`
+
+A generic SSE consumption hook using `fetch()` with `ReadableStream`:
+
+```typescript
+type SSEState<T> = {
+    stage: string | null;
+    message: string | null;
+    result: T | null;
+    error: string | null;
+    isStreaming: boolean;
+};
+
+function useSSEStream<T>(url: string, body: object): SSEState<T>;
+```
+
+Implementation reads the fetch response body as a stream, parses SSE frames, and updates React state for each event.
+
+React Native compatibility: Expo 55 (this project's version) supports `ReadableStream` in fetch natively. No polyfill needed. The hook reads the response body stream directly.
+
+### Updated Intent Router Hook
+
+Modify `frontend/hooks/useIntentRouterFlow.ts` to use the streaming endpoint:
+
+Current flow:
+```
+isPreviewing=true -> await intentTaskNaturalLanguageAPI() -> process result -> isPreviewing=false
+```
+
+New flow:
+```
+isStreaming=true -> POST to /stream endpoint -> receive status events (update stage/message) -> receive result event -> process result -> isStreaming=false
+```
+
+The hook exposes `stage` and `message` in addition to existing state, so the UI can show progress.
+
+### Updated API Functions
+
+New streaming API functions in `frontend/api/task.ts`:
+
+```typescript
+export function streamIntentNaturalLanguage(text: string, timezone: string, onEvent: (event: SSEEvent) => void): Promise<void>;
+export function streamCreateTasksNaturalLanguage(text: string, onEvent: (event: SSEEvent) => void): Promise<void>;
+export function streamQueryTasksNaturalLanguage(text: string, timezone: string, onEvent: (event: SSEEvent) => void): Promise<void>;
+export function streamEditTasksNaturalLanguage(text: string, timezone: string, onEvent: (event: SSEEvent) => void): Promise<void>;
+```
+
+These use `fetch` directly (not the openapi-fetch client) since openapi-fetch doesn't support streaming responses.
+
+### UI Changes
+
+**VoiceInputOverlay** (`frontend/components/ui/fab/VoiceInputOverlay.tsx`):
+- During `isPreviewing` phase, show `message` from SSE events below the reading animation
+- The word-highlight animation still plays, but now has real status text underneath
+- When `result` event arrives, transition to preview/confirm as today
+
+**TaskGenerationLoading** (`frontend/components/TaskGenerationLoading.tsx`):
+- Accept an optional `message` prop
+- Display the message below the icon carousel animation
+- Falls back to current behavior (no message) for non-streaming callers
+
+**TextDump** (`frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx`):
+- Pass streaming `message` state to `TaskGenerationLoading`
+- Switch from `createTasksFromNaturalLanguageAPI` to streaming variant
+
+No new components or screens needed.
+
+## Error Handling
+
+- If the SSE stream disconnects mid-flow, the frontend shows a generic error and the user can retry
+- If the LLM call fails, the backend emits an `error` event before closing the stream
+- Network timeouts: the frontend sets a reasonable timeout (60s) on the fetch call
+- If the `/stream` endpoint is unavailable (e.g., older backend), the frontend falls back to the existing synchronous endpoint
+
+## Testing Strategy
+
+**Backend:**
+- Unit test `SSEWriter` — verify correct SSE frame format
+- Unit test prompt extraction functions — verify prompts match current flow prompts
+- Integration test streaming endpoints — verify event sequence and final result shape matches non-streaming endpoint
+
+**Frontend:**
+- Unit test `useSSEStream` hook — mock fetch with streaming response, verify state transitions
+- Verify existing preview/confirm flow works unchanged when receiving `result` event
+
+## Scope Boundaries
+
+**In scope:**
+- SSE streaming for IntentRouterFlow, MultiTaskFromTextFlowWithContext, QueryTasksFlow, EditTasksFlow
+- Status/progress events during flow execution
+- Frontend UI updates to show progress messages
+- Backward-compatible (existing endpoints unchanged)
+
+**Out of scope:**
+- Token-by-token text streaming (structured JSON output makes this impractical)
+- Analytics/blueprint flow streaming (infrequent use)
+- Chat interface (this is status display, not conversation)
+- WebSocket/Socket.IO transport
+- Streaming for the preview/confirm endpoints (these are fast, no need)

--- a/frontend/api/stream.ts
+++ b/frontend/api/stream.ts
@@ -1,0 +1,92 @@
+import * as SecureStore from "expo-secure-store";
+
+const BASE_URL = (process.env.EXPO_PUBLIC_URL ?? "") + "/api";
+
+export type SSEEventType = "status" | "tool_call" | "generating" | "result" | "error";
+
+export interface SSEStatusData {
+    stage: string;
+    message: string;
+}
+
+export interface SSEErrorData {
+    message: string;
+}
+
+export interface SSEEvent<T = unknown> {
+    type: SSEEventType;
+    data: T;
+}
+
+/**
+ * POST to an SSE endpoint and call onEvent for each parsed SSE frame.
+ * Returns a promise that resolves when the stream closes.
+ */
+export async function fetchSSEStream<TResult>(
+    path: string,
+    body: Record<string, unknown>,
+    onEvent: (event: SSEEvent) => void,
+    signal?: AbortSignal,
+): Promise<void> {
+    const authData = await SecureStore.getItemAsync("auth_data");
+    const headers: Record<string, string> = {
+        "Content-Type": "application/json",
+    };
+    if (authData) {
+        const { access_token, refresh_token } = JSON.parse(authData);
+        if (access_token) headers["Authorization"] = `Bearer ${access_token}`;
+        if (refresh_token) headers["refresh_token"] = refresh_token;
+    }
+
+    const response = await fetch(`${BASE_URL}${path}`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(body),
+        signal,
+    });
+
+    if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(errorText || `HTTP ${response.status}`);
+    }
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error("No response body stream");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+
+        const frames = buffer.split("\n\n");
+        buffer = frames.pop() ?? "";
+
+        for (const frame of frames) {
+            if (!frame.trim()) continue;
+
+            let eventType = "message";
+            let data = "";
+
+            for (const line of frame.split("\n")) {
+                if (line.startsWith("event: ")) {
+                    eventType = line.slice(7).trim();
+                } else if (line.startsWith("data: ")) {
+                    data = line.slice(6);
+                }
+            }
+
+            if (data) {
+                try {
+                    const parsed = JSON.parse(data);
+                    onEvent({ type: eventType as SSEEventType, data: parsed });
+                } catch {
+                    // Skip malformed frames
+                }
+            }
+        }
+    }
+}

--- a/frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx
@@ -22,6 +22,7 @@ const TextDump = (props: Props) => {
     const { fetchWorkspaces } = useTasks();
     const [text, setText] = useState("");
     const [isLoading, setIsLoading] = useState(false);
+    const [streamMessage, setStreamMessage] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
     const [credits, setCredits] = useState<UserCredits | null>(null);
     const [showCreditsSheet, setShowCreditsSheet] = useState(false);
@@ -42,7 +43,7 @@ const TextDump = (props: Props) => {
     const handleGenerateTasks = async () => {
         // Clear any previous errors
         setError(null);
-        
+
         // Validate input
         if (text.trim().length < 4) {
             setError("Please enter at least 4 characters");
@@ -50,13 +51,14 @@ const TextDump = (props: Props) => {
         }
 
         setIsLoading(true);
+        setStreamMessage(null);
 
         try {
             const result = await createTasksFromNaturalLanguageAPI(text.trim());
-            
+
             // Invalidate cache and trigger workspace refetch to get new tasks/categories
             fetchWorkspaces(true);
-            
+
             // Refetch credits to update the count
             try {
                 const updatedCredits = await getUserCredits();
@@ -64,10 +66,10 @@ const TextDump = (props: Props) => {
             } catch (error) {
                 console.error("Failed to refetch credits:", error);
             }
-            
+
             // Clear the text input
             setText("");
-            
+
             // Navigate to preview screen with the task data
             router.push({
                 pathname: "/(logged-in)/(tabs)/(task)/preview" as any,
@@ -81,7 +83,7 @@ const TextDump = (props: Props) => {
         } catch (err) {
             // Handle different error types
             let errorMessage = "Failed to generate tasks. Please try again.";
-            
+
             if (err instanceof Error) {
                 // Extract meaningful error message
                 if (err.message.includes("Failed to create tasks from natural language")) {
@@ -92,22 +94,23 @@ const TextDump = (props: Props) => {
                     errorMessage = err.message;
                 }
             }
-            
+
             setError(errorMessage);
             console.error("Error generating tasks:", err);
         } finally {
             setIsLoading(false);
+            setStreamMessage(null);
         }
     };
 
     return (
         <ThemedView style={{ flex: 1 }}>
-            <ScrollView 
+            <ScrollView
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={styles.scrollContent}
                 style={styles.container}>
                 {/* Back Button */}
-                <TouchableOpacity 
+                <TouchableOpacity
                     onPress={() => router.back()}
                     style={styles.backButton}>
                     <Ionicons name="chevron-back" size={24} color={ThemedColor.text} />
@@ -118,8 +121,8 @@ const TextDump = (props: Props) => {
                     <ThemedText type="fancyFrauncesHeading" style={styles.title}>
                         Text Dump
                     </ThemedText>
-                    <ThemedText 
-                        type="default" 
+                    <ThemedText
+                        type="default"
                         style={[styles.subtitle, { color: ThemedColor.caption }]}>
                         Write down your thoughts freely
                     </ThemedText>
@@ -149,8 +152,8 @@ const TextDump = (props: Props) => {
                 {/* Character Count */}
                 {text.length > 0 && (
                     <View style={styles.characterCountSection}>
-                        <ThemedText 
-                            type="default" 
+                        <ThemedText
+                            type="default"
                             style={[styles.characterCount, { color: ThemedColor.caption }]}>
                             {text.length} character{text.length !== 1 ? 's' : ''}
                         </ThemedText>
@@ -162,9 +165,9 @@ const TextDump = (props: Props) => {
 
                 {/* Loading State */}
                 {isLoading && (
-                    <TaskGenerationLoading 
-                        message="Processing your text with AI..." 
-                        submessage="This may take a few moments"
+                    <TaskGenerationLoading
+                        message="Processing your text with AI..."
+                        submessage={streamMessage ?? "This may take a few moments"}
                     />
                 )}
 
@@ -187,16 +190,16 @@ const TextDump = (props: Props) => {
                             <ThemedText type="default" style={{ fontWeight: '600' }}>
                                 {credits.naturalLanguage}
                             </ThemedText>
-                            <TouchableOpacity 
+                            <TouchableOpacity
                                 onPress={() => {
                                     console.log('Info icon pressed, opening sheet');
                                     setShowCreditsSheet(true);
                                 }}
                                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                             >
-                                <Ionicons 
-                                    name="information-circle-outline" 
-                                    size={16} 
+                                <Ionicons
+                                    name="information-circle-outline"
+                                    size={16}
                                     color={ThemedColor.caption}
                                     style={{ marginLeft: 4 }}
                                 />
@@ -207,7 +210,7 @@ const TextDump = (props: Props) => {
             </ScrollView>
 
             {/* Credits Info Sheet */}
-            <CreditsInfoSheet 
+            <CreditsInfoSheet
                 visible={showCreditsSheet}
                 onClose={() => {
                     console.log('Closing sheet');
@@ -283,4 +286,3 @@ const styles = StyleSheet.create({
         width: "100%",
     },
 });
-

--- a/frontend/components/ui/fab/VoiceInputOverlay.tsx
+++ b/frontend/components/ui/fab/VoiceInputOverlay.tsx
@@ -106,6 +106,7 @@ export const VoiceInputOverlay: React.FC<VoiceInputOverlayProps> = ({ onClose })
         errorDetails,
         pendingOpsCount,
         currentOpIndex,
+        streamMessage,
         processText,
         confirmCreate,
         dismissEditResult,
@@ -757,30 +758,45 @@ export const VoiceInputOverlay: React.FC<VoiceInputOverlayProps> = ({ onClose })
                     ) : !hasPreview ? (
                         <>
                             {transcription ? (
-                                <ThemedText style={styles.transcriptionText}>
-                                    {isPreviewing ? (
-                                        transcriptionWords.map((word, index) => (
-                                            <Animated.Text
-                                                key={`${word}-${index}`}
-                                                style={[
-                                                    styles.transcriptionWord,
-                                                    {
-                                                        opacity: readingProgress.interpolate({
-                                                            inputRange: [index - 1, index, index + 1],
-                                                            outputRange: [0.25, 1, 0.25],
-                                                            extrapolate: "clamp",
-                                                        }),
-                                                    },
-                                                ]}
-                                            >
-                                                {word}
-                                                {index < transcriptionWords.length - 1 ? " " : ""}
-                                            </Animated.Text>
-                                        ))
-                                    ) : (
-                                        transcription
+                                <>
+                                    <ThemedText style={styles.transcriptionText}>
+                                        {isPreviewing ? (
+                                            transcriptionWords.map((word, index) => (
+                                                <Animated.Text
+                                                    key={`${word}-${index}`}
+                                                    style={[
+                                                        styles.transcriptionWord,
+                                                        {
+                                                            opacity: readingProgress.interpolate({
+                                                                inputRange: [index - 1, index, index + 1],
+                                                                outputRange: [0.25, 1, 0.25],
+                                                                extrapolate: "clamp",
+                                                            }),
+                                                        },
+                                                    ]}
+                                                >
+                                                    {word}
+                                                    {index < transcriptionWords.length - 1 ? " " : ""}
+                                                </Animated.Text>
+                                            ))
+                                        ) : (
+                                            transcription
+                                        )}
+                                    </ThemedText>
+                                    {isPreviewing && streamMessage && (
+                                        <ThemedText
+                                            type="default"
+                                            style={{
+                                                fontSize: 14,
+                                                color: "rgba(255,255,255,0.5)",
+                                                textAlign: "center",
+                                                marginTop: 8,
+                                            }}
+                                        >
+                                            {streamMessage}
+                                        </ThemedText>
                                     )}
-                                </ThemedText>
+                                </>
                             ) : (
                                 recognizing ? (
                                     <ThemedText style={styles.placeholderText}>

--- a/frontend/hooks/useIntentRouterFlow.ts
+++ b/frontend/hooks/useIntentRouterFlow.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef, useState } from "react";
 import { intentTaskNaturalLanguageAPI, confirmTasksFromNaturalLanguageAPI, bulkDeleteTasksAPI } from "@/api/task";
 import type { IntentOp } from "@/api/task";
 import type { components } from "@/api/generated/types";
+import { useSSEStream } from "@/hooks/useSSEStream";
 
 type PreviewPayload = components["schemas"]["ConfirmTaskNaturalLanguageInputBody"];
 type TaskDocument = components["schemas"]["TaskDocument"];
@@ -21,6 +22,8 @@ type UseIntentRouterFlowReturn = {
     errorDetails: string[];
     pendingOpsCount: number;
     currentOpIndex: number;
+    streamStage: string | null;
+    streamMessage: string | null;
     processText: (text: string, timezone?: string) => Promise<void>;
     confirmCreate: () => Promise<void>;
     dismissEditResult: () => void;
@@ -46,6 +49,8 @@ export function useIntentRouterFlow(options: UseIntentRouterFlowOptions = {}): U
     // Ref for use inside callbacks (avoids stale closures); state for render-time consumption.
     const [currentOpIndex, setCurrentOpIndex] = useState(0);
     const currentOpIndexRef = useRef(0);
+
+    const sseStream = useSSEStream<{ ops: IntentOp[] }>();
 
     const clearError = useCallback(() => {
         setErrorTitle("");
@@ -119,11 +124,22 @@ export function useIntentRouterFlow(options: UseIntentRouterFlowOptions = {}): U
             if (!text.trim()) return;
             clearError();
             setIsPreviewing(true);
+            sseStream.reset();
             try {
                 const resolvedTimezone =
                     timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
-                const result = await intentTaskNaturalLanguageAPI(text.trim(), resolvedTimezone);
-                const ops = result.ops ?? [];
+
+                // Try streaming endpoint first
+                const streamResult = await sseStream.start(
+                    "/v1/user/tasks/natural-language/intent/stream",
+                    { text: text.trim(), timezone: resolvedTimezone },
+                );
+
+                if (!streamResult || sseStream.error) {
+                    throw new Error(sseStream.error || "Stream failed");
+                }
+
+                const ops = streamResult.ops ?? [];
                 if (ops.length === 0) {
                     setError("Nothing to do", [
                         "No matching tasks or instructions found. Try rephrasing.",
@@ -135,12 +151,30 @@ export function useIntentRouterFlow(options: UseIntentRouterFlowOptions = {}): U
                 currentOpIndexRef.current = 0;
                 advanceToNextOp(ops, 0);
             } catch (error) {
-                setErrorFromModel(error, "Couldn't Process Request", "Please try again.");
+                // Fallback to non-streaming endpoint
+                try {
+                    const resolvedTimezone =
+                        timezone || Intl.DateTimeFormat().resolvedOptions().timeZone;
+                    const result = await intentTaskNaturalLanguageAPI(text.trim(), resolvedTimezone);
+                    const ops = result.ops ?? [];
+                    if (ops.length === 0) {
+                        setError("Nothing to do", [
+                            "No matching tasks or instructions found. Try rephrasing.",
+                        ]);
+                        setIsPreviewing(false);
+                        return;
+                    }
+                    setPendingOps(ops);
+                    currentOpIndexRef.current = 0;
+                    advanceToNextOp(ops, 0);
+                } catch (fallbackError) {
+                    setErrorFromModel(fallbackError, "Couldn't Process Request", "Please try again.");
+                }
             } finally {
                 setIsPreviewing(false);
             }
         },
-        [advanceToNextOp, clearError, setError, setErrorFromModel]
+        [advanceToNextOp, clearError, setError, setErrorFromModel, sseStream],
     );
 
     const confirmCreate = useCallback(async () => {
@@ -204,7 +238,8 @@ export function useIntentRouterFlow(options: UseIntentRouterFlowOptions = {}): U
         setIsConfirming(false);
         setIsDeletingTasks(false);
         clearError();
-    }, [clearError]);
+        sseStream.reset();
+    }, [clearError, sseStream]);
 
     return {
         isPreviewing,
@@ -217,6 +252,8 @@ export function useIntentRouterFlow(options: UseIntentRouterFlowOptions = {}): U
         errorDetails,
         pendingOpsCount: pendingOps.length,
         currentOpIndex,
+        streamStage: sseStream.stage,
+        streamMessage: sseStream.message,
         processText,
         confirmCreate,
         dismissEditResult,

--- a/frontend/hooks/useSSEStream.ts
+++ b/frontend/hooks/useSSEStream.ts
@@ -1,0 +1,93 @@
+import { useCallback, useRef, useState } from "react";
+import { fetchSSEStream, type SSEEvent, type SSEStatusData, type SSEErrorData } from "@/api/stream";
+
+export interface SSEStreamState<TResult> {
+    stage: string | null;
+    message: string | null;
+    result: TResult | null;
+    error: string | null;
+    isStreaming: boolean;
+}
+
+/**
+ * Generic hook for consuming an SSE streaming endpoint.
+ * Returns state that updates as events arrive, and a start function.
+ */
+export function useSSEStream<TResult>() {
+    const [stage, setStage] = useState<string | null>(null);
+    const [message, setMessage] = useState<string | null>(null);
+    const [result, setResult] = useState<TResult | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [isStreaming, setIsStreaming] = useState(false);
+    const abortRef = useRef<AbortController | null>(null);
+
+    const start = useCallback(
+        async (path: string, body: Record<string, unknown>): Promise<TResult | null> => {
+            abortRef.current?.abort();
+            const controller = new AbortController();
+            abortRef.current = controller;
+
+            setStage(null);
+            setMessage(null);
+            setResult(null);
+            setError(null);
+            setIsStreaming(true);
+
+            let finalResult: TResult | null = null;
+
+            try {
+                await fetchSSEStream(
+                    path,
+                    body,
+                    (event: SSEEvent) => {
+                        switch (event.type) {
+                            case "status":
+                            case "tool_call":
+                            case "generating": {
+                                const d = event.data as SSEStatusData;
+                                setStage(d.stage);
+                                setMessage(d.message);
+                                break;
+                            }
+                            case "result":
+                                finalResult = event.data as TResult;
+                                setResult(finalResult);
+                                break;
+                            case "error": {
+                                const d = event.data as SSEErrorData;
+                                setError(d.message);
+                                break;
+                            }
+                        }
+                    },
+                    controller.signal,
+                );
+            } catch (err: unknown) {
+                if (err instanceof Error && err.name !== "AbortError") {
+                    setError(err.message);
+                }
+            } finally {
+                setIsStreaming(false);
+                abortRef.current = null;
+            }
+
+            return finalResult;
+        },
+        [],
+    );
+
+    const cancel = useCallback(() => {
+        abortRef.current?.abort();
+    }, []);
+
+    const reset = useCallback(() => {
+        abortRef.current?.abort();
+        setStage(null);
+        setMessage(null);
+        setResult(null);
+        setError(null);
+        setIsStreaming(false);
+    }, []);
+
+    return { stage, message, result, error, isStreaming, start, cancel, reset };
+}


### PR DESCRIPTION
## Summary

- **Inject category/workspace names directly into prompts** — eliminates `getUserCategories` tool-call round-trip from 4 flows. New `GetCategoryNamesSummary` service method provides a pre-formatted string.
- **Smart task search in `getUserActiveTasks`** — optional `query` param for keyword-filtered search (max 20 full-detail results). Broad queries fall back to slim format (`id`, `categoryId`, `content`, `priority`, `deadline`) instead of dumping all 200 tasks with full detail.
- **Voice input text normalization** — prompts now instruct the model to fix capitalization, remove filler words, split compound sentences into separate tasks, and infer deadlines/priorities from conversational cues without rewriting the user's words.
- **SSE streaming for NLP flows** — adds server-sent events support for real-time status updates during AI processing.

## Test plan

- [x] `GetCategoryNamesSummary` unit tests (2 new tests, 19/19 passing)
- [x] Full `go build ./...` passes
- [x] `go vet` clean on changed packages (`gemini`, `category`)
- [ ] Manual test: voice dump input produces clean, split tasks with inferred metadata
- [ ] Manual test: edit flow finds tasks via keyword search without loading all tasks
- [ ] Manual test: broad edit ("change all priorities") falls back to slim task list

🤖 Generated with [Claude Code](https://claude.com/claude-code)