### PR TITLE
feat: productivity score & rings system

### DIFF
--- a/backend/internal/handlers/congratulation/congratulation.go
+++ b/backend/internal/handlers/congratulation/congratulation.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -83,6 +84,17 @@ func (h *Handler) CreateCongratulationHuma(ctx context.Context, input *CreateCon
 		}
 		slog.Error("failed to create congratulation", "userId", user_id, "receiver", input.Body.Receiver, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to create congratulation. Please try again.", err)
+	}
+
+	// Fire-and-forget: increment Share ring for the sender
+	if h.service.RingService != nil {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			_, _, err := h.service.RingService.IncrementRing(context.Background(), senderID, tz, rings.RingShare)
+			if err != nil {
+				slog.Error("Failed to increment Share ring on congratulation sent", "user_id", senderID.Hex(), "error", err)
+			}
+		}()
 	}
 
 	return &CreateCongratulationOutput{Body: *congratulation}, nil

--- a/backend/internal/handlers/congratulation/routes.go
+++ b/backend/internal/handlers/congratulation/routes.go
@@ -1,6 +1,7 @@
 package congratulation
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -8,8 +9,8 @@ import (
 /*
 Router maps endpoints to handlers using Huma operations
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection) {
-	service := newService(collections)
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *rings.RingService) {
+	service := newService(collections, ringService)
 	handler := Handler{service}
 
 	// Register all congratulation operations

--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/xutils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -15,7 +16,7 @@ import (
 )
 
 // newService receives the map of collections and picks out congratulations
-func newService(collections map[string]*mongo.Collection) *Service {
+func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
 	congratulations := collections["congratulations"]
 	users := collections["users"]
 	posts := collections["posts"]
@@ -36,12 +37,13 @@ func newService(collections map[string]*mongo.Collection) *Service {
 		Users:               users,
 		Posts:               posts,
 		NotificationService: notifications.NewNotificationService(collections),
+		RingService:         ringService,
 	}
 }
 
 // NewService is the exported version for testing
 func NewService(collections map[string]*mongo.Collection) *Service {
-	return newService(collections)
+	return newService(collections, nil)
 }
 
 // GetAllCongratulations fetches all Congratulation documents from MongoDB for a specific receiver

--- a/backend/internal/handlers/congratulation/types.go
+++ b/backend/internal/handlers/congratulation/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -178,4 +179,5 @@ type Service struct {
 	Users               *mongo.Collection
 	Posts               *mongo.Collection
 	NotificationService *notifications.Service
+	RingService         *rings.RingService
 }

--- a/backend/internal/handlers/encouragement/encouragement.go
+++ b/backend/internal/handlers/encouragement/encouragement.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -103,6 +104,17 @@ func (h *Handler) CreateEncouragementHuma(ctx context.Context, input *CreateEnco
 		}
 		slog.Error("failed to create encouragement", "userId", user_id, "receiver", input.Body.Receiver, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to create encouragement. Please try again.", err)
+	}
+
+	// Fire-and-forget: increment Share ring for the sender
+	if h.service.RingService != nil {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			_, _, err := h.service.RingService.IncrementRing(context.Background(), senderID, tz, rings.RingShare)
+			if err != nil {
+				slog.Error("Failed to increment Share ring on encouragement sent", "user_id", senderID.Hex(), "error", err)
+			}
+		}()
 	}
 
 	return &CreateEncouragementOutput{Body: *encouragement}, nil

--- a/backend/internal/handlers/encouragement/routes.go
+++ b/backend/internal/handlers/encouragement/routes.go
@@ -1,6 +1,7 @@
 package encouragement
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -8,8 +9,8 @@ import (
 /*
 Router maps endpoints to handlers using Huma operations
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection) {
-	service := newService(collections)
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *rings.RingService) {
+	service := newService(collections, ringService)
 	handler := Handler{service}
 
 	// Register all encouragement operations

--- a/backend/internal/handlers/encouragement/service.go
+++ b/backend/internal/handlers/encouragement/service.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/xutils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -15,7 +16,7 @@ import (
 )
 
 // newService receives the map of collections and picks out encouragements
-func newService(collections map[string]*mongo.Collection) *Service {
+func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
 	encouragements := collections["encouragements"]
 	users := collections["users"]
 
@@ -31,12 +32,13 @@ func newService(collections map[string]*mongo.Collection) *Service {
 		Encouragements:      encouragements,
 		Users:               users,
 		NotificationService: notifications.NewNotificationService(collections),
+		RingService:         ringService,
 	}
 }
 
 // NewEncouragementService is a public constructor for external packages
 func NewEncouragementService(collections map[string]*mongo.Collection) *Service {
-	return newService(collections)
+	return newService(collections, nil)
 }
 
 // GetAllEncouragements fetches all Encouragement documents from MongoDB for a specific receiver

--- a/backend/internal/handlers/encouragement/types.go
+++ b/backend/internal/handlers/encouragement/types.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -192,4 +193,5 @@ type Service struct {
 	Encouragements      *mongo.Collection
 	Users               *mongo.Collection
 	NotificationService *notifications.Service
+	RingService         *rings.RingService
 }

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
 	"github.com/danielgtaylor/huma/v2"
@@ -96,6 +97,17 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 	if err != nil {
 		slog.Error("failed to create post", "userId", user_id, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to create post. Please try again.", err)
+	}
+
+	// Fire-and-forget: increment Share ring
+	if h.service.RingService != nil {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			_, _, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, rings.RingShare)
+			if err != nil {
+				slog.Error("Failed to increment Share ring on post creation", "user_id", userObjID.Hex(), "error", err)
+			}
+		}()
 	}
 
 	// Prepare response with user stats

--- a/backend/internal/handlers/post/routes.go
+++ b/backend/internal/handlers/post/routes.go
@@ -1,6 +1,7 @@
 package Post
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -8,8 +9,8 @@ import (
 /*
 Router maps endpoints to handlers using Huma operations
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection) {
-	service := newService(collections)
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *rings.RingService) {
+	service := newService(collections, ringService)
 	handler := Handler{service}
 
 	// Register all post operations

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/xutils"
 	"go.mongodb.org/mongo-driver/bson"
@@ -23,7 +24,7 @@ type UserStatsUpdate struct {
 }
 
 // newService receives the map of collections and picks out Jobs
-func newService(collections map[string]*mongo.Collection) *Service {
+func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
 	return &Service{
 		Posts:               collections["posts"],
 		Users:               collections["users"],
@@ -33,12 +34,13 @@ func newService(collections map[string]*mongo.Collection) *Service {
 		Connections:         collections["friend-requests"],
 		Reports:             collections["reports"],
 		NotificationService: notifications.NewNotificationService(collections),
+		RingService:         ringService,
 	}
 }
 
 // NewService is the exported version for testing
 func NewService(collections map[string]*mongo.Collection) *Service {
-	return newService(collections)
+	return newService(collections, nil)
 }
 
 // GetReportedPostIDs returns IDs of all posts that have been reported by any user with pending or reviewed status
@@ -239,17 +241,14 @@ func (s *Service) CreatePost(r *types.PostDocument) (*types.PostDocument, *UserS
 	return r, userStats, nil
 }
 
-// updateUserPostStats increments the user's posts made count and adds points based on streak
+// updateUserPostStats increments the user's posts made count.
 func (s *Service) updateUserPostStats(ctx context.Context, userID primitive.ObjectID) (*UserStatsUpdate, error) {
 	userFilter := bson.M{"_id": userID}
 
-	// Use aggregation pipeline to calculate points based on current streak in a single atomic operation
-	// Points = 1 (base) + current streak value
 	updatePipeline := []bson.M{
 		{
 			"$set": bson.M{
 				"posts_made": bson.M{"$add": []interface{}{"$posts_made", 1}},
-				"points":     bson.M{"$add": []interface{}{"$points", bson.M{"$add": []interface{}{1, "$streak"}}}},
 			},
 		},
 	}

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -2,6 +2,7 @@ package Post
 
 import (
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -248,4 +249,5 @@ type Service struct {
 	Connections         *mongo.Collection
 	Reports             *mongo.Collection
 	NotificationService *notifications.Service
+	RingService         *rings.RingService
 }

--- a/backend/internal/handlers/profile/profile.go
+++ b/backend/internal/handlers/profile/profile.go
@@ -21,6 +21,10 @@ func (h *Handler) GetProfiles(ctx context.Context, input *GetProfilesInput) (*Ge
 		return nil, huma.Error500InternalServerError("Unable to load profiles. Please try again.", err)
 	}
 
+	for i := range profiles {
+		profiles[i].sanitizeForResponse(false)
+	}
+
 	return &GetProfilesOutput{Body: profiles}, nil
 }
 
@@ -62,6 +66,7 @@ func (h *Handler) GetProfileByEmail(ctx context.Context, input *GetProfileByEmai
 		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
+	profile.sanitizeForResponse(false)
 	return &GetProfileByEmailOutput{Body: *profile}, nil
 }
 
@@ -71,6 +76,7 @@ func (h *Handler) GetProfileByPhone(ctx context.Context, input *GetProfileByPhon
 		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
+	profile.sanitizeForResponse(false)
 	return &GetProfileByPhoneOutput{Body: *profile}, nil
 }
 
@@ -89,6 +95,10 @@ func (h *Handler) SearchProfiles(ctx context.Context, input *SearchProfilesInput
 		return nil, huma.Error500InternalServerError("Unable to search profiles. Please try again.", err)
 	}
 
+	for i := range profiles {
+		profiles[i].sanitizeForResponse(false)
+	}
+
 	return &SearchProfilesOutput{Body: profiles}, nil
 }
 
@@ -99,6 +109,10 @@ func (h *Handler) GetProfilesHuma(ctx context.Context, input *GetProfilesInput) 
 	if err != nil {
 		slog.Error("Failed to fetch profiles", "error", err)
 		return nil, huma.Error500InternalServerError("Unable to load profiles. Please try again.", err)
+	}
+
+	for i := range profiles {
+		profiles[i].sanitizeForResponse(false)
 	}
 
 	resp := &GetProfilesOutput{Body: profiles}
@@ -170,6 +184,10 @@ func (h *Handler) GetProfileHuma(ctx context.Context, input *GetProfileInput) (*
 		profile.CompletedTasks = []types.TaskDocument{}
 	}
 
+	// Sanitize internal metrics before returning
+	isSelf := relationship != nil && relationship.Status == RelationshipSelf
+	profile.sanitizeForResponse(isSelf)
+
 	resp := &GetProfileOutput{Body: *profile}
 	return resp, nil
 }
@@ -212,6 +230,7 @@ func (h *Handler) GetProfileByEmailHuma(ctx context.Context, input *GetProfileBy
 		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
+	profile.sanitizeForResponse(false)
 	resp := &GetProfileByEmailOutput{Body: *profile}
 	return resp, nil
 }
@@ -222,6 +241,7 @@ func (h *Handler) GetProfileByPhoneHuma(ctx context.Context, input *GetProfileBy
 		return nil, huma.Error404NotFound("No profile found matching your search", err)
 	}
 
+	profile.sanitizeForResponse(false)
 	resp := &GetProfileByPhoneOutput{Body: *profile}
 	return resp, nil
 }
@@ -325,6 +345,12 @@ func (h *Handler) SearchProfilesHuma(ctx context.Context, input *SearchProfilesI
 	}
 	profiles = filtered
 
+	// Sanitize internal metrics before returning
+	for i := range profiles {
+		isSelf := profiles[i].Relationship != nil && profiles[i].Relationship.Status == RelationshipSelf
+		profiles[i].sanitizeForResponse(isSelf)
+	}
+
 	resp := &SearchProfilesOutput{Body: profiles}
 	return resp, nil
 }
@@ -372,6 +398,12 @@ func (h *Handler) AutocompleteProfilesHuma(ctx context.Context, input *Autocompl
 		}
 	}
 	profiles = filtered
+
+	// Sanitize internal metrics before returning
+	for i := range profiles {
+		isSelf := profiles[i].Relationship != nil && profiles[i].Relationship.Status == RelationshipSelf
+		profiles[i].sanitizeForResponse(isSelf)
+	}
 
 	resp := &AutocompleteProfilesOutput{Body: profiles}
 	return resp, nil

--- a/backend/internal/handlers/profile/types.go
+++ b/backend/internal/handlers/profile/types.go
@@ -19,15 +19,16 @@ const (
 )
 
 type ProfileDocument struct {
-	ID             primitive.ObjectID   `bson:"_id" json:"id"`
-	ProfilePicture *string              `bson:"profile_picture" json:"profile_picture"`
-	DisplayName    string               `bson:"display_name" json:"display_name"`
-	Handle         string               `bson:"handle" json:"handle"`
-	TasksComplete  int                  `bson:"tasks_complete" json:"tasks_complete"`
-	Streak         int                  `bson:"streak" json:"streak"`
-	Points         int                  `bson:"points" json:"points"`         // Stored field in users collection
-	PostsMade      int                  `bson:"posts_made" json:"posts_made"` // Stored field in users collection
-	Friends        []primitive.ObjectID `bson:"friends" json:"friends"`
+	ID                primitive.ObjectID   `bson:"_id" json:"id"`
+	ProfilePicture    *string              `bson:"profile_picture" json:"profile_picture"`
+	DisplayName       string               `bson:"display_name" json:"display_name"`
+	Handle            string               `bson:"handle" json:"handle"`
+	TasksComplete     int                  `bson:"tasks_complete" json:"tasks_complete"`
+	Streak            int                  `bson:"streak" json:"streak"`
+	Points            int                  `bson:"points" json:"points"`                         // Suppressed in API responses (always 0)
+	ProductivityScore int                  `bson:"productivity_score" json:"productivity_score"` // Public-facing score
+	PostsMade         int                  `bson:"posts_made" json:"posts_made"`                 // Stored field in users collection
+	Friends           []primitive.ObjectID `bson:"friends" json:"friends"`
 	// Relationship information - only included when viewing another user's profile
 	Relationship   *RelationshipInfo    `bson:"-" json:"relationship,omitempty"`
 	Tasks          []types.TaskDocument `bson:"tasks" json:"tasks,omitempty"`
@@ -38,6 +39,16 @@ type ProfileDocument struct {
 type RelationshipInfo struct {
 	Status    RelationshipStatus `json:"status"`
 	RequestID *string            `json:"request_id,omitempty"` // ID of the connection request if applicable
+}
+
+// sanitizeForResponse hides internal metrics from the API response.
+// Points are always hidden. Streak is hidden when viewing another user's profile
+// (it is only visible to the user themselves via productivity_score).
+func (p *ProfileDocument) sanitizeForResponse(isSelf bool) {
+	p.Points = 0
+	if !isSelf {
+		p.Streak = 0
+	}
 }
 
 type UpdateProfileDocument struct {

--- a/backend/internal/handlers/rings/routes.go
+++ b/backend/internal/handlers/rings/routes.go
@@ -19,18 +19,22 @@ type Handler struct {
 	users   *mongo.Collection
 }
 
-// Routes registers ring endpoints with the Huma API.
-func Routes(api huma.API, collections map[string]*mongo.Collection) {
+// NewRingServiceFromCollections creates a RingService from the standard
+// collections map, auto-creating the ring_states collection if absent.
+func NewRingServiceFromCollections(collections map[string]*mongo.Collection) *RingService {
 	ringStates := collections["ring_states"]
 	if ringStates == nil {
 		db := collections["users"].Database()
 		ringStates = db.Collection("ring_states")
 		collections["ring_states"] = ringStates
 	}
+	return NewRingService(ringStates, collections["users"])
+}
 
-	service := NewRingService(ringStates, collections["users"])
+// Routes registers ring endpoints with the Huma API.
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *RingService) {
 	handler := &Handler{
-		service: service,
+		service: ringService,
 		users:   collections["users"],
 	}
 

--- a/backend/internal/handlers/rings/routes.go
+++ b/backend/internal/handlers/rings/routes.go
@@ -1,0 +1,195 @@
+package rings
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Handler holds the ring service for HTTP handling.
+type Handler struct {
+	service *RingService
+	users   *mongo.Collection
+}
+
+// Routes registers ring endpoints with the Huma API.
+func Routes(api huma.API, collections map[string]*mongo.Collection) {
+	ringStates := collections["ring_states"]
+	if ringStates == nil {
+		db := collections["users"].Database()
+		ringStates = db.Collection("ring_states")
+		collections["ring_states"] = ringStates
+	}
+
+	service := NewRingService(ringStates, collections["users"])
+	handler := &Handler{
+		service: service,
+		users:   collections["users"],
+	}
+
+	RegisterRingOperations(api, handler)
+}
+
+// RegisterRingOperations registers all ring operations with Huma.
+func RegisterRingOperations(api huma.API, handler *Handler) {
+	RegisterGetTodayOperation(api, handler)
+	RegisterGetHistoryOperation(api, handler)
+	RegisterClaimRewardOperation(api, handler)
+}
+
+// --- Operation registrations ---
+
+func RegisterGetTodayOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-rings-today",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/rings/today",
+		Summary:     "Get today's ring state and score",
+		Description: "Returns the current day's ring progress, productivity score, streak, and reward availability",
+		Tags:        []string{"rings"},
+	}, handler.GetToday)
+}
+
+func RegisterGetHistoryOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-rings-history",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/rings/history",
+		Summary:     "Get ring history",
+		Description: "Returns ring state history for the specified number of days (default 7, max 30)",
+		Tags:        []string{"rings"},
+	}, handler.GetHistory)
+}
+
+func RegisterClaimRewardOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "claim-ring-reward",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/rings/reward",
+		Summary:     "Claim daily ring reward",
+		Description: "Claims the daily reward when all three rings are closed",
+		Tags:        []string{"rings"},
+	}, handler.ClaimReward)
+}
+
+// --- Handlers ---
+
+// GetToday returns today's ring state along with the productivity score and streak.
+func (h *Handler) GetToday(ctx context.Context, input *struct{}) (*GetTodayResponse, error) {
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID")
+	}
+
+	timezone := auth.GetTimezoneOrDefault(ctx)
+
+	state, err := h.service.GetOrCreateToday(ctx, userObjID, timezone)
+	if err != nil {
+		slog.Error("Failed to get today's ring state", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to load ring state")
+	}
+
+	score, err := h.service.CalculateScore(ctx, userObjID, timezone)
+	if err != nil {
+		slog.Error("Failed to calculate productivity score", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to calculate productivity score")
+	}
+
+	// Fetch user streak from the users collection.
+	var user types.User
+	if err := h.users.FindOne(ctx, bson.M{"_id": userObjID}).Decode(&user); err != nil {
+		slog.Error("Failed to fetch user for streak", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to load user data")
+	}
+
+	resp := &GetTodayResponse{}
+	resp.Body.RingState = *state
+	resp.Body.ProductivityScore = score
+	resp.Body.CurrentStreak = user.Streak
+	resp.Body.RewardAvailable = state.AllClosed && !state.RewardClaimed
+
+	return resp, nil
+}
+
+// GetHistory returns the user's ring history for the requested number of days.
+func (h *Handler) GetHistory(ctx context.Context, input *GetHistoryInput) (*GetHistoryResponse, error) {
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID")
+	}
+
+	timezone := auth.GetTimezoneOrDefault(ctx)
+
+	history, err := h.service.GetHistory(ctx, userObjID, timezone, input.Days)
+	if err != nil {
+		slog.Error("Failed to get ring history", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to load ring history")
+	}
+
+	score, err := h.service.CalculateScore(ctx, userObjID, timezone)
+	if err != nil {
+		slog.Error("Failed to calculate productivity score", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to calculate productivity score")
+	}
+
+	var user types.User
+	if err := h.users.FindOne(ctx, bson.M{"_id": userObjID}).Decode(&user); err != nil {
+		slog.Error("Failed to fetch user for streak", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to load user data")
+	}
+
+	resp := &GetHistoryResponse{}
+	resp.Body.History = history
+	resp.Body.Score = score
+	resp.Body.Streak = user.Streak
+
+	return resp, nil
+}
+
+// ClaimReward claims the daily reward when all rings are closed.
+func (h *Handler) ClaimReward(ctx context.Context, input *struct{}) (*ClaimRewardResponse, error) {
+	userID, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, huma.Error401Unauthorized("Authentication required")
+	}
+
+	userObjID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID")
+	}
+
+	timezone := auth.GetTimezoneOrDefault(ctx)
+
+	result, err := h.service.ClaimReward(ctx, userObjID, timezone)
+	if err != nil {
+		slog.Error("Failed to claim ring reward", "error", err, "user_id", userID)
+		return nil, huma.Error500InternalServerError("Unable to claim reward")
+	}
+
+	if !result.Claimed {
+		return nil, huma.Error400BadRequest("Reward not available. All rings must be closed and reward must not already be claimed.")
+	}
+
+	resp := &ClaimRewardResponse{}
+	resp.Body.CreditType = result.CreditType
+	resp.Body.Amount = result.Amount
+
+	return resp, nil
+}

--- a/backend/internal/handlers/rings/service.go
+++ b/backend/internal/handlers/rings/service.go
@@ -1,0 +1,376 @@
+package rings
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// ClaimResult is the internal result of a reward claim operation.
+type ClaimResult struct {
+	Claimed    bool
+	CreditType string
+	Amount     int
+}
+
+// RingService contains the core ring logic.
+type RingService struct {
+	ringStates *mongo.Collection
+	users      *mongo.Collection
+}
+
+// NewRingService creates a new RingService.
+func NewRingService(ringStates, users *mongo.Collection) *RingService {
+	return &RingService{
+		ringStates: ringStates,
+		users:      users,
+	}
+}
+
+// todayInTimezone returns today's date (midnight UTC representation) based on
+// the given IANA timezone string. If the timezone is invalid, UTC is used.
+func todayInTimezone(timezone string) time.Time {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	return time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+// GetOrCreateToday returns today's ring state for the user, creating one with
+// default targets if it does not already exist.
+func (s *RingService) GetOrCreateToday(ctx context.Context, userID primitive.ObjectID, timezone string) (*RingState, error) {
+	today := todayInTimezone(timezone)
+	now := time.Now()
+
+	filter := bson.M{
+		"user_id": userID,
+		"date":    today,
+	}
+
+	update := bson.M{
+		"$setOnInsert": bson.M{
+			"user_id": userID,
+			"date":    today,
+			"plan": RingProgress{
+				Current: 0,
+				Target:  DefaultPlanTarget,
+				Closed:  false,
+			},
+			"do": RingProgress{
+				Current: 0,
+				Target:  DefaultDoTarget,
+				Closed:  false,
+			},
+			"share": RingProgress{
+				Current: 0,
+				Target:  DefaultShareTarget,
+				Closed:  false,
+			},
+			"all_closed":     false,
+			"reward_claimed": false,
+			"created_at":     now,
+			"updated_at":     now,
+		},
+	}
+
+	opts := options.FindOneAndUpdate().
+		SetUpsert(true).
+		SetReturnDocument(options.After)
+
+	var state RingState
+	err := s.ringStates.FindOneAndUpdate(ctx, filter, update, opts).Decode(&state)
+	if err != nil {
+		return nil, fmt.Errorf("get or create ring state: %w", err)
+	}
+	return &state, nil
+}
+
+// IncrementRing increments the specified ring's current count by 1, updates
+// closure flags, and recalculates the productivity score. It returns the
+// updated state and whether all rings just became closed on this increment.
+func (s *RingService) IncrementRing(ctx context.Context, userID primitive.ObjectID, timezone string, ringType RingType) (*RingState, bool, error) {
+	// Ensure today's state exists first.
+	_, err := s.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		return nil, false, err
+	}
+
+	today := todayInTimezone(timezone)
+	now := time.Now()
+
+	ringField := string(ringType) + ".current"
+
+	// Atomically increment the ring's current value.
+	filter := bson.M{
+		"user_id": userID,
+		"date":    today,
+	}
+
+	incUpdate := bson.M{
+		"$inc": bson.M{ringField: 1},
+		"$set": bson.M{"updated_at": now},
+	}
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+	var state RingState
+	err = s.ringStates.FindOneAndUpdate(ctx, filter, incUpdate, opts).Decode(&state)
+	if err != nil {
+		return nil, false, fmt.Errorf("increment ring: %w", err)
+	}
+
+	// Recalculate closure flags.
+	planClosed := state.Plan.Current >= state.Plan.Target
+	doClosed := state.Do.Current >= state.Do.Target
+	shareClosed := state.Share.Current >= state.Share.Target
+	allClosed := planClosed && doClosed && shareClosed
+	wasPreviouslyAllClosed := state.AllClosed
+	justClosedAll := allClosed && !wasPreviouslyAllClosed
+
+	// Update closure flags on the document.
+	closureUpdate := bson.M{
+		"$set": bson.M{
+			"plan.closed":  planClosed,
+			"do.closed":    doClosed,
+			"share.closed": shareClosed,
+			"all_closed":   allClosed,
+			"updated_at":   now,
+		},
+	}
+
+	err = s.ringStates.FindOneAndUpdate(ctx, filter, closureUpdate, opts).Decode(&state)
+	if err != nil {
+		return nil, false, fmt.Errorf("update closure flags: %w", err)
+	}
+
+	// Recalculate and cache the productivity score on the user document.
+	if err := s.recalculateScore(ctx, userID, timezone); err != nil {
+		return nil, false, err
+	}
+
+	return &state, justClosedAll, nil
+}
+
+// CalculateScore computes the productivity score for a user based on recent
+// ring closures and streak.
+func (s *RingService) CalculateScore(ctx context.Context, userID primitive.ObjectID, timezone string) (int, error) {
+	today := todayInTimezone(timezone)
+	windowStart := today.AddDate(0, 0, -ScoreRingWindow+1)
+
+	// Query ring states for the last 7 days.
+	filter := bson.M{
+		"user_id": userID,
+		"date": bson.M{
+			"$gte": windowStart,
+			"$lte": today,
+		},
+	}
+
+	cursor, err := s.ringStates.Find(ctx, filter)
+	if err != nil {
+		return 0, fmt.Errorf("query ring states for score: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var states []RingState
+	if err := cursor.All(ctx, &states); err != nil {
+		return 0, fmt.Errorf("decode ring states: %w", err)
+	}
+
+	// Count total closed rings across all days in the window.
+	closedRings := 0
+	for _, st := range states {
+		if st.Plan.Closed {
+			closedRings++
+		}
+		if st.Do.Closed {
+			closedRings++
+		}
+		if st.Share.Closed {
+			closedRings++
+		}
+	}
+
+	// Fetch user streak.
+	var user types.User
+	err = s.users.FindOne(ctx, bson.M{"_id": userID}).Decode(&user)
+	if err != nil {
+		return 0, fmt.Errorf("fetch user for score: %w", err)
+	}
+
+	// Formula: base + ring_bonus + streak_bonus, capped at 100.
+	ringBonus := float64(closedRings) / float64(ScoreMaxRings) * float64(ScoreRingBonus)
+	streakBonus := math.Min(float64(user.Streak), float64(ScoreMaxStreak))
+	score := float64(ScoreBase) + ringBonus + streakBonus
+	if score > 100 {
+		score = 100
+	}
+
+	return int(score), nil
+}
+
+// GetHistory returns the user's ring states for the last N days (capped at 30),
+// sorted by date descending.
+func (s *RingService) GetHistory(ctx context.Context, userID primitive.ObjectID, timezone string, days int) ([]RingState, error) {
+	if days > 30 {
+		days = 30
+	}
+	if days <= 0 {
+		days = 7
+	}
+
+	today := todayInTimezone(timezone)
+	startDate := today.AddDate(0, 0, -days+1)
+
+	filter := bson.M{
+		"user_id": userID,
+		"date": bson.M{
+			"$gte": startDate,
+			"$lte": today,
+		},
+	}
+
+	opts := options.Find().SetSort(bson.M{"date": -1})
+	cursor, err := s.ringStates.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("query ring history: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var states []RingState
+	if err := cursor.All(ctx, &states); err != nil {
+		return nil, fmt.Errorf("decode ring history: %w", err)
+	}
+
+	return states, nil
+}
+
+// ClaimReward claims the daily ring reward if all rings are closed and the
+// reward has not already been claimed. Returns the claim result.
+func (s *RingService) ClaimReward(ctx context.Context, userID primitive.ObjectID, timezone string) (*ClaimResult, error) {
+	state, err := s.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	if !state.AllClosed {
+		return &ClaimResult{Claimed: false}, nil
+	}
+	if state.RewardClaimed {
+		return &ClaimResult{Claimed: false}, nil
+	}
+
+	reward := pickRandomReward()
+
+	// Add credits to user document.
+	creditType := types.CreditType(reward.CreditType)
+	fieldName, err := types.GetCreditFieldName(creditType)
+	if err != nil {
+		return nil, fmt.Errorf("invalid reward credit type %q: %w", reward.CreditType, err)
+	}
+
+	now := time.Now()
+	_, err = s.users.UpdateOne(ctx, bson.M{"_id": userID}, bson.M{
+		"$inc": bson.M{fieldName: reward.Amount},
+		"$set": bson.M{"last_reward_date": now},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("add reward credits: %w", err)
+	}
+
+	// Mark reward on ring state.
+	today := todayInTimezone(timezone)
+	_, err = s.ringStates.UpdateOne(ctx, bson.M{
+		"user_id": userID,
+		"date":    today,
+	}, bson.M{
+		"$set": bson.M{
+			"reward_claimed": true,
+			"reward_type":    reward.CreditType,
+			"reward_amount":  reward.Amount,
+			"updated_at":     now,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("mark reward claimed: %w", err)
+	}
+
+	return &ClaimResult{
+		Claimed:    true,
+		CreditType: reward.CreditType,
+		Amount:     reward.Amount,
+	}, nil
+}
+
+// pickRandomReward performs weighted random selection from the RewardPool.
+func pickRandomReward() RewardDrop {
+	totalWeight := 0
+	for _, r := range RewardPool {
+		totalWeight += r.Weight
+	}
+
+	roll := rand.Intn(totalWeight)
+	cumulative := 0
+	for _, r := range RewardPool {
+		cumulative += r.Weight
+		if roll < cumulative {
+			return r
+		}
+	}
+
+	// Fallback (should never reach here).
+	return RewardPool[0]
+}
+
+// EnsureIndexes creates the required indexes on the ring_states collection.
+func (s *RingService) EnsureIndexes(ctx context.Context) error {
+	indexes := []mongo.IndexModel{
+		{
+			Keys: bson.D{
+				{Key: "user_id", Value: 1},
+				{Key: "date", Value: 1},
+			},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys: bson.D{
+				{Key: "created_at", Value: 1},
+			},
+			Options: options.Index().SetExpireAfterSeconds(30 * 24 * 60 * 60), // 30 days
+		},
+	}
+
+	_, err := s.ringStates.Indexes().CreateMany(ctx, indexes)
+	if err != nil {
+		return fmt.Errorf("create ring state indexes: %w", err)
+	}
+
+	return nil
+}
+
+// recalculateScore calculates the productivity score and caches it on the user
+// document.
+func (s *RingService) recalculateScore(ctx context.Context, userID primitive.ObjectID, timezone string) error {
+	score, err := s.CalculateScore(ctx, userID, timezone)
+	if err != nil {
+		return fmt.Errorf("recalculate score: %w", err)
+	}
+
+	_, err = s.users.UpdateOne(ctx, bson.M{"_id": userID}, bson.M{
+		"$set": bson.M{"productivity_score": score},
+	})
+	if err != nil {
+		return fmt.Errorf("cache productivity score: %w", err)
+	}
+
+	return nil
+}

--- a/backend/internal/handlers/rings/service_test.go
+++ b/backend/internal/handlers/rings/service_test.go
@@ -1,0 +1,311 @@
+package rings_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/abhikaboy/Kindred/internal/handlers/rings"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// RingServiceTestSuite tests the ring service
+type RingServiceTestSuite struct {
+	testpkg.BaseSuite
+	service    *RingService
+	ringStates *mongo.Collection
+	users      *mongo.Collection
+}
+
+// SetupTest runs before each test
+func (s *RingServiceTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+
+	// Create ring_states collection from the test database
+	s.ringStates = s.TestDB.DB.Collection("ring_states")
+	s.users = s.Collections["users"]
+
+	// Create service
+	s.service = NewRingService(s.ringStates, s.users)
+}
+
+// TestRingService runs the test suite
+func TestRingService(t *testing.T) {
+	testpkg.RunSuite(t, new(RingServiceTestSuite))
+}
+
+// ========================================
+// GetOrCreateToday Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestGetOrCreateToday_CreatesNewState() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// First call should create a new state with default targets
+	state, err := s.service.GetOrCreateToday(ctx, user.ID, "UTC")
+
+	s.NoError(err)
+	s.NotNil(state)
+	s.Equal(user.ID, state.UserID)
+	s.Equal(0, state.Plan.Current)
+	s.Equal(DefaultPlanTarget, state.Plan.Target)
+	s.False(state.Plan.Closed)
+	s.Equal(0, state.Do.Current)
+	s.Equal(DefaultDoTarget, state.Do.Target)
+	s.False(state.Do.Closed)
+	s.Equal(0, state.Share.Current)
+	s.Equal(DefaultShareTarget, state.Share.Target)
+	s.False(state.Share.Closed)
+	s.False(state.AllClosed)
+	s.False(state.RewardClaimed)
+}
+
+func (s *RingServiceTestSuite) TestGetOrCreateToday_ReturnsSameDocument() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// First call creates
+	state1, err := s.service.GetOrCreateToday(ctx, user.ID, "UTC")
+	s.NoError(err)
+
+	// Second call should return the same document
+	state2, err := s.service.GetOrCreateToday(ctx, user.ID, "UTC")
+	s.NoError(err)
+
+	s.Equal(state1.ID, state2.ID)
+	s.Equal(state1.Date, state2.Date)
+}
+
+// ========================================
+// IncrementRing Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestIncrementRing_DoRingOnce() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Increment Do ring once
+	state, justClosedAll, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+
+	s.NoError(err)
+	s.NotNil(state)
+	s.Equal(1, state.Do.Current)
+	s.False(state.Do.Closed) // Target is 3, so not closed yet
+	s.False(justClosedAll)
+}
+
+// ========================================
+// AllRingsClose Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestAllRingsClose() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Close Plan ring (target = 2)
+	var state *RingState
+	var justClosedAll bool
+	var err error
+
+	for i := 0; i < DefaultPlanTarget; i++ {
+		state, justClosedAll, err = s.service.IncrementRing(ctx, user.ID, "UTC", RingPlan)
+		s.NoError(err)
+	}
+	s.True(state.Plan.Closed)
+	s.False(justClosedAll)
+
+	// Close Do ring (target = 3)
+	for i := 0; i < DefaultDoTarget; i++ {
+		state, justClosedAll, err = s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+		s.NoError(err)
+	}
+	s.True(state.Do.Closed)
+	s.False(justClosedAll)
+
+	// Close Share ring (target = 1) — this should trigger justClosedAll
+	state, justClosedAll, err = s.service.IncrementRing(ctx, user.ID, "UTC", RingShare)
+	s.NoError(err)
+	s.True(state.Share.Closed)
+	s.True(state.AllClosed)
+	s.True(justClosedAll)
+}
+
+// ========================================
+// ClaimReward Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestClaimReward_CannotClaimWithoutClosingAllRings() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Create today's state (no rings closed)
+	_, err := s.service.GetOrCreateToday(ctx, user.ID, "UTC")
+	s.NoError(err)
+
+	// Try to claim reward
+	result, err := s.service.ClaimReward(ctx, user.ID, "UTC")
+	s.NoError(err)
+	s.NotNil(result)
+	s.False(result.Claimed)
+}
+
+func (s *RingServiceTestSuite) TestClaimReward_SuccessAfterClosingAllRings() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Close all rings
+	for i := 0; i < DefaultPlanTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingPlan)
+		s.NoError(err)
+	}
+	for i := 0; i < DefaultDoTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+		s.NoError(err)
+	}
+	for i := 0; i < DefaultShareTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingShare)
+		s.NoError(err)
+	}
+
+	// Claim reward
+	result, err := s.service.ClaimReward(ctx, user.ID, "UTC")
+	s.NoError(err)
+	s.NotNil(result)
+	s.True(result.Claimed)
+	s.NotEmpty(result.CreditType)
+	s.Greater(result.Amount, 0)
+
+	// Verify credits were added to user
+	var updatedUser types.User
+	err = s.users.FindOne(ctx, bson.M{"_id": user.ID}).Decode(&updatedUser)
+	s.NoError(err)
+
+	// At least one credit type should have been incremented
+	totalCredits := updatedUser.Credits.Voice + updatedUser.Credits.Analytics + updatedUser.Credits.NaturalLanguage
+	s.Greater(totalCredits, 0)
+}
+
+func (s *RingServiceTestSuite) TestClaimReward_CannotClaimTwice() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Close all rings
+	for i := 0; i < DefaultPlanTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingPlan)
+		s.NoError(err)
+	}
+	for i := 0; i < DefaultDoTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+		s.NoError(err)
+	}
+	for i := 0; i < DefaultShareTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingShare)
+		s.NoError(err)
+	}
+
+	// First claim succeeds
+	result1, err := s.service.ClaimReward(ctx, user.ID, "UTC")
+	s.NoError(err)
+	s.True(result1.Claimed)
+
+	// Second claim fails
+	result2, err := s.service.ClaimReward(ctx, user.ID, "UTC")
+	s.NoError(err)
+	s.False(result2.Claimed)
+}
+
+// ========================================
+// CalculateScore Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestCalculateScore_BaseScoreWithNoRings() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	score, err := s.service.CalculateScore(ctx, user.ID, "UTC")
+
+	s.NoError(err)
+	s.GreaterOrEqual(score, ScoreBase)
+}
+
+func (s *RingServiceTestSuite) TestCalculateScore_IncreasesWithClosedRings() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// Get base score
+	baseScore, err := s.service.CalculateScore(ctx, user.ID, "UTC")
+	s.NoError(err)
+
+	// Close some rings
+	for i := 0; i < DefaultPlanTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingPlan)
+		s.NoError(err)
+	}
+	for i := 0; i < DefaultDoTarget; i++ {
+		_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+		s.NoError(err)
+	}
+
+	// Score should be higher now
+	newScore, err := s.service.CalculateScore(ctx, user.ID, "UTC")
+	s.NoError(err)
+	s.Greater(newScore, baseScore)
+}
+
+// ========================================
+// PickRandomReward Tests
+// ========================================
+
+func (s *RingServiceTestSuite) TestPickRandomReward_DistinctTypes() {
+	user := s.GetUser(0)
+	ctx := context.Background()
+
+	// We need to close all rings and claim rewards multiple times.
+	// Since we can only claim once per day, we test the distribution
+	// by repeatedly closing rings and claiming.
+	// However, pickRandomReward is not exported directly.
+	// Instead, we run multiple claims across different "users" or
+	// verify through ClaimReward results.
+
+	// Use a map to track distinct reward types
+	rewardTypes := make(map[string]bool)
+
+	// Run 10000 iterations by claiming rewards for the same user
+	// We need to create a fresh ring state for each iteration.
+	for i := 0; i < 10000; i++ {
+		// Clean ring_states for this user so we can claim again
+		_, err := s.ringStates.DeleteMany(ctx, bson.M{"user_id": user.ID})
+		s.NoError(err)
+
+		// Close all rings
+		for j := 0; j < DefaultPlanTarget; j++ {
+			_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingPlan)
+			s.NoError(err)
+		}
+		for j := 0; j < DefaultDoTarget; j++ {
+			_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingDo)
+			s.NoError(err)
+		}
+		for j := 0; j < DefaultShareTarget; j++ {
+			_, _, err := s.service.IncrementRing(ctx, user.ID, "UTC", RingShare)
+			s.NoError(err)
+		}
+
+		// Claim reward
+		result, err := s.service.ClaimReward(ctx, user.ID, "UTC")
+		s.NoError(err)
+		s.True(result.Claimed)
+
+		rewardTypes[result.CreditType] = true
+
+		// Early exit if we already found enough distinct types
+		if len(rewardTypes) >= 3 {
+			break
+		}
+	}
+
+	s.GreaterOrEqual(len(rewardTypes), 3, "Expected at least 3 distinct reward types, got: %v", rewardTypes)
+}

--- a/backend/internal/handlers/rings/types.go
+++ b/backend/internal/handlers/rings/types.go
@@ -1,0 +1,105 @@
+package rings
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// RingType represents the type of activity ring
+type RingType string
+
+const (
+	RingPlan  RingType = "plan"
+	RingDo    RingType = "do"
+	RingShare RingType = "share"
+)
+
+// Default targets for each ring
+const (
+	DefaultPlanTarget  = 2
+	DefaultDoTarget    = 3
+	DefaultShareTarget = 1
+)
+
+// Score calculation constants
+const (
+	ScoreBase       = 50
+	ScoreRingWindow = 7
+	ScoreMaxRings   = 21
+	ScoreRingBonus  = 50
+	ScoreMaxStreak  = 7
+	ScoreDisplayMin = 30
+)
+
+// RingProgress tracks progress toward closing a single ring
+type RingProgress struct {
+	Current int  `bson:"current" json:"current"`
+	Target  int  `bson:"target" json:"target"`
+	Closed  bool `bson:"closed" json:"closed"`
+}
+
+// RingState represents a user's ring state for a single day
+type RingState struct {
+	ID            primitive.ObjectID `bson:"_id,omitempty" json:"id"`
+	UserID        primitive.ObjectID `bson:"user_id" json:"user_id"`
+	Date          time.Time          `bson:"date" json:"date"`
+	Plan          RingProgress       `bson:"plan" json:"plan"`
+	Do            RingProgress       `bson:"do" json:"do"`
+	Share         RingProgress       `bson:"share" json:"share"`
+	AllClosed     bool               `bson:"all_closed" json:"all_closed"`
+	RewardClaimed bool               `bson:"reward_claimed" json:"reward_claimed"`
+	RewardType    string             `bson:"reward_type,omitempty" json:"reward_type,omitempty"`
+	RewardAmount  int                `bson:"reward_amount,omitempty" json:"reward_amount,omitempty"`
+	CreatedAt     time.Time          `bson:"created_at" json:"created_at"`
+	UpdatedAt     time.Time          `bson:"updated_at" json:"updated_at"`
+}
+
+// RewardDrop defines a possible reward with its probability weight
+type RewardDrop struct {
+	CreditType string `json:"credit_type"`
+	Amount     int    `json:"amount"`
+	Weight     int    `json:"weight"` // relative weight out of total
+}
+
+// RewardPool contains the weighted list of possible reward drops
+var RewardPool = []RewardDrop{
+	{CreditType: "voice", Amount: 1, Weight: 40},
+	{CreditType: "naturalLanguage", Amount: 1, Weight: 40},
+	{CreditType: "analytics", Amount: 1, Weight: 15},
+	{CreditType: "voice", Amount: 2, Weight: 5},
+}
+
+// --- API response types ---
+
+// GetTodayResponse is the response for fetching today's ring state
+type GetTodayResponse struct {
+	Body struct {
+		RingState         RingState `json:"ring_state"`
+		ProductivityScore int       `json:"productivity_score"`
+		CurrentStreak     int       `json:"current_streak"`
+		RewardAvailable   bool      `json:"reward_available"`
+	}
+}
+
+// GetHistoryInput is the query input for fetching ring history
+type GetHistoryInput struct {
+	Days int `query:"days" default:"7" doc:"Number of days of history to fetch"`
+}
+
+// GetHistoryResponse is the response for fetching ring history
+type GetHistoryResponse struct {
+	Body struct {
+		History []RingState `json:"history"`
+		Score   int         `json:"score"`
+		Streak  int         `json:"streak"`
+	}
+}
+
+// ClaimRewardResponse is the response after claiming a ring reward
+type ClaimRewardResponse struct {
+	Body struct {
+		CreditType string `json:"credit_type"`
+		Amount     int    `json:"amount"`
+	}
+}

--- a/backend/internal/handlers/task/cron.go
+++ b/backend/internal/handlers/task/cron.go
@@ -14,7 +14,7 @@ import (
 Cron sets up periodic background jobs for tasks, reminders, and checkins.
 */
 func Cron(collections map[string]*mongo.Collection) *cron.Cron {
-	service := newService(collections)
+	service := newService(collections, nil)
 	handler := Handler{
 		service:       service,
 		geminiService: nil,

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -8,8 +9,8 @@ import (
 /*
 Router maps endpoints to handlers
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection, geminiService any) {
-	service := newService(collections)
+func Routes(api huma.API, collections map[string]*mongo.Collection, geminiService any, ringService *rings.RingService) {
+	service := newService(collections, ringService)
 	handler := Handler{
 		service:       service,
 		geminiService: geminiService,

--- a/backend/internal/handlers/task/stream_handlers.go
+++ b/backend/internal/handlers/task/stream_handlers.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/gofiber/fiber/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -14,8 +15,8 @@ import (
 )
 
 // NewStreamHandler creates a Handler for SSE streaming routes.
-func NewStreamHandler(collections map[string]*mongo.Collection, geminiService any) *Handler {
-	service := newService(collections)
+func NewStreamHandler(collections map[string]*mongo.Collection, geminiService any, ringService *rings.RingService) *Handler {
+	service := newService(collections, ringService)
 	return &Handler{
 		service:       service,
 		geminiService: geminiService,

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson"
@@ -212,6 +213,17 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 	if err != nil {
 		slog.Error("Failed to create task", "userId", userObjID.Hex(), "categoryId", categoryID.Hex(), "error", err)
 		return nil, huma.Error500InternalServerError("Unable to create task due to a database error. Please try again.", err)
+	}
+
+	// Fire-and-forget: increment Plan ring
+	if h.service.RingService != nil {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			_, _, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, rings.RingPlan)
+			if err != nil {
+				slog.Error("Failed to increment Plan ring on task creation", "user_id", userObjID.Hex(), "error", err)
+			}
+		}()
 	}
 
 	return &CreateTaskOutput{Body: *doc}, nil
@@ -421,6 +433,17 @@ func (h *Handler) CompleteTask(ctx context.Context, input *CompleteTaskInput) (*
 		return nil, huma.Error500InternalServerError("Task was completed but could not be removed. Please try again.", err)
 	}
 
+	// Fire-and-forget: increment Do ring
+	if h.service.RingService != nil {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			_, _, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, rings.RingDo)
+			if err != nil {
+				slog.Error("Failed to increment Do ring on task completion", "user_id", userObjID.Hex(), "error", err)
+			}
+		}()
+	}
+
 	resp := &CompleteTaskOutput{}
 	resp.Body.Message = "Task completed successfully"
 	resp.Body.StreakChanged = result.StreakChanged
@@ -528,6 +551,20 @@ func (h *Handler) BulkCompleteTask(ctx context.Context, input *BulkCompleteTaskI
 	if err != nil {
 		slog.Error("Failed to bulk complete tasks", "userId", userObjID.Hex(), "taskCount", len(input.Body.Tasks), "error", err)
 		return nil, huma.Error500InternalServerError("Unable to complete tasks due to a server error. Please try again.", err)
+	}
+
+	// Fire-and-forget: increment Do ring once per successfully completed task
+	if h.service.RingService != nil && result.Body.TotalCompleted > 0 {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			for i := 0; i < result.Body.TotalCompleted; i++ {
+				_, _, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, rings.RingDo)
+				if err != nil {
+					slog.Error("Failed to increment Do ring on bulk task completion", "user_id", userObjID.Hex(), "error", err)
+					break
+				}
+			}
+		}()
 	}
 
 	return result, nil

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	mongorepo "github.com/abhikaboy/Kindred/internal/repository/mongo"
 	"github.com/abhikaboy/Kindred/xutils"
@@ -57,7 +58,7 @@ func getTaskArrayFilterOptions(taskId primitive.ObjectID) *options.UpdateOptions
 }
 
 // newService receives the map of collections and picks out Jobs
-func newService(collections map[string]*mongo.Collection) *Service {
+func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
 	users := mongorepo.NewUserRepository(collections["users"])
 	return &Service{
 		Tasks:               collections["categories"],
@@ -65,12 +66,13 @@ func newService(collections map[string]*mongo.Collection) *Service {
 		CompletedTasks:      collections["completed-tasks"],
 		TemplateTasks:       collections["template-tasks"],
 		EncouragementHelper: encouragement.NewEncouragementService(collections),
+		RingService:         ringService,
 	}
 }
 
 // NewService is the exported version of newService for external packages
 func NewService(collections map[string]*mongo.Collection) *Service {
-	return newService(collections)
+	return newService(collections, nil)
 }
 
 func handleMongoError(ctx context.Context, operation string, err error) error {

--- a/backend/internal/handlers/task/types.go
+++ b/backend/internal/handlers/task/types.go
@@ -3,6 +3,7 @@ package task
 import (
 	"time"
 
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/internal/repository"
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -138,6 +139,7 @@ type Service struct {
 	CompletedTasks      *mongo.Collection
 	TemplateTasks       *mongo.Collection
 	EncouragementHelper EncouragementServiceInterface
+	RingService         *rings.RingService
 }
 
 // EncouragementServiceInterface defines the methods we need from the encouragement service

--- a/backend/internal/handlers/types/credits.go
+++ b/backend/internal/handlers/types/credits.go
@@ -50,7 +50,7 @@ func GetDefaultCredits() UserCredits {
 // This ensures thread-safe credit consumption
 func ConsumeCredit(ctx context.Context, collection *mongo.Collection, userID primitive.ObjectID, creditType CreditType) error {
 	// Map credit type to field name
-	fieldName, err := getCreditFieldName(creditType)
+	fieldName, err := GetCreditFieldName(creditType)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func AddCredits(ctx context.Context, collection *mongo.Collection, userID primit
 		return errors.New("amount must be positive")
 	}
 
-	fieldName, err := getCreditFieldName(creditType)
+	fieldName, err := GetCreditFieldName(creditType)
 	if err != nil {
 		return err
 	}
@@ -119,7 +119,7 @@ func GetCredits(ctx context.Context, collection *mongo.Collection, userID primit
 
 // CheckCredits checks if user has at least 1 credit of the specified type
 func CheckCredits(ctx context.Context, collection *mongo.Collection, userID primitive.ObjectID, creditType CreditType) (bool, error) {
-	fieldName, err := getCreditFieldName(creditType)
+	fieldName, err := GetCreditFieldName(creditType)
 	if err != nil {
 		return false, err
 	}
@@ -139,8 +139,8 @@ func CheckCredits(ctx context.Context, collection *mongo.Collection, userID prim
 	return count > 0, nil
 }
 
-// getCreditFieldName returns the BSON field name for a credit type
-func getCreditFieldName(creditType CreditType) (string, error) {
+// GetCreditFieldName returns the BSON field name for a credit type
+func GetCreditFieldName(creditType CreditType) (string, error) {
 	switch creditType {
 	case CreditTypeVoice:
 		return "credits.voice", nil

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -241,22 +241,24 @@ type User struct {
 	RecentActivity []ActivityDocument   `bson:"recent_activity" json:"recent_activity"`
 	PushToken      string               `bson:"push_token" json:"push_token"`
 
-	DisplayName     string       `bson:"display_name" json:"display_name"`
-	Handle          string       `bson:"handle" json:"handle"`
-	ProfilePicture  string       `bson:"profile_picture" json:"profile_picture"`
-	Encouragements  int          `bson:"encouragements" json:"encouragements"`   // Available balance to send
-	Congratulations int          `bson:"congratulations" json:"congratulations"` // Available balance to send
-	Streak          int          `bson:"streak" json:"streak"`
-	StreakEligible  bool         `bson:"streakEligible" json:"streakEligible"`
-	Points          int          `bson:"points" json:"points"`
-	PostsMade       int          `bson:"posts_made" json:"posts_made"`
-	Credits         UserCredits  `bson:"credits" json:"credits"`
-	KudosRewards    KudosRewards `bson:"kudosRewards" json:"kudosRewards"` // Number sent (for rewards system)
-	Subscription    Subscription `bson:"subscription" json:"subscription"`
-	Timezone        string       `bson:"timezone,omitempty" json:"timezone,omitempty"`
-	Settings        UserSettings `bson:"settings" json:"settings"`
-	TermsAcceptedAt *time.Time   `bson:"terms_accepted_at,omitempty" json:"terms_accepted_at,omitempty"`
-	TermsVersion    string       `bson:"terms_version,omitempty" json:"terms_version,omitempty"`
+	DisplayName       string       `bson:"display_name" json:"display_name"`
+	Handle            string       `bson:"handle" json:"handle"`
+	ProfilePicture    string       `bson:"profile_picture" json:"profile_picture"`
+	Encouragements    int          `bson:"encouragements" json:"encouragements"`   // Available balance to send
+	Congratulations   int          `bson:"congratulations" json:"congratulations"` // Available balance to send
+	Streak            int          `bson:"streak" json:"streak"`
+	StreakEligible    bool         `bson:"streakEligible" json:"streakEligible"`
+	Points            int          `bson:"points" json:"points"`
+	ProductivityScore int          `bson:"productivity_score" json:"productivity_score"`
+	LastRewardDate    *time.Time   `bson:"last_reward_date,omitempty" json:"last_reward_date,omitempty"`
+	PostsMade         int          `bson:"posts_made" json:"posts_made"`
+	Credits           UserCredits  `bson:"credits" json:"credits"`
+	KudosRewards      KudosRewards `bson:"kudosRewards" json:"kudosRewards"` // Number sent (for rewards system)
+	Subscription      Subscription `bson:"subscription" json:"subscription"`
+	Timezone          string       `bson:"timezone,omitempty" json:"timezone,omitempty"`
+	Settings          UserSettings `bson:"settings" json:"settings"`
+	TermsAcceptedAt   *time.Time   `bson:"terms_accepted_at,omitempty" json:"terms_accepted_at,omitempty"`
+	TermsVersion      string       `bson:"terms_version,omitempty" json:"terms_version,omitempty"`
 }
 
 type SafeUser struct {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	referral "github.com/abhikaboy/Kindred/internal/handlers/referral"
 	report "github.com/abhikaboy/Kindred/internal/handlers/report"
 	"github.com/abhikaboy/Kindred/internal/handlers/rewards"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/settings"
 	spaces "github.com/abhikaboy/Kindred/internal/handlers/spaces"
 	"github.com/abhikaboy/Kindred/internal/handlers/subscription"
@@ -137,16 +138,19 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	// Create presigner and S3 client
 	presigner, s3Client := spaces.NewPresigner()
 
+	// Create ring service (shared across handlers for fire-and-forget increments)
+	ringService := rings.NewRingServiceFromCollections(collections)
+
 	// Register converted routes
 	health.Routes(api, collections)
 	auth.Routes(api, collections)
 	category.Routes(api, collections)
 	activity.Routes(api, collections)
 	profile.Routes(api, collections)
-	task.Routes(api, collections, geminiService)
+	task.Routes(api, collections, geminiService, ringService)
 
 	// SSE streaming routes for NLP flows (raw Fiber, bypass Huma)
-	taskStreamHandler := task.NewStreamHandler(collections, geminiService)
+	taskStreamHandler := task.NewStreamHandler(collections, geminiService, ringService)
 	app.Post("/api/v1/user/tasks/natural-language/intent/stream", taskStreamHandler.StreamIntentNaturalLanguage)
 	app.Post("/api/v1/user/tasks/natural-language/stream", taskStreamHandler.StreamCreateNaturalLanguage)
 	app.Post("/api/v1/user/tasks/natural-language/query/stream", taskStreamHandler.StreamQueryNaturalLanguage)
@@ -154,7 +158,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 
 	connection.Routes(api, collections)
 	group.RegisterRoutes(api, collections)
-	post.Routes(api, collections)
+	post.Routes(api, collections, ringService)
 	spaces.Routes(api, presigner, s3Client, collections)
 
 	// Register waitlist and blueprint routes
@@ -162,8 +166,11 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	Blueprint.Routes(api, collections, geminiService)
 
 	// Register encouragement and congratulation routes
-	encouragement.Routes(api, collections)
-	congratulation.Routes(api, collections)
+	encouragement.Routes(api, collections, ringService)
+	congratulation.Routes(api, collections, ringService)
+
+	// Register ring routes
+	rings.Routes(api, collections, ringService)
 
 	// Register notification routes
 	notifications.Routes(api, collections)

--- a/docs/superpowers/plans/2026-05-16-productivity-score-rings.md
+++ b/docs/superpowers/plans/2026-05-16-productivity-score-rings.md
@@ -1,0 +1,1750 @@
+# Productivity Score & Rings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace points and visible streaks with a Productivity Score (0-100) powered by three daily rings (Plan, Do, Share), with a variable AI credit reward when all rings close.
+
+**Architecture:** New `rings` handler package with a RingService that tracks daily ring state in a `ring_states` MongoDB collection. Existing handlers (task, post, encouragement, congratulation) call RingService as a side effect. Frontend replaces the TodayStats 4-stat grid with a three-ring visualization and score display, reusing the DashboardStats expand/collapse pattern.
+
+**Tech Stack:** Go/Fiber/Huma (backend), MongoDB (ring_states collection), React Native/Expo (frontend), Reanimated (ring animations)
+
+**Spec:** `docs/superpowers/specs/2026-05-16-productivity-score-rings-design.md`
+
+---
+
+## File Map
+
+### Backend — New Files
+- `backend/internal/handlers/rings/types.go` — RingState document type, API input/output types
+- `backend/internal/handlers/rings/service.go` — Core ring logic (increment, score calculation, reward claiming)
+- `backend/internal/handlers/rings/routes.go` — HTTP handler registration
+- `backend/internal/handlers/rings/service_test.go` — Tests for ring service
+
+### Backend — Modified Files
+- `backend/internal/handlers/types/types.go` — Add `ProductivityScore` and `LastRewardDate` to User struct, keep `Points` but stop exposing it
+- `backend/internal/handlers/task/task_service.go` — Call RingService on task creation and completion
+- `backend/internal/handlers/task/handler.go` — Pass RingService to task service
+- `backend/internal/handlers/post/service.go` — Remove points logic, call RingService.IncrementShare
+- `backend/internal/handlers/encouragement/service.go` — Call RingService.IncrementShare after sending
+- `backend/internal/handlers/congratulation/service.go` — Call RingService.IncrementShare after sending
+- `backend/internal/server/server.go` — Register rings routes, pass RingService to other handlers
+- `backend/internal/handlers/category/handler.go` — Pass RingService for task creation ring tracking
+
+### Frontend — New Files
+- `frontend/api/rings.ts` — API client for ring endpoints
+- `frontend/hooks/useRings.ts` — Hook for ring state and score
+- `frontend/components/profile/ProductivityRings.tsx` — Three-ring visualization with score
+
+### Frontend — Modified Files
+- `frontend/api/types.ts` — Add RingState, RingRewardResponse types
+- `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx` — Replace TodayStats with ProductivityRings
+- `frontend/components/dashboard/HomescrollContent.tsx` — Add compact ring widget to dashboard
+- `frontend/components/profile/TodayStats.tsx` — Remove (or stop importing)
+
+---
+
+## Task 1: Backend — Ring State Types
+
+**Files:**
+- Create: `backend/internal/handlers/rings/types.go`
+
+- [ ] **Step 1: Create the rings package directory**
+
+```bash
+mkdir -p backend/internal/handlers/rings
+```
+
+- [ ] **Step 2: Write the types file**
+
+```go
+// backend/internal/handlers/rings/types.go
+package rings
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// RingState represents a user's daily ring progress.
+type RingState struct {
+	ID            bson.ObjectID `bson:"_id,omitempty" json:"_id"`
+	UserID        bson.ObjectID `bson:"user_id" json:"user_id"`
+	Date          string        `bson:"date" json:"date"` // YYYY-MM-DD in user's timezone
+	Plan          RingProgress  `bson:"plan" json:"plan"`
+	Do            RingProgress  `bson:"do" json:"do"`
+	Share         RingProgress  `bson:"share" json:"share"`
+	AllClosed     bool          `bson:"all_closed" json:"all_closed"`
+	RewardClaimed bool          `bson:"reward_claimed" json:"reward_claimed"`
+	RewardType    string        `bson:"reward_type,omitempty" json:"reward_type,omitempty"`
+	RewardAmount  int           `bson:"reward_amount,omitempty" json:"reward_amount,omitempty"`
+	CreatedAt     time.Time     `bson:"created_at" json:"created_at"`
+	UpdatedAt     time.Time     `bson:"updated_at" json:"updated_at"`
+}
+
+// RingProgress tracks current vs target for a single ring.
+type RingProgress struct {
+	Current int  `bson:"current" json:"current"`
+	Target  int  `bson:"target" json:"target"`
+	Closed  bool `bson:"closed" json:"closed"`
+}
+
+// RingType identifies which ring to increment.
+type RingType string
+
+const (
+	RingPlan  RingType = "plan"
+	RingDo    RingType = "do"
+	RingShare RingType = "share"
+)
+
+// Default daily targets (v1 — fixed).
+const (
+	DefaultPlanTarget  = 2
+	DefaultDoTarget    = 3
+	DefaultShareTarget = 1
+)
+
+// Reward drop weights and amounts.
+type RewardDrop struct {
+	CreditType string
+	Amount     int
+	Weight     int // relative weight for random selection
+}
+
+var RewardPool = []RewardDrop{
+	{CreditType: "voice", Amount: 1, Weight: 40},
+	{CreditType: "naturalLanguage", Amount: 1, Weight: 40},
+	{CreditType: "analytics", Amount: 1, Weight: 15},
+	{CreditType: "voice", Amount: 2, Weight: 5},
+}
+
+// Score calculation constants.
+const (
+	ScoreBase        = 50
+	ScoreRingWindow  = 7 // days
+	ScoreMaxRings    = 3 * ScoreRingWindow // 21
+	ScoreRingBonus   = 50
+	ScoreMaxStreak   = 7
+	ScoreDisplayMin  = 30
+)
+
+// --- API types ---
+
+type GetTodayResponse struct {
+	Rings RingState `json:"rings"`
+	Score int       `json:"score"`
+}
+
+type GetHistoryInput struct {
+	Days int `query:"days" default:"7" doc:"Number of days of history to return (max 30)"`
+}
+
+type GetHistoryResponse struct {
+	History []RingState `json:"history"`
+	Score   int         `json:"score"`
+}
+
+type ClaimRewardResponse struct {
+	Claimed    bool   `json:"claimed"`
+	CreditType string `json:"credit_type,omitempty"`
+	Amount     int    `json:"amount,omitempty"`
+	Message    string `json:"message"`
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/handlers/rings/types.go
+git commit -m "feat(rings): add ring state types and constants"
+```
+
+---
+
+## Task 2: Backend — Ring Service Core Logic
+
+**Files:**
+- Create: `backend/internal/handlers/rings/service.go`
+
+- [ ] **Step 1: Write the ring service**
+
+```go
+// backend/internal/handlers/rings/service.go
+package rings
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"kindred/internal/handlers/types"
+)
+
+type RingService struct {
+	ringStates *mongo.Collection
+	users      *mongo.Collection
+}
+
+func NewRingService(ringStates, users *mongo.Collection) *RingService {
+	return &RingService{
+		ringStates: ringStates,
+		users:      users,
+	}
+}
+
+// getDateForUser returns today's date string in the user's timezone.
+func getDateForUser(timezone string) string {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	return time.Now().In(loc).Format("2006-01-02")
+}
+
+// GetOrCreateToday returns today's ring state for the user, creating it if needed.
+func (s *RingService) GetOrCreateToday(ctx context.Context, userID bson.ObjectID, timezone string) (*RingState, error) {
+	date := getDateForUser(timezone)
+
+	filter := bson.M{"user_id": userID, "date": date}
+	var state RingState
+	err := s.ringStates.FindOne(ctx, filter).Decode(&state)
+	if err == mongo.ErrNoDocuments {
+		state = RingState{
+			UserID: userID,
+			Date:   date,
+			Plan:   RingProgress{Current: 0, Target: DefaultPlanTarget},
+			Do:     RingProgress{Current: 0, Target: DefaultDoTarget},
+			Share:  RingProgress{Current: 0, Target: DefaultShareTarget},
+			CreatedAt: time.Now(),
+			UpdatedAt: time.Now(),
+		}
+		result, insertErr := s.ringStates.InsertOne(ctx, state)
+		if insertErr != nil {
+			return nil, insertErr
+		}
+		state.ID = result.InsertedID.(bson.ObjectID)
+		return &state, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+// IncrementRing increments a ring's current count by 1 and checks for closure.
+// Returns the updated state and whether all rings just closed (for reward trigger).
+func (s *RingService) IncrementRing(ctx context.Context, userID bson.ObjectID, timezone string, ring RingType) (*RingState, bool, error) {
+	state, err := s.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		return nil, false, err
+	}
+
+	wasAllClosed := state.AllClosed
+
+	// Build the field path for the ring
+	fieldPrefix := string(ring)
+	currentField := fieldPrefix + ".current"
+
+	// Increment the ring's current count
+	update := bson.M{
+		"$inc": bson.M{currentField: 1},
+		"$set": bson.M{"updated_at": time.Now()},
+	}
+
+	opts := options.FindOneAndUpdate().SetReturnDocument(options.After)
+	var updated RingState
+	err = s.ringStates.FindOneAndUpdate(ctx, bson.M{"_id": state.ID}, update, opts).Decode(&updated)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Check and update closure status
+	updated.Plan.Closed = updated.Plan.Current >= updated.Plan.Target
+	updated.Do.Closed = updated.Do.Current >= updated.Do.Target
+	updated.Share.Closed = updated.Share.Current >= updated.Share.Target
+	allClosed := updated.Plan.Closed && updated.Do.Closed && updated.Share.Closed
+	updated.AllClosed = allClosed
+
+	// Persist closure flags
+	_, err = s.ringStates.UpdateOne(ctx, bson.M{"_id": state.ID}, bson.M{
+		"$set": bson.M{
+			"plan.closed":  updated.Plan.Closed,
+			"do.closed":    updated.Do.Closed,
+			"share.closed": updated.Share.Closed,
+			"all_closed":   allClosed,
+		},
+	})
+	if err != nil {
+		return nil, false, err
+	}
+
+	justClosedAll := allClosed && !wasAllClosed
+
+	// Recalculate and cache the productivity score
+	if err := s.recalculateScore(ctx, userID, timezone); err != nil {
+		slog.Error("failed to recalculate productivity score", "error", err, "userID", userID)
+	}
+
+	return &updated, justClosedAll, nil
+}
+
+// recalculateScore computes the productivity score and caches it on the user document.
+func (s *RingService) recalculateScore(ctx context.Context, userID bson.ObjectID, timezone string) error {
+	score, err := s.CalculateScore(ctx, userID, timezone)
+	if err != nil {
+		return err
+	}
+	_, err = s.users.UpdateOne(ctx, bson.M{"_id": userID}, bson.M{
+		"$set": bson.M{"productivity_score": score},
+	})
+	return err
+}
+
+// CalculateScore computes the productivity score for a user.
+// Formula: base(50) + ringBonus(0-50) + streakBonus(0-7), capped at 100.
+func (s *RingService) CalculateScore(ctx context.Context, userID bson.ObjectID, timezone string) (int, error) {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+
+	// Get ring states for the last 7 days
+	dates := make([]string, ScoreRingWindow)
+	for i := range ScoreRingWindow {
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+	}
+
+	filter := bson.M{
+		"user_id": userID,
+		"date":    bson.M{"$in": dates},
+	}
+	cursor, err := s.ringStates.Find(ctx, filter)
+	if err != nil {
+		return ScoreBase, err
+	}
+	defer cursor.Close(ctx)
+
+	var states []RingState
+	if err := cursor.All(ctx, &states); err != nil {
+		return ScoreBase, err
+	}
+
+	// Count total rings closed
+	ringsClosedCount := 0
+	for _, st := range states {
+		if st.Plan.Closed {
+			ringsClosedCount++
+		}
+		if st.Do.Closed {
+			ringsClosedCount++
+		}
+		if st.Share.Closed {
+			ringsClosedCount++
+		}
+	}
+
+	// Get user's current streak
+	var user types.User
+	err = s.users.FindOne(ctx, bson.M{"_id": userID}).Decode(&user)
+	if err != nil {
+		return ScoreBase, err
+	}
+
+	ringBonus := float64(ringsClosedCount) / float64(ScoreMaxRings) * float64(ScoreRingBonus)
+	streakBonus := float64(min(user.Streak, ScoreMaxStreak))
+	score := int(math.Min(float64(ScoreBase)+ringBonus+streakBonus, 100))
+
+	return score, nil
+}
+
+// GetHistory returns ring states for the last N days.
+func (s *RingService) GetHistory(ctx context.Context, userID bson.ObjectID, timezone string, days int) ([]RingState, error) {
+	if days > 30 {
+		days = 30
+	}
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+
+	dates := make([]string, days)
+	for i := range days {
+		dates[i] = now.AddDate(0, 0, -i).Format("2006-01-02")
+	}
+
+	filter := bson.M{
+		"user_id": userID,
+		"date":    bson.M{"$in": dates},
+	}
+	opts := options.Find().SetSort(bson.M{"date": -1})
+	cursor, err := s.ringStates.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	var states []RingState
+	if err := cursor.All(ctx, &states); err != nil {
+		return nil, err
+	}
+	return states, nil
+}
+
+// ClaimReward claims the daily reward for closing all rings.
+// Returns the reward details or an error if not eligible.
+func (s *RingService) ClaimReward(ctx context.Context, userID bson.ObjectID, timezone string) (*ClaimRewardResponse, error) {
+	state, err := s.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		return nil, err
+	}
+
+	if !state.AllClosed {
+		return &ClaimRewardResponse{
+			Claimed: false,
+			Message: "Not all rings are closed today",
+		}, nil
+	}
+
+	if state.RewardClaimed {
+		return &ClaimRewardResponse{
+			Claimed: false,
+			Message: "Reward already claimed today",
+		}, nil
+	}
+
+	// Pick a random reward
+	drop := pickRandomReward()
+
+	// Apply credit to user
+	creditField, err := types.GetCreditFieldName(drop.CreditType)
+	if err != nil {
+		return nil, err
+	}
+	_, err = s.users.UpdateOne(ctx, bson.M{"_id": userID}, bson.M{
+		"$inc": bson.M{creditField: drop.Amount},
+		"$set": bson.M{"last_reward_date": time.Now()},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark reward as claimed
+	_, err = s.ringStates.UpdateOne(ctx, bson.M{"_id": state.ID}, bson.M{
+		"$set": bson.M{
+			"reward_claimed": true,
+			"reward_type":    drop.CreditType,
+			"reward_amount":  drop.Amount,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ClaimRewardResponse{
+		Claimed:    true,
+		CreditType: drop.CreditType,
+		Amount:     drop.Amount,
+		Message:    "Reward claimed!",
+	}, nil
+}
+
+// pickRandomReward selects a reward from the pool using weighted random selection.
+func pickRandomReward() RewardDrop {
+	totalWeight := 0
+	for _, r := range RewardPool {
+		totalWeight += r.Weight
+	}
+
+	roll := rand.IntN(totalWeight)
+	cumulative := 0
+	for _, r := range RewardPool {
+		cumulative += r.Weight
+		if roll < cumulative {
+			return r
+		}
+	}
+	return RewardPool[0]
+}
+
+// EnsureIndexes creates required indexes on the ring_states collection.
+func (s *RingService) EnsureIndexes(ctx context.Context) error {
+	indexes := []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "user_id", Value: 1}, {Key: "date", Value: -1}},
+			Options: options.Index().SetUnique(true),
+		},
+		{
+			Keys:    bson.D{{Key: "created_at", Value: 1}},
+			Options: options.Index().SetExpireAfterSeconds(30 * 24 * 60 * 60), // 30 day TTL
+		},
+	}
+	_, err := s.ringStates.Indexes().CreateMany(ctx, indexes)
+	return err
+}
+```
+
+Note: The `types.GetCreditFieldName` function needs to be exported. It currently exists as `getCreditFieldName` (unexported) in `backend/internal/handlers/types/credits.go` at line 143. This will be addressed in Task 4.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/internal/handlers/rings/service.go
+git commit -m "feat(rings): add ring service with increment, score, and reward logic"
+```
+
+---
+
+## Task 3: Backend — Ring API Routes
+
+**Files:**
+- Create: `backend/internal/handlers/rings/routes.go`
+
+- [ ] **Step 1: Write the routes file**
+
+```go
+// backend/internal/handlers/rings/routes.go
+package rings
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+
+	"kindred/internal/auth"
+)
+
+type RingHandler struct {
+	service *RingService
+}
+
+func Routes(api huma.API, service *RingService) {
+	h := &RingHandler{service: service}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-rings-today",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/rings/today",
+		Summary:     "Get today's ring state",
+		Tags:        []string{"Rings"},
+	}, h.GetToday)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "get-rings-history",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/rings/history",
+		Summary:     "Get ring history",
+		Tags:        []string{"Rings"},
+	}, h.GetHistory)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "claim-ring-reward",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/rings/reward",
+		Summary:     "Claim daily ring reward",
+		Tags:        []string{"Rings"},
+	}, h.ClaimReward)
+}
+
+type GetTodayOutput struct {
+	Body GetTodayResponse
+}
+
+func (h *RingHandler) GetToday(ctx context.Context, input *struct{}) (*GetTodayOutput, error) {
+	userID := auth.GetUserID(ctx)
+	timezone := auth.GetTimezone(ctx)
+
+	state, err := h.service.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to get ring state", err)
+	}
+
+	score, err := h.service.CalculateScore(ctx, userID, timezone)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to calculate score", err)
+	}
+
+	return &GetTodayOutput{
+		Body: GetTodayResponse{
+			Rings: *state,
+			Score: score,
+		},
+	}, nil
+}
+
+type GetHistoryOutput struct {
+	Body GetHistoryResponse
+}
+
+func (h *RingHandler) GetHistory(ctx context.Context, input *GetHistoryInput) (*GetHistoryOutput, error) {
+	userID := auth.GetUserID(ctx)
+	timezone := auth.GetTimezone(ctx)
+
+	history, err := h.service.GetHistory(ctx, userID, timezone, input.Days)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to get ring history", err)
+	}
+
+	score, err := h.service.CalculateScore(ctx, userID, timezone)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to calculate score", err)
+	}
+
+	return &GetHistoryOutput{
+		Body: GetHistoryResponse{
+			History: history,
+			Score:   score,
+		},
+	}, nil
+}
+
+type ClaimRewardOutput struct {
+	Body ClaimRewardResponse
+}
+
+func (h *RingHandler) ClaimReward(ctx context.Context, input *struct{}) (*ClaimRewardOutput, error) {
+	userID := auth.GetUserID(ctx)
+	timezone := auth.GetTimezone(ctx)
+
+	result, err := h.service.ClaimReward(ctx, userID, timezone)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to claim reward", err)
+	}
+
+	return &ClaimRewardOutput{Body: *result}, nil
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add backend/internal/handlers/rings/routes.go
+git commit -m "feat(rings): add API routes for ring state, history, and rewards"
+```
+
+---
+
+## Task 4: Backend — Export Credit Field Name Helper
+
+**Files:**
+- Modify: `backend/internal/handlers/types/credits.go` (line 143)
+
+The ring service needs to map credit type strings to BSON field paths. The existing `getCreditFieldName` function is unexported. Export it.
+
+- [ ] **Step 1: Read the current function**
+
+```bash
+cd /Users/abhik.ray/Kindred && sed -n '143,160p' backend/internal/handlers/types/credits.go
+```
+
+- [ ] **Step 2: Rename `getCreditFieldName` to `GetCreditFieldName`**
+
+Change the function signature from:
+```go
+func getCreditFieldName(creditType string) (string, error) {
+```
+to:
+```go
+func GetCreditFieldName(creditType string) (string, error) {
+```
+
+Update all callers within the same file (there should be calls in `ConsumeCredit`, `AddCredits`, `CheckCredits`) to use `GetCreditFieldName`.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend && go build ./...
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/handlers/types/credits.go
+git commit -m "refactor(credits): export GetCreditFieldName for cross-package use"
+```
+
+---
+
+## Task 5: Backend — Add User Fields for Productivity Score
+
+**Files:**
+- Modify: `backend/internal/handlers/types/types.go` (User struct, around line 251)
+
+- [ ] **Step 1: Add new fields to User struct**
+
+After the `Points` field (line 251), add:
+
+```go
+ProductivityScore int        `bson:"productivity_score" json:"productivity_score"`
+LastRewardDate    *time.Time `bson:"last_reward_date,omitempty" json:"last_reward_date,omitempty"`
+```
+
+Do NOT remove the `Points` field yet — it stays in the DB for backward compatibility during migration. We just stop writing to it and stop including it in profile API responses (handled in Task 8).
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend && go build ./...
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/handlers/types/types.go
+git commit -m "feat(types): add ProductivityScore and LastRewardDate to User"
+```
+
+---
+
+## Task 6: Backend — Wire Ring Increments Into Existing Handlers
+
+**Files:**
+- Modify: `backend/internal/server/server.go`
+- Modify: `backend/internal/handlers/task/task_service.go`
+- Modify: `backend/internal/handlers/post/service.go`
+- Modify: `backend/internal/handlers/encouragement/service.go`
+- Modify: `backend/internal/handlers/congratulation/service.go`
+
+This task wires the RingService into existing handlers as a side effect. Ring increments are fire-and-forget — failures are logged but don't block the primary operation.
+
+- [ ] **Step 1: Register ring routes and create RingService in server.go**
+
+In `server.go`, after the existing handler registrations (around line 175):
+
+1. Get or create the `ring_states` collection from the database
+2. Create a `RingService` instance
+3. Call `rings.Routes(api, ringService)`
+4. Ensure indexes on startup
+5. Pass the `ringService` to task, post, encouragement, and congratulation handlers
+
+The exact wiring depends on how each handler package accepts dependencies. Follow the existing pattern — most handler packages have a `Routes(api, collections)` or `Routes(api, collections, service)` signature. Add `ringService *rings.RingService` as an additional parameter where needed.
+
+- [ ] **Step 2: Wire into task completion (Do ring)**
+
+In `task_service.go`, after the successful task completion (around line 445, after streak logic), add:
+
+```go
+// Increment Do ring (fire-and-forget)
+go func() {
+    bgCtx := context.Background()
+    if _, _, err := ringService.IncrementRing(bgCtx, userId, userTimezone, rings.RingDo); err != nil {
+        slog.Error("failed to increment Do ring", "error", err, "userID", userId)
+    }
+}()
+```
+
+The `ringService` needs to be accessible from the task service. Either pass it as a field on the task service struct, or pass it through the handler layer. Follow the existing pattern for how `geminiService` is passed to task handlers (see `server.go` line 146).
+
+- [ ] **Step 3: Wire into task creation (Plan ring)**
+
+In the task creation handler (the function that handles `POST /v1/user/tasks/{category}`), after successful task insertion, add:
+
+```go
+// Increment Plan ring (fire-and-forget)
+go func() {
+    bgCtx := context.Background()
+    if _, _, err := ringService.IncrementRing(bgCtx, userId, userTimezone, rings.RingPlan); err != nil {
+        slog.Error("failed to increment Plan ring", "error", err, "userID", userId)
+    }
+}()
+```
+
+- [ ] **Step 4: Wire into post creation (Share ring) and remove points logic**
+
+In `post/service.go`, in the `updateUserPostStats` function (lines 242-269):
+
+1. Remove the points calculation logic (the `$add` with streak)
+2. Remove `points` from the update pipeline
+3. After the post stats update, increment the Share ring:
+
+```go
+// Increment Share ring (fire-and-forget)
+go func() {
+    bgCtx := context.Background()
+    if _, _, err := ringService.IncrementRing(bgCtx, userId, userTimezone, rings.RingShare); err != nil {
+        slog.Error("failed to increment Share ring", "error", err, "userID", userId)
+    }
+}()
+```
+
+- [ ] **Step 5: Wire into encouragement creation (Share ring)**
+
+In `encouragement/service.go`, after the successful `DecrementUserBalance` call (around line 169), add:
+
+```go
+// Increment Share ring (fire-and-forget)
+go func() {
+    bgCtx := context.Background()
+    if _, _, err := ringService.IncrementRing(bgCtx, senderID, senderTimezone, rings.RingShare); err != nil {
+        slog.Error("failed to increment Share ring on encouragement", "error", err, "userID", senderID)
+    }
+}()
+```
+
+The sender's timezone needs to be available. It should already be in the auth context (`auth.GetTimezone(ctx)`). Pass it through to the service function.
+
+- [ ] **Step 6: Wire into congratulation creation (Share ring)**
+
+Same pattern as Step 5, in `congratulation/service.go` after `DecrementUserBalance`:
+
+```go
+// Increment Share ring (fire-and-forget)
+go func() {
+    bgCtx := context.Background()
+    if _, _, err := ringService.IncrementRing(bgCtx, senderID, senderTimezone, rings.RingShare); err != nil {
+        slog.Error("failed to increment Share ring on congratulation", "error", err, "userID", senderID)
+    }
+}()
+```
+
+- [ ] **Step 7: Verify build**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend && go build ./...
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add backend/internal/server/server.go \
+    backend/internal/handlers/task/ \
+    backend/internal/handlers/post/ \
+    backend/internal/handlers/encouragement/ \
+    backend/internal/handlers/congratulation/
+git commit -m "feat(rings): wire ring increments into task, post, and kudos handlers"
+```
+
+---
+
+## Task 7: Backend — Ring Service Tests
+
+**Files:**
+- Create: `backend/internal/handlers/rings/service_test.go`
+
+- [ ] **Step 1: Write tests for the ring service**
+
+Follow the existing test pattern from `backend/internal/testing/`. Tests use ephemeral MongoDB databases with pre-seeded fixtures.
+
+```go
+// backend/internal/handlers/rings/service_test.go
+package rings
+
+import (
+	"context"
+	"testing"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	kindredtest "kindred/internal/testing"
+)
+
+func TestGetOrCreateToday(t *testing.T) {
+	suite := kindredtest.NewSuite(t)
+	defer suite.Teardown()
+
+	ringStates := suite.DB.Collection("ring_states")
+	users := suite.DB.Collection("users")
+	service := NewRingService(ringStates, users)
+
+	userID := suite.Fixtures.Users[0].ID
+
+	// First call creates a new ring state
+	state, err := service.GetOrCreateToday(context.Background(), userID, "UTC")
+	if err != nil {
+		t.Fatalf("GetOrCreateToday failed: %v", err)
+	}
+	if state.Plan.Target != DefaultPlanTarget {
+		t.Errorf("expected Plan target %d, got %d", DefaultPlanTarget, state.Plan.Target)
+	}
+	if state.Do.Target != DefaultDoTarget {
+		t.Errorf("expected Do target %d, got %d", DefaultDoTarget, state.Do.Target)
+	}
+	if state.Share.Target != DefaultShareTarget {
+		t.Errorf("expected Share target %d, got %d", DefaultShareTarget, state.Share.Target)
+	}
+
+	// Second call returns the same state
+	state2, err := service.GetOrCreateToday(context.Background(), userID, "UTC")
+	if err != nil {
+		t.Fatalf("second GetOrCreateToday failed: %v", err)
+	}
+	if state.ID != state2.ID {
+		t.Error("expected same ring state document on second call")
+	}
+}
+
+func TestIncrementRing(t *testing.T) {
+	suite := kindredtest.NewSuite(t)
+	defer suite.Teardown()
+
+	ringStates := suite.DB.Collection("ring_states")
+	users := suite.DB.Collection("users")
+	service := NewRingService(ringStates, users)
+
+	userID := suite.Fixtures.Users[0].ID
+
+	// Increment Do ring once
+	state, justClosed, err := service.IncrementRing(context.Background(), userID, "UTC", RingDo)
+	if err != nil {
+		t.Fatalf("IncrementRing failed: %v", err)
+	}
+	if state.Do.Current != 1 {
+		t.Errorf("expected Do.Current = 1, got %d", state.Do.Current)
+	}
+	if state.Do.Closed {
+		t.Error("Do ring should not be closed after 1 increment (target is 3)")
+	}
+	if justClosed {
+		t.Error("all rings should not be closed yet")
+	}
+}
+
+func TestAllRingsClose(t *testing.T) {
+	suite := kindredtest.NewSuite(t)
+	defer suite.Teardown()
+
+	ringStates := suite.DB.Collection("ring_states")
+	users := suite.DB.Collection("users")
+	service := NewRingService(ringStates, users)
+
+	userID := suite.Fixtures.Users[0].ID
+	ctx := context.Background()
+
+	// Close Plan ring (target: 2)
+	service.IncrementRing(ctx, userID, "UTC", RingPlan)
+	service.IncrementRing(ctx, userID, "UTC", RingPlan)
+
+	// Close Do ring (target: 3)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+
+	// Close Share ring (target: 1) — this should trigger justClosedAll
+	state, justClosed, err := service.IncrementRing(ctx, userID, "UTC", RingShare)
+	if err != nil {
+		t.Fatalf("final IncrementRing failed: %v", err)
+	}
+	if !state.AllClosed {
+		t.Error("expected AllClosed to be true")
+	}
+	if !justClosed {
+		t.Error("expected justClosedAll to be true on the closing increment")
+	}
+}
+
+func TestClaimReward(t *testing.T) {
+	suite := kindredtest.NewSuite(t)
+	defer suite.Teardown()
+
+	ringStates := suite.DB.Collection("ring_states")
+	users := suite.DB.Collection("users")
+	service := NewRingService(ringStates, users)
+
+	userID := suite.Fixtures.Users[0].ID
+	ctx := context.Background()
+
+	// Cannot claim without closing all rings
+	result, err := service.ClaimReward(ctx, userID, "UTC")
+	if err != nil {
+		t.Fatalf("ClaimReward failed: %v", err)
+	}
+	if result.Claimed {
+		t.Error("should not be able to claim without closing all rings")
+	}
+
+	// Close all rings
+	service.IncrementRing(ctx, userID, "UTC", RingPlan)
+	service.IncrementRing(ctx, userID, "UTC", RingPlan)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingShare)
+
+	// Claim reward
+	result, err = service.ClaimReward(ctx, userID, "UTC")
+	if err != nil {
+		t.Fatalf("ClaimReward failed: %v", err)
+	}
+	if !result.Claimed {
+		t.Error("expected reward to be claimed")
+	}
+	if result.CreditType == "" {
+		t.Error("expected a credit type")
+	}
+	if result.Amount < 1 {
+		t.Error("expected amount >= 1")
+	}
+
+	// Cannot claim twice
+	result2, err := service.ClaimReward(ctx, userID, "UTC")
+	if err != nil {
+		t.Fatalf("second ClaimReward failed: %v", err)
+	}
+	if result2.Claimed {
+		t.Error("should not be able to claim twice in one day")
+	}
+}
+
+func TestCalculateScore(t *testing.T) {
+	suite := kindredtest.NewSuite(t)
+	defer suite.Teardown()
+
+	ringStates := suite.DB.Collection("ring_states")
+	users := suite.DB.Collection("users")
+	service := NewRingService(ringStates, users)
+
+	userID := suite.Fixtures.Users[0].ID
+	ctx := context.Background()
+
+	// Base score with no rings closed should be 50 + streak bonus
+	score, err := service.CalculateScore(ctx, userID, "UTC")
+	if err != nil {
+		t.Fatalf("CalculateScore failed: %v", err)
+	}
+	// Score should be at least 50 (base) and at most 50 + streak
+	if score < ScoreBase {
+		t.Errorf("expected score >= %d, got %d", ScoreBase, score)
+	}
+
+	// Close some rings and check score increases
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+	service.IncrementRing(ctx, userID, "UTC", RingDo)
+
+	scoreAfter, err := service.CalculateScore(ctx, userID, "UTC")
+	if err != nil {
+		t.Fatalf("CalculateScore after increments failed: %v", err)
+	}
+	if scoreAfter <= score {
+		t.Errorf("expected score to increase after closing Do ring, was %d now %d", score, scoreAfter)
+	}
+}
+
+func TestPickRandomReward(t *testing.T) {
+	// Verify reward pool weights sum correctly and all rewards are reachable
+	counts := make(map[string]int)
+	for range 10000 {
+		r := pickRandomReward()
+		key := r.CreditType + "_" + bson.Raw([]byte{byte(r.Amount)}).String()
+		counts[key] = counts[key] + 1
+	}
+	if len(counts) < 3 {
+		t.Errorf("expected at least 3 distinct reward types, got %d", len(counts))
+	}
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+cd /Users/abhik.ray/Kindred && make test-backend
+```
+
+Expected: All new ring tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/handlers/rings/service_test.go
+git commit -m "test(rings): add tests for ring service core logic"
+```
+
+---
+
+## Task 8: Backend — Hide Points and Streak From Profile Responses
+
+**Files:**
+- Modify: Profile handler (the handler serving `GET /v1/profiles/{id}`)
+
+- [ ] **Step 1: Find the profile response type**
+
+Look at the profile handler to find where the User struct is serialized to JSON. The goal is to:
+1. Stop including `points` in profile API responses (set to 0 or omit)
+2. Stop including `streak` in profile API responses for OTHER users (keep for own profile since it feeds the score internally)
+3. Include `productivity_score` in profile responses
+
+The approach depends on whether the profile handler returns the raw User struct or a separate profile response type. If it returns the raw User, add `json:"-"` to the Points field or create a profile-specific response type.
+
+- [ ] **Step 2: Verify the API no longer returns points**
+
+```bash
+# After starting the dev server, test the profile endpoint
+curl -H "Authorization: Bearer <token>" http://localhost:8080/v1/profiles/<id> | jq '.points, .productivity_score'
+```
+
+Expected: `points` should be absent or 0, `productivity_score` should be present.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/internal/handlers/
+git commit -m "feat(profile): expose productivity_score, hide points from profile responses"
+```
+
+---
+
+## Task 9: Frontend — Ring API Client
+
+**Files:**
+- Create: `frontend/api/rings.ts`
+- Modify: `frontend/api/types.ts`
+
+- [ ] **Step 1: Add ring types to types.ts**
+
+Add at the end of `frontend/api/types.ts`:
+
+```typescript
+// Ring system types
+export interface RingProgress {
+    current: number;
+    target: number;
+    closed: boolean;
+}
+
+export interface RingState {
+    _id: string;
+    user_id: string;
+    date: string;
+    plan: RingProgress;
+    do: RingProgress;
+    share: RingProgress;
+    all_closed: boolean;
+    reward_claimed: boolean;
+    reward_type?: string;
+    reward_amount?: number;
+}
+
+export interface RingTodayResponse {
+    rings: RingState;
+    score: number;
+}
+
+export interface RingHistoryResponse {
+    history: RingState[];
+    score: number;
+}
+
+export interface RingRewardResponse {
+    claimed: boolean;
+    credit_type?: string;
+    amount?: number;
+    message: string;
+}
+```
+
+- [ ] **Step 2: Create the ring API client**
+
+```typescript
+// frontend/api/rings.ts
+import { createLogger } from '@/utils/logger';
+import { withAuthHeaders } from './client';
+import type { RingTodayResponse, RingHistoryResponse, RingRewardResponse } from './types';
+
+const logger = createLogger('api:rings');
+
+const API_BASE = process.env.EXPO_PUBLIC_API_URL;
+
+export async function getRingsToday(): Promise<RingTodayResponse> {
+    logger.debug('Fetching today ring state');
+    const response = await fetch(`${API_BASE}/v1/user/rings/today`, {
+        method: 'GET',
+        headers: await withAuthHeaders(),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch rings: ${response.status}`);
+    }
+    return response.json();
+}
+
+export async function getRingsHistory(days: number = 7): Promise<RingHistoryResponse> {
+    logger.debug('Fetching ring history', { days });
+    const response = await fetch(`${API_BASE}/v1/user/rings/history?days=${days}`, {
+        method: 'GET',
+        headers: await withAuthHeaders(),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to fetch ring history: ${response.status}`);
+    }
+    return response.json();
+}
+
+export async function claimRingReward(): Promise<RingRewardResponse> {
+    logger.debug('Claiming ring reward');
+    const response = await fetch(`${API_BASE}/v1/user/rings/reward`, {
+        method: 'POST',
+        headers: await withAuthHeaders(),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to claim reward: ${response.status}`);
+    }
+    return response.json();
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/api/rings.ts frontend/api/types.ts
+git commit -m "feat(frontend): add ring API client and types"
+```
+
+---
+
+## Task 10: Frontend — useRings Hook
+
+**Files:**
+- Create: `frontend/hooks/useRings.ts`
+
+- [ ] **Step 1: Create the hook**
+
+```typescript
+// frontend/hooks/useRings.ts
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { getRingsToday, getRingsHistory, claimRingReward } from '@/api/rings';
+import { useAuth } from '@/hooks/useAuth';
+import type { RingRewardResponse } from '@/api/types';
+
+export function useRings() {
+    const { user } = useAuth();
+    const queryClient = useQueryClient();
+
+    const todayQuery = useQuery({
+        queryKey: ['rings', 'today'],
+        queryFn: getRingsToday,
+        enabled: !!user,
+        staleTime: 60 * 1000, // 1 minute — rings change frequently
+        refetchInterval: 5 * 60 * 1000, // refresh every 5 min in background
+    });
+
+    const historyQuery = useQuery({
+        queryKey: ['rings', 'history'],
+        queryFn: () => getRingsHistory(7),
+        enabled: !!user,
+        staleTime: 5 * 60 * 1000,
+    });
+
+    const claimRewardMutation = useMutation({
+        mutationFn: claimRingReward,
+        onSuccess: (data: RingRewardResponse) => {
+            // Refetch ring state to update reward_claimed
+            queryClient.invalidateQueries({ queryKey: ['rings'] });
+            // Refetch user to update credit balances
+            queryClient.invalidateQueries({ queryKey: ['user'] });
+        },
+    });
+
+    const rings = todayQuery.data?.rings;
+    const score = todayQuery.data?.score ?? 50;
+    const allClosed = rings?.all_closed ?? false;
+    const canClaimReward = allClosed && !rings?.reward_claimed;
+
+    return {
+        // Ring state
+        rings,
+        score,
+        allClosed,
+        canClaimReward,
+        isLoading: todayQuery.isLoading,
+
+        // History
+        history: historyQuery.data?.history ?? [],
+
+        // Reward
+        claimReward: claimRewardMutation.mutateAsync,
+        isClaiming: claimRewardMutation.isPending,
+
+        // Refresh
+        refetch: todayQuery.refetch,
+    };
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/hooks/useRings.ts
+git commit -m "feat(frontend): add useRings hook for ring state and rewards"
+```
+
+---
+
+## Task 11: Frontend — ProductivityRings Component
+
+**Files:**
+- Create: `frontend/components/profile/ProductivityRings.tsx`
+
+- [ ] **Step 1: Create the ring visualization component**
+
+This component renders three separate rings in a row with the Productivity Score above them. Uses the expand/collapse pattern from DashboardStats (LayoutAnimation for smooth transitions, tap to expand ring detail).
+
+```typescript
+// frontend/components/profile/ProductivityRings.tsx
+import React, { useState, useCallback } from 'react';
+import { View, StyleSheet, Pressable, LayoutAnimation, Platform, UIManager } from 'react-native';
+import { Check } from 'phosphor-react-native';
+import Svg, { Circle } from 'react-native-svg';
+import { ThemedText } from '@/components/ThemedText';
+import { useThemeColor } from '@/hooks/useThemeColor';
+import { useRings } from '@/hooks/useRings';
+import Colors from '@/constants/Colors';
+
+if (Platform.OS === 'android' && UIManager.setLayoutAnimationEnabledExperimental) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const RING_SIZE = 80;
+const STROKE_WIDTH = 6;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+type RingName = 'plan' | 'do' | 'share';
+
+const RING_GUIDANCE: Record<RingName, string> = {
+    plan: 'Create or schedule tasks to close this ring',
+    do: 'Complete tasks to close this ring',
+    share: 'Post an update or send kudos to close this ring',
+};
+
+const RING_LABELS: Record<RingName, string> = {
+    plan: 'Plan',
+    do: 'Do',
+    share: 'Share',
+};
+
+interface ProductivityRingsProps {
+    userId?: string;
+    compact?: boolean;
+}
+
+export function ProductivityRings({ userId, compact = false }: ProductivityRingsProps) {
+    const { rings, score, isLoading } = useRings();
+    const [expandedRing, setExpandedRing] = useState<RingName | null>(null);
+    const primaryColor = Colors.dark.primary;
+    const trackColor = useThemeColor({}, 'inputBackground');
+    const textColor = useThemeColor({}, 'text');
+    const captionColor = useThemeColor({}, 'caption');
+
+    const handlePress = useCallback((ring: RingName) => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpandedRing(prev => prev === ring ? null : ring);
+    }, []);
+
+    if (isLoading || !rings) {
+        return (
+            <View style={styles.container}>
+                <ThemedText type="caption">Loading...</ThemedText>
+            </View>
+        );
+    }
+
+    const ringData: { name: RingName; current: number; target: number; closed: boolean }[] = [
+        { name: 'plan', ...rings.plan },
+        { name: 'do', ...rings.do },
+        { name: 'share', ...rings.share },
+    ];
+
+    const displayScore = score >= 30 ? score.toString() : '--';
+
+    return (
+        <View style={styles.container}>
+            {/* Productivity Score */}
+            <View style={styles.scoreContainer}>
+                <ThemedText style={[styles.scoreNumber, { color: textColor }]}>
+                    {displayScore}
+                </ThemedText>
+                <ThemedText style={[styles.scoreLabel, { color: captionColor }]}>
+                    Productivity Score
+                </ThemedText>
+            </View>
+
+            {/* Three Rings */}
+            <View style={styles.ringsRow}>
+                {ringData.map((ring) => {
+                    const progress = Math.min(ring.current / ring.target, 1);
+                    const strokeDashoffset = CIRCUMFERENCE * (1 - progress);
+
+                    return (
+                        <Pressable
+                            key={ring.name}
+                            onPress={() => handlePress(ring.name)}
+                            style={styles.ringItem}
+                        >
+                            <View style={styles.ringCircle}>
+                                <Svg width={RING_SIZE} height={RING_SIZE}>
+                                    {/* Track */}
+                                    <Circle
+                                        cx={RING_SIZE / 2}
+                                        cy={RING_SIZE / 2}
+                                        r={RADIUS}
+                                        stroke={trackColor}
+                                        strokeWidth={STROKE_WIDTH}
+                                        fill="none"
+                                    />
+                                    {/* Progress */}
+                                    <Circle
+                                        cx={RING_SIZE / 2}
+                                        cy={RING_SIZE / 2}
+                                        r={RADIUS}
+                                        stroke={primaryColor}
+                                        strokeWidth={STROKE_WIDTH}
+                                        fill="none"
+                                        strokeDasharray={`${CIRCUMFERENCE}`}
+                                        strokeDashoffset={strokeDashoffset}
+                                        strokeLinecap="round"
+                                        rotation="-90"
+                                        origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+                                    />
+                                </Svg>
+                                {/* Center text */}
+                                <View style={styles.ringCenter}>
+                                    {ring.closed ? (
+                                        <Check size={20} color={primaryColor} weight="bold" />
+                                    ) : (
+                                        <ThemedText style={[styles.ringCount, { color: textColor }]}>
+                                            {ring.current}/{ring.target}
+                                        </ThemedText>
+                                    )}
+                                </View>
+                            </View>
+                            <ThemedText style={[styles.ringLabel, { color: captionColor }]}>
+                                {RING_LABELS[ring.name]}
+                            </ThemedText>
+                        </Pressable>
+                    );
+                })}
+            </View>
+
+            {/* Expanded Ring Detail */}
+            {expandedRing && (
+                <View style={[styles.expandedDetail, { borderColor: primaryColor + '30' }]}>
+                    {(() => {
+                        const ring = ringData.find(r => r.name === expandedRing)!;
+                        if (ring.closed) {
+                            return (
+                                <ThemedText style={[styles.detailText, { color: primaryColor }]}>
+                                    Closed!
+                                </ThemedText>
+                            );
+                        }
+                        const remaining = ring.target - ring.current;
+                        return (
+                            <>
+                                <ThemedText style={[styles.detailProgress, { color: textColor }]}>
+                                    {ring.current} of {ring.target}
+                                </ThemedText>
+                                <ThemedText style={[styles.detailText, { color: captionColor }]}>
+                                    {RING_GUIDANCE[expandedRing]}
+                                </ThemedText>
+                            </>
+                        );
+                    })()}
+                </View>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: 'center',
+        paddingVertical: 16,
+    },
+    scoreContainer: {
+        alignItems: 'center',
+        marginBottom: 16,
+    },
+    scoreNumber: {
+        fontFamily: 'Fraunces',
+        fontSize: 36,
+        fontWeight: '600',
+    },
+    scoreLabel: {
+        fontFamily: 'Outfit',
+        fontSize: 12,
+        fontWeight: '500',
+        textTransform: 'uppercase',
+        letterSpacing: 1,
+        marginTop: 2,
+    },
+    ringsRow: {
+        flexDirection: 'row',
+        justifyContent: 'center',
+        gap: 24,
+    },
+    ringItem: {
+        alignItems: 'center',
+        gap: 6,
+    },
+    ringCircle: {
+        width: RING_SIZE,
+        height: RING_SIZE,
+        position: 'relative',
+    },
+    ringCenter: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        justifyContent: 'center',
+        alignItems: 'center',
+    },
+    ringCount: {
+        fontFamily: 'Outfit',
+        fontSize: 14,
+        fontWeight: '600',
+    },
+    ringLabel: {
+        fontFamily: 'Outfit',
+        fontSize: 11,
+        fontWeight: '600',
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+    },
+    expandedDetail: {
+        marginTop: 16,
+        paddingVertical: 12,
+        paddingHorizontal: 20,
+        borderRadius: 12,
+        borderWidth: 1,
+        alignItems: 'center',
+        gap: 4,
+    },
+    detailProgress: {
+        fontFamily: 'Outfit',
+        fontSize: 16,
+        fontWeight: '600',
+    },
+    detailText: {
+        fontFamily: 'Outfit',
+        fontSize: 13,
+        textAlign: 'center',
+    },
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/components/profile/ProductivityRings.tsx
+git commit -m "feat(frontend): add ProductivityRings component with three rings and score"
+```
+
+---
+
+## Task 12: Frontend — Replace TodayStats With Rings on Profile
+
+**Files:**
+- Modify: `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx` (line 112)
+
+- [ ] **Step 1: Replace TodayStats import and usage**
+
+In `profile.tsx`:
+
+1. Remove the import of `TodayStats`:
+```typescript
+// Remove this line:
+import { TodayStats } from '@/components/profile/TodayStats';
+```
+
+2. Add the import of `ProductivityRings`:
+```typescript
+import { ProductivityRings } from '@/components/profile/ProductivityRings';
+```
+
+3. Replace the usage at line 112:
+```typescript
+// Replace:
+<TodayStats userId={user?._id} />
+
+// With:
+<ProductivityRings userId={user?._id} />
+```
+
+- [ ] **Step 2: Verify the profile renders correctly**
+
+```bash
+cd /Users/abhik.ray/Kindred && bun run dev-frontend
+```
+
+Navigate to the Profile tab and verify:
+- Three rings display in a row (Plan, Do, Share)
+- Score shows above the rings
+- Tapping a ring expands detail with guidance text
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
+git commit -m "feat(profile): replace TodayStats with ProductivityRings"
+```
+
+---
+
+## Task 13: Frontend — Add Ring Widget to Dashboard
+
+**Files:**
+- Modify: `frontend/components/dashboard/HomescrollContent.tsx`
+
+- [ ] **Step 1: Add compact rings to the dashboard**
+
+In `HomescrollContent.tsx`, add the `ProductivityRings` component above or below the `DashboardStats` component (around line 317).
+
+1. Add the import:
+```typescript
+import { ProductivityRings } from '@/components/profile/ProductivityRings';
+```
+
+2. Add the component near DashboardStats:
+```typescript
+{/* Productivity Rings */}
+<View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>
+    <ProductivityRings compact />
+</View>
+
+{/* Existing DashboardStats */}
+<View style={{ marginHorizontal: HORIZONTAL_PADDING }}>
+    <DashboardStats onExpandChange={handleStatsExpandChange} />
+</View>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/components/dashboard/HomescrollContent.tsx
+git commit -m "feat(dashboard): add productivity rings widget to home screen"
+```
+
+---
+
+## Task 14: Frontend — Reward Celebration Toast
+
+**Files:**
+- Modify: `frontend/hooks/useRings.ts`
+
+- [ ] **Step 1: Add reward auto-claim and toast**
+
+Update the `useRings` hook to automatically detect when all rings just closed and show a celebration toast. Use the existing `showToast` utility.
+
+In `useRings.ts`, add an effect that watches for `allClosed && canClaimReward`:
+
+```typescript
+import { useEffect, useRef } from 'react';
+import { showToast } from '@/utils/toast';
+
+// Inside useRings():
+const hasAutoClaimedRef = useRef(false);
+
+useEffect(() => {
+    if (canClaimReward && !hasAutoClaimedRef.current && !claimRewardMutation.isPending) {
+        hasAutoClaimedRef.current = true;
+        claimRewardMutation.mutateAsync().then((result) => {
+            if (result.claimed) {
+                const creditName = result.credit_type === 'naturalLanguage'
+                    ? 'Natural Language'
+                    : result.credit_type!.charAt(0).toUpperCase() + result.credit_type!.slice(1);
+                showToast(
+                    `All rings closed! +${result.amount} ${creditName} Credit${result.amount! > 1 ? 's' : ''}`,
+                    'success'
+                );
+            }
+        });
+    }
+    // Reset when rings data refreshes for a new day
+    if (!canClaimReward) {
+        hasAutoClaimedRef.current = false;
+    }
+}, [canClaimReward]);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/hooks/useRings.ts
+git commit -m "feat(frontend): auto-claim reward and show toast when all rings close"
+```
+
+---
+
+## Task 15: Frontend — Clean Up Points References
+
+**Files:**
+- Modify: `frontend/api/types.ts` — Mark `points` as deprecated/optional
+- Modify: `frontend/components/profile/TodayStats.tsx` — Can be deleted or left (no longer imported)
+
+- [ ] **Step 1: Make `points` optional in frontend types**
+
+In `frontend/api/types.ts`, wherever the User type references `points`, make it optional:
+```typescript
+points?: number; // deprecated — replaced by productivity_score
+```
+
+Add the new field:
+```typescript
+productivity_score?: number;
+```
+
+- [ ] **Step 2: Search for any other `points` references in the frontend**
+
+```bash
+cd /Users/abhik.ray/Kindred/frontend && grep -r "\.points" --include="*.ts" --include="*.tsx" -l
+```
+
+For each file found, evaluate whether the reference needs updating:
+- Profile displays → already replaced by ProductivityRings
+- API types → already updated
+- Any analytics/tracking → can keep reading from API response if still present
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/
+git commit -m "chore(frontend): deprecate points field, add productivity_score to types"
+```
+
+---
+
+## Task 16: Final Verification
+
+- [ ] **Step 1: Run backend tests**
+
+```bash
+cd /Users/abhik.ray/Kindred && make test-backend
+```
+
+Expected: All tests pass, including new ring tests.
+
+- [ ] **Step 2: Run frontend dev server**
+
+```bash
+cd /Users/abhik.ray/Kindred && bun run dev-frontend
+```
+
+Verify:
+- Profile shows three rings + score (not the old 4-stat grid)
+- Dashboard shows the ring widget
+- Tapping rings expands detail with guidance
+- Score shows a number (>= 50 for existing users)
+- Points no longer visible anywhere
+
+- [ ] **Step 3: Build check**
+
+```bash
+cd /Users/abhik.ray/Kindred/backend && go build ./...
+```
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: productivity score and rings system complete"
+```

--- a/docs/superpowers/specs/2026-05-16-productivity-score-rings-design.md
+++ b/docs/superpowers/specs/2026-05-16-productivity-score-rings-design.md
@@ -1,0 +1,255 @@
+# Productivity Score & Rings
+
+## Overview
+
+Replace the current points/streak-based gamification with a **Productivity Score** (0-100) powered by three daily **rings** — Plan, Do, Share. Streaks become an invisible input to the score formula. Closing all three rings in a day triggers a variable reward (random AI credit drop).
+
+## What Gets Removed
+
+### Points
+- Remove `points` field from User document and all API responses
+- Remove points earning logic in post creation (`post/service.go` lines 243-268)
+- Remove points display from `TodayStats.tsx` (lines 95-100)
+
+### Visible Streak
+- Keep `streak` and `streakEligible` fields in the database (they feed the score formula)
+- Keep streak increment logic on task completion (`task_service.go` lines 439-445)
+- Remove streak display from `TodayStats.tsx` (lines 77-82)
+- Remove streak from profile API responses sent to other users
+
+### 4-Stat Grid
+- Replace the `TodayStats` component entirely with the new ring visualization
+- The 4-stat grid (streak, tasks complete, posts made, points) is removed from profile
+
+## Rings
+
+### Three Rings
+
+| Ring | Color | What it tracks | How it closes |
+|------|-------|---------------|---------------|
+| **Plan** | `#7DC4FF` (blue) | Tasks created or scheduled | Create a new task (any date) or set/update a future start date or deadline on an existing task. Each distinct task counts once per day toward the Plan ring regardless of how many times it's edited. |
+| **Do** | `#5CFF95` (green) | Tasks completed | Complete N tasks in a day |
+| **Share** | `#FF7EB3` (pink) | Social actions | Post or send a kudos (encouragement or congratulation) |
+
+### Daily Targets (v1 — fixed)
+
+Start with fixed targets. Adaptive targets are a future iteration.
+
+| Ring | Target to close |
+|------|----------------|
+| Plan | 2 tasks created or scheduled |
+| Do | 3 tasks completed |
+| Share | 1 social action (post or kudos) |
+
+These are configurable server-side so they can be tuned without a client release.
+
+### Ring State
+
+Each ring has a `current` count and a `target`. The ring fills proportionally: `current / target`. At `current >= target`, the ring is closed.
+
+Ring state resets daily at midnight in the user's local timezone.
+
+### Ring Detail (tap interaction)
+
+Tapping a ring expands it inline — reusing the same expand/collapse pattern from `DashboardStats.tsx` (the Open/Due Today/Done This Week stats that expand to show task lists).
+
+Each expanded ring shows:
+- Current progress: "2 of 3 completed"
+- A sentence explaining how to close it:
+  - **Plan**: "Create or schedule 2 tasks to close this ring"
+  - **Do**: "Complete 3 tasks to close this ring"
+  - **Share**: "Post an update or send kudos to close this ring"
+- If closed: a checkmark and "Closed!" with the ring's accent color
+
+## Productivity Score
+
+### Formula
+
+The score is calculated from ring closure over a **rolling 14-day window**:
+
+```
+base_score = (rings_closed_in_last_14_days / (3 * 14)) * 100
+
+streak_multiplier = 1.0 + (min(current_streak, 14) * 0.01)
+  // streak of 7 = 1.07x, streak of 14+ = 1.14x (capped)
+
+productivity_score = min(round(base_score * streak_multiplier), 100)
+```
+
+- A user closing all 3 rings every day for 14 days with a 14-day streak scores: `(42/42) * 100 * 1.14 = 100` (capped)
+- A user closing 2 rings per day for 14 days with no streak: `(28/42) * 100 * 1.0 = 67` → shows `--`
+- A brand new user: `0` → shows `--`
+
+### Display Rules
+
+- Score **>= 70**: show the number (70, 85, 100, etc.)
+- Score **< 70**: show `--` (no shame for new users or breaks)
+- The score updates in real-time as rings close throughout the day
+
+### Where it appears
+
+- **Profile**: centered inside the three concentric rings
+- **Home dashboard**: compact ring widget (replaces or supplements DashboardStats)
+
+## Profile Ring Visualization
+
+Three concentric rings displayed on the user's profile, replacing the 4-stat grid.
+
+```
+        ┌─────────────────┐
+        │   ╭─── Plan ───╮│  (outer ring, blue)
+        │  ╭─── Do ────╮ ││  (middle ring, green)
+        │ ╭─── Share ──╮│ ││  (inner ring, pink)
+        │ │            ││ ││
+        │ │     85     ││ ││  (score in center)
+        │ │            ││ ││
+        │ ╰────────────╯│ ││
+        │  ╰────────────╯ ││
+        │   ╰─────────────╯│
+        └─────────────────┘
+```
+
+- Rings animate as they fill
+- Tapping the visualization opens the detail view (ring-by-ring progress + guidance sentences)
+- For other users' profiles: shows their current score and ring state (read-only, no tap detail)
+
+## Variable Reward: AI Credit Drops
+
+### Trigger
+
+All three rings close in a single day.
+
+### Reward
+
+A random AI credit drop from the following pool:
+
+| Drop | Weight | Amount |
+|------|--------|--------|
+| Voice credit | 40% | +1 |
+| Natural Language credit | 40% | +1 |
+| Analytics credit | 15% | +1 |
+| Voice credits (bonus) | 5% | +2 |
+
+### UX
+
+- When the third ring closes, a brief celebration animation plays
+- Toast notification: "All rings closed! You earned +1 Voice Credit"
+- The reward is applied immediately to the user's credit balance
+- One reward per day maximum (closing rings multiple times in a day — e.g., exceeding targets — does not grant additional rewards)
+
+### Backend
+
+- Track `lastRewardDate` on user document to prevent duplicate daily rewards
+- Reward selection is server-side (client sends "all rings closed" event, server picks the reward and returns it)
+- This prevents client-side manipulation of reward odds
+
+## Notifications
+
+### Ring Reminder Notifications
+
+Add ring-specific push notifications to encourage ring closure.
+
+**Generic reminders** (sent based on check-in frequency setting):
+- "You're 1 task away from closing your Do ring today"
+- "Your Plan and Share rings are still open — there's still time!"
+- "You haven't closed any rings today. Start with one task to get going."
+
+**Ring-specific targeted notifications:**
+- **Plan ring open** (afternoon): "Got anything on your mind for tomorrow? Plan 2 tasks to close your Plan ring."
+- **Do ring open** (afternoon/evening): "You have {N} tasks due today. Complete 3 to close your Do ring."
+- **Share ring open**: "Someone in your circle could use a boost. Send kudos to close your Share ring."
+
+**All rings closed notification:**
+- Sent immediately when all three rings close
+- "You closed all your rings today! +1 {credit_type} Credit"
+- This is the reward notification — combines the celebration with the credit drop
+
+### Notification Settings
+
+Reuse the existing check-in frequency setting (`None / Occasionally / Regularly / Frequently`) to control ring reminder frequency:
+- **None**: no ring reminders
+- **Occasionally**: max 1 ring reminder per day (evening only, if rings still open)
+- **Regularly**: up to 2 reminders (afternoon + evening)
+- **Frequently**: up to 3 reminders (morning check-in + afternoon + evening)
+
+The "all rings closed" notification always fires regardless of frequency setting (it's a reward, not a nag).
+
+## Data Model Changes
+
+### New: Ring State (daily, ephemeral)
+
+Could be stored in the existing `activity` collection or a new `ring_state` collection:
+
+```
+RingState {
+  user_id: ObjectID
+  date: string (YYYY-MM-DD)
+  plan: { current: int, target: int, closed: bool }
+  do: { current: int, target: int, closed: bool }
+  share: { current: int, target: int, closed: bool }
+  all_closed: bool
+  reward_claimed: bool
+  reward_type: string (nullable)
+  reward_amount: int (nullable)
+}
+```
+
+### Modified: User Document
+
+```
+// Remove:
+points: int
+
+// Add:
+productivity_score: int (cached, recalculated on ring state changes)
+last_reward_date: date (nullable, for daily reward cap)
+```
+
+### Unchanged
+- `streak`, `streakEligible` — kept, still incremented, now hidden
+- `credits` — unchanged, receives reward drops
+- `kudosRewards` — unchanged
+- `activity` — unchanged (still tracks daily completion counts)
+
+## API Changes
+
+### New Endpoints
+
+```
+GET  /v1/user/rings/today     — Get today's ring state
+GET  /v1/user/rings/history   — Get ring states for date range (for score calculation on client, or score trend display)
+POST /v1/user/rings/reward    — Claim daily reward (called when all rings close)
+```
+
+### Modified Endpoints
+
+Ring state is updated as a side effect of existing actions — no explicit "update ring" endpoint needed:
+
+- **Task creation** (`POST /v1/user/tasks/{category}`) → increments Plan ring
+- **Task scheduling** (deadline/start date updates) → increments Plan ring (if scheduling for future)
+- **Task completion** (`POST /v1/user/tasks/complete/{category}/{id}`) → increments Do ring
+- **Post creation** (`POST /v1/user/posts/`) → increments Share ring
+- **Kudos sent** (`POST /v1/encouragements/`, `POST /v1/congratulations/`) → increments Share ring
+
+### Profile Response
+
+- Remove `points` from profile API response
+- Add `productivity_score` (int, or null if < 70)
+- Add `rings` object with today's state (for own profile) or just the score (for other users)
+
+## Migration
+
+1. Stop writing to `points` field
+2. Add `productivity_score` and `last_reward_date` fields to user documents
+3. Create `ring_state` collection with TTL index (auto-delete after 30 days — only need 14 for score calculation, 30 for buffer)
+4. Deploy backend changes (ring state tracking as side effects)
+5. Deploy frontend changes (new ring visualization, remove stats grid)
+6. `points` field can be dropped from the schema in a later cleanup
+
+## Out of Scope (Future)
+
+- Adaptive daily targets based on user's rolling average
+- Weekly/monthly ring summaries
+- Social ring comparisons (see friends' ring states)
+- Collectible stamps/badges layer on top of rings
+- Ring-specific analytics ("you close your Plan ring 80% of days but Share only 30%")

--- a/docs/superpowers/specs/2026-05-16-productivity-score-rings-design.md
+++ b/docs/superpowers/specs/2026-05-16-productivity-score-rings-design.md
@@ -27,9 +27,9 @@ Replace the current points/streak-based gamification with a **Productivity Score
 
 | Ring | Color | What it tracks | How it closes |
 |------|-------|---------------|---------------|
-| **Plan** | `#7DC4FF` (blue) | Tasks created or scheduled | Create a new task (any date) or set/update a future start date or deadline on an existing task. Each distinct task counts once per day toward the Plan ring regardless of how many times it's edited. |
-| **Do** | `#5CFF95` (green) | Tasks completed | Complete N tasks in a day |
-| **Share** | `#FF7EB3` (pink) | Social actions | Post or send a kudos (encouragement or congratulation) |
+| **Plan** | `#854DFF` (purple) | Tasks created or scheduled | Create a new task (any date) or set/update a future start date or deadline on an existing task. Each distinct task counts once per day toward the Plan ring regardless of how many times it's edited. |
+| **Do** | `#854DFF` (purple) | Tasks completed | Complete N tasks in a day |
+| **Share** | `#854DFF` (purple) | Social actions | Post or send a kudos (encouragement or congratulation) |
 
 ### Daily Targets (v1 — fixed)
 
@@ -65,26 +65,36 @@ Each expanded ring shows:
 
 ### Formula
 
-The score is calculated from ring closure over a **rolling 14-day window**:
+The score starts at 50 and builds over a **rolling 7-day window**:
 
 ```
-base_score = (rings_closed_in_last_14_days / (3 * 14)) * 100
+base = 50
+ring_bonus = (rings_closed_last_7_days / 21) * 50    // 0 to +50
+streak_bonus = min(current_streak, 7)                  // 0 to +7
 
-streak_multiplier = 1.0 + (min(current_streak, 14) * 0.01)
-  // streak of 7 = 1.07x, streak of 14+ = 1.14x (capped)
-
-productivity_score = min(round(base_score * streak_multiplier), 100)
+productivity_score = min(base + ring_bonus + streak_bonus, 100)
 ```
 
-- A user closing all 3 rings every day for 14 days with a 14-day streak scores: `(42/42) * 100 * 1.14 = 100` (capped)
-- A user closing 2 rings per day for 14 days with no streak: `(28/42) * 100 * 1.0 = 67` → shows `--`
-- A brand new user: `0` → shows `--`
+Example progression:
+
+| Day | Rings closed (total last 7d) | Score |
+|-----|------------------------------|-------|
+| New user | 0 | 50 |
+| Day 1 (close all 3) | 3 | 58 |
+| Day 2 (close all 3) | 6 | 66 |
+| Day 3 (close all 3) | 9 | 74 |
+| Day 5 (close all 3) | 15 | 88 |
+| Day 7 (close all 3) | 21 | 100 |
+| Miss a day after 7 | 18 | 90 |
+
+The floor is always 50 — a new or inactive user sits at 50, never 0.
 
 ### Display Rules
 
-- Score **>= 70**: show the number (70, 85, 100, etc.)
-- Score **< 70**: show `--` (no shame for new users or breaks)
+- Score **>= 30**: show the number
+- Score **< 30**: show `--` (practically unreachable since floor is 50, but handles edge cases)
 - The score updates in real-time as rings close throughout the day
+- Visible from day 1 — a new user sees "50" immediately
 
 ### Where it appears
 
@@ -93,25 +103,27 @@ productivity_score = min(round(base_score * streak_multiplier), 100)
 
 ## Profile Ring Visualization
 
-Three concentric rings displayed on the user's profile, replacing the 4-stat grid.
+Three separate rings displayed in a row on the user's profile, replacing the 4-stat grid. The Productivity Score sits above or below the rings as a standalone number.
 
 ```
-        ┌─────────────────┐
-        │   ╭─── Plan ───╮│  (outer ring, blue)
-        │  ╭─── Do ────╮ ││  (middle ring, green)
-        │ ╭─── Share ──╮│ ││  (inner ring, pink)
-        │ │            ││ ││
-        │ │     85     ││ ││  (score in center)
-        │ │            ││ ││
-        │ ╰────────────╯│ ││
-        │  ╰────────────╯ ││
-        │   ╰─────────────╯│
-        └─────────────────┘
+              85
+       Productivity Score
+
+    ╭───╮     ╭───╮     ╭───╮
+    │   │     │   │     │   │
+    │ 2 │     │ 1 │     │ 0 │
+    │/2 │     │/3 │     │/1 │
+    ╰───╯     ╰───╯     ╰───╯
+    Plan       Do       Share
 ```
 
+- Each ring is its own circle, filled proportionally (current/target)
+- All three rings use the primary purple (`#854DFF`); unfilled portion is a faint purple track
+- The current/target count is displayed inside each ring
+- Ring label sits below each circle
+- Tapping a ring expands it inline (same pattern as DashboardStats) showing progress and a guidance sentence
 - Rings animate as they fill
-- Tapping the visualization opens the detail view (ring-by-ring progress + guidance sentences)
-- For other users' profiles: shows their current score and ring state (read-only, no tap detail)
+- For other users' profiles: shows their score and ring state (read-only, no tap detail)
 
 ## Variable Reward: AI Credit Drops
 

--- a/frontend/api/rings.ts
+++ b/frontend/api/rings.ts
@@ -1,0 +1,75 @@
+import client from "./client";
+import { withAuthHeaders } from "./utils";
+import { createLogger } from "@/utils/logger";
+import { RingTodayResponse, RingHistoryResponse, RingRewardResponse } from "./types";
+
+const logger = createLogger('RingsAPI');
+
+/**
+ * Get today's ring state and productivity score
+ * API: GET /v1/user/rings/today
+ */
+export const getRingsToday = async (): Promise<RingTodayResponse> => {
+    try {
+        const { data, error } = await client.GET("/v1/user/rings/today" as any, {
+            params: withAuthHeaders(),
+        });
+
+        if (error) {
+            throw new Error(`Failed to fetch rings today: ${JSON.stringify(error)}`);
+        }
+
+        return data as RingTodayResponse;
+    } catch (error) {
+        logger.error("Error fetching rings today", error);
+        throw error;
+    }
+};
+
+/**
+ * Get ring history for the last N days
+ * API: GET /v1/user/rings/history?days=N
+ * @param days - Number of days of history to fetch (default: server decides)
+ */
+export const getRingsHistory = async (days?: number): Promise<RingHistoryResponse> => {
+    try {
+        const query: Record<string, any> = {};
+        if (days !== undefined) {
+            query.days = days;
+        }
+
+        const { data, error } = await client.GET("/v1/user/rings/history" as any, {
+            params: withAuthHeaders({ query }),
+        });
+
+        if (error) {
+            throw new Error(`Failed to fetch rings history: ${JSON.stringify(error)}`);
+        }
+
+        return data as RingHistoryResponse;
+    } catch (error) {
+        logger.error("Error fetching rings history", error);
+        throw error;
+    }
+};
+
+/**
+ * Claim the daily ring completion reward
+ * API: POST /v1/user/rings/reward
+ */
+export const claimRingReward = async (): Promise<RingRewardResponse> => {
+    try {
+        const { data, error } = await client.POST("/v1/user/rings/reward" as any, {
+            params: withAuthHeaders(),
+        });
+
+        if (error) {
+            throw new Error(`Failed to claim ring reward: ${JSON.stringify(error)}`);
+        }
+
+        return data as RingRewardResponse;
+    } catch (error) {
+        logger.error("Error claiming ring reward", error);
+        throw error;
+    }
+};

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -175,6 +175,8 @@ export interface Profile {
     handle: string;
     profile_picture: string;
     tasks_complete: number;
+    points?: number;
+    productivity_score?: number;
     friends: string[];
     relationship?: RelationshipInfo;
 }

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -224,4 +224,41 @@ export interface MarkNotificationsReadRequest {
     /** @description Array of notification IDs to mark as read */
     notification_ids: string[];
 }
+// Ring system types
+export interface RingProgress {
+    current: number;
+    target: number;
+    closed: boolean;
+}
+
+export interface RingState {
+    _id: string;
+    user_id: string;
+    date: string;
+    plan: RingProgress;
+    do: RingProgress;
+    share: RingProgress;
+    all_closed: boolean;
+    reward_claimed: boolean;
+    reward_type?: string;
+    reward_amount?: number;
+}
+
+export interface RingTodayResponse {
+    rings: RingState;
+    score: number;
+}
+
+export interface RingHistoryResponse {
+    history: RingState[];
+    score: number;
+}
+
+export interface RingRewardResponse {
+    claimed: boolean;
+    credit_type?: string;
+    amount?: number;
+    message: string;
+}
+
 export { components };

--- a/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
@@ -11,7 +11,7 @@ import { useAuth } from "@/hooks/useAuth";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
 import ProfileStats from "@/components/profile/ProfileStats";
-import TodayStats from "@/components/profile/TodayStats";
+import ProductivityRings from "@/components/profile/ProductivityRings";
 import ProfileGallery from "@/components/profile/ProfileGallery";
 import ProfileHeader from "@/components/profile/ProfileHeader";
 import WeeklyActivity from "@/components/profile/WeeklyActivity";
@@ -109,7 +109,7 @@ export default function Profile() {
 
                 <CompleteProfileCard />
 
-                <TodayStats userId={user?._id} />
+                <ProductivityRings userId={user?._id} />
 
                 <ReferralCard />
 

--- a/frontend/components/dashboard/HomescrollContent.tsx
+++ b/frontend/components/dashboard/HomescrollContent.tsx
@@ -11,6 +11,7 @@ import { useRouter } from "expo-router";
 import { KudosCards } from "../cards/KudosCard";
 import { HorseIcon, PlusIcon } from "phosphor-react-native";
 import { HORIZONTAL_PADDING } from "@/constants/spacing";
+import ProductivityRings from "@/components/profile/ProductivityRings";
 import TodaySection from "./TodaySection";
 import RecentlyCompletedTasks from "./RecentlyCompletedTasks";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -311,6 +312,11 @@ export const HomeScrollContent: React.FC<HomeScrollContentProps> = ({
                         />
                     </View>
                 </BasicCard> */}
+
+                {/* Productivity Rings */}
+                <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>
+                    <ProductivityRings compact />
+                </View>
 
                 {/* Dashboard Stats */}
                 <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -1,0 +1,278 @@
+import React, { useState, useCallback } from "react";
+import {
+    View,
+    StyleSheet,
+    LayoutAnimation,
+    UIManager,
+    Platform,
+    TouchableOpacity,
+} from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Check } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useRings } from "@/hooks/useRings";
+import { RingProgress } from "@/api/types";
+
+if (
+    Platform.OS === "android" &&
+    UIManager.setLayoutAnimationEnabledExperimental
+) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const RING_SIZE = 80;
+const STROKE_WIDTH = 6;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const PRIMARY_COLOR = "#854DFF";
+
+type RingKey = "plan" | "do" | "share";
+
+const RING_GUIDANCE: Record<RingKey, string> = {
+    plan: "Create or schedule tasks to close this ring",
+    do: "Complete tasks to close this ring",
+    share: "Post an update or send kudos to close this ring",
+};
+
+interface ProductivityRingsProps {
+    userId?: string;
+    compact?: boolean;
+}
+
+function RingCircle({
+    progress,
+    trackColor,
+}: {
+    progress: RingProgress;
+    trackColor: string;
+}) {
+    const fraction = progress.target > 0
+        ? Math.min(progress.current / progress.target, 1)
+        : 0;
+    const strokeDashoffset = CIRCUMFERENCE * (1 - fraction);
+
+    return (
+        <Svg width={RING_SIZE} height={RING_SIZE}>
+            {/* Background track */}
+            <Circle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RADIUS}
+                stroke={trackColor}
+                strokeWidth={STROKE_WIDTH}
+                fill="none"
+            />
+            {/* Progress arc */}
+            <Circle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RADIUS}
+                stroke={PRIMARY_COLOR}
+                strokeWidth={STROKE_WIDTH}
+                fill="none"
+                strokeDasharray={`${CIRCUMFERENCE}`}
+                strokeDashoffset={strokeDashoffset}
+                strokeLinecap="round"
+                rotation={-90}
+                origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+            />
+        </Svg>
+    );
+}
+
+const ProductivityRings: React.FC<ProductivityRingsProps> = ({ compact }) => {
+    const ThemedColor = useThemeColor();
+    const { rings, score, isLoading } = useRings();
+    const [expandedRing, setExpandedRing] = useState<RingKey | null>(null);
+
+    const trackColor = ThemedColor.tertiary;
+    const displayScore = score >= 30 ? score : null;
+
+    const handleRingPress = useCallback((key: RingKey) => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpandedRing((prev) => (prev === key ? null : key));
+    }, []);
+
+    if (isLoading || !rings) {
+        return null;
+    }
+
+    const ringEntries: { key: RingKey; label: string; progress: RingProgress }[] = [
+        { key: "plan", label: "Plan", progress: rings.plan },
+        { key: "do", label: "Do", progress: rings.do },
+        { key: "share", label: "Share", progress: rings.share },
+    ];
+
+    return (
+        <View style={styles.container}>
+            {/* Productivity Score */}
+            {!compact && (
+                <View style={styles.scoreSection}>
+                    <ThemedText
+                        style={[
+                            styles.scoreValue,
+                            { color: ThemedColor.text },
+                        ]}
+                    >
+                        {displayScore !== null ? displayScore : "--"}
+                    </ThemedText>
+                    <ThemedText
+                        style={[
+                            styles.scoreLabel,
+                            { color: ThemedColor.caption },
+                        ]}
+                    >
+                        PRODUCTIVITY SCORE
+                    </ThemedText>
+                </View>
+            )}
+
+            {/* Rings row */}
+            <View style={styles.ringsRow}>
+                {ringEntries.map(({ key, label, progress }) => (
+                    <TouchableOpacity
+                        key={key}
+                        style={styles.ringItem}
+                        onPress={() => handleRingPress(key)}
+                        activeOpacity={0.7}
+                    >
+                        <View style={styles.ringWrapper}>
+                            <RingCircle
+                                progress={progress}
+                                trackColor={trackColor}
+                            />
+                            <View style={styles.ringCenter}>
+                                {progress.closed ? (
+                                    <Check
+                                        size={24}
+                                        color={PRIMARY_COLOR}
+                                        weight="bold"
+                                    />
+                                ) : (
+                                    <ThemedText
+                                        style={[
+                                            styles.ringText,
+                                            { color: ThemedColor.text },
+                                        ]}
+                                    >
+                                        {progress.current}/{progress.target}
+                                    </ThemedText>
+                                )}
+                            </View>
+                        </View>
+                        <ThemedText
+                            style={[
+                                styles.ringLabel,
+                                { color: ThemedColor.caption },
+                            ]}
+                        >
+                            {label.toUpperCase()}
+                        </ThemedText>
+                    </TouchableOpacity>
+                ))}
+            </View>
+
+            {/* Expanded detail */}
+            {expandedRing && (
+                <View style={styles.expandedSection}>
+                    {(() => {
+                        const entry = ringEntries.find(
+                            (e) => e.key === expandedRing
+                        )!;
+                        const { progress } = entry;
+                        return (
+                            <>
+                                <ThemedText
+                                    style={[
+                                        styles.expandedProgress,
+                                        { color: ThemedColor.text },
+                                    ]}
+                                >
+                                    {progress.current} / {progress.target}
+                                </ThemedText>
+                                <ThemedText
+                                    style={[
+                                        styles.expandedGuidance,
+                                        progress.closed
+                                            ? { color: ThemedColor.success }
+                                            : { color: ThemedColor.caption },
+                                    ]}
+                                >
+                                    {progress.closed
+                                        ? "Closed!"
+                                        : RING_GUIDANCE[expandedRing]}
+                                </ThemedText>
+                            </>
+                        );
+                    })()}
+                </View>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 16,
+    },
+    scoreSection: {
+        alignItems: "flex-start",
+        marginBottom: 4,
+    },
+    scoreValue: {
+        fontSize: 36,
+        fontWeight: "600",
+        fontFamily: "Fraunces",
+    },
+    scoreLabel: {
+        fontSize: 12,
+        fontFamily: "Outfit",
+        letterSpacing: 1,
+        marginTop: 2,
+    },
+    ringsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+    },
+    ringItem: {
+        alignItems: "center",
+        gap: 6,
+    },
+    ringWrapper: {
+        width: RING_SIZE,
+        height: RING_SIZE,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringCenter: {
+        position: "absolute",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringText: {
+        fontSize: 14,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+    ringLabel: {
+        fontSize: 11,
+        fontFamily: "Outfit",
+        letterSpacing: 1,
+    },
+    expandedSection: {
+        alignItems: "flex-start",
+        gap: 4,
+    },
+    expandedProgress: {
+        fontSize: 14,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+    expandedGuidance: {
+        fontSize: 13,
+        fontFamily: "Outfit",
+    },
+});
+
+export default ProductivityRings;

--- a/frontend/hooks/useRings.ts
+++ b/frontend/hooks/useRings.ts
@@ -1,0 +1,56 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getRingsToday, getRingsHistory, claimRingReward } from "@/api/rings";
+import { RingState } from "@/api/types";
+
+export function useRings() {
+    const queryClient = useQueryClient();
+
+    // Query for today's ring state
+    const {
+        data: todayData,
+        isLoading: isLoadingToday,
+        refetch,
+    } = useQuery({
+        queryKey: ["rings", "today"],
+        queryFn: getRingsToday,
+        staleTime: 60_000, // 60 seconds
+        refetchInterval: 5 * 60_000, // 5 minutes
+    });
+
+    // Query for ring history
+    const {
+        data: historyData,
+        isLoading: isLoadingHistory,
+    } = useQuery({
+        queryKey: ["rings", "history"],
+        queryFn: () => getRingsHistory(),
+        staleTime: 5 * 60_000, // 5 minutes
+    });
+
+    // Mutation for claiming reward
+    const claimRewardMutation = useMutation({
+        mutationFn: claimRingReward,
+        onSuccess: () => {
+            queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
+            queryClient.invalidateQueries({ queryKey: ["rings", "history"] });
+        },
+    });
+
+    // Derived state
+    const rings: RingState | null = todayData?.rings ?? null;
+    const score = todayData?.score ?? 0;
+    const allClosed = rings?.all_closed ?? false;
+    const canClaimReward = allClosed && !(rings?.reward_claimed ?? false);
+
+    return {
+        rings,
+        score,
+        allClosed,
+        canClaimReward,
+        isLoading: isLoadingToday,
+        history: historyData?.history ?? [],
+        claimReward: claimRewardMutation.mutateAsync,
+        isClaiming: claimRewardMutation.isPending,
+        refetch,
+    };
+}

--- a/frontend/hooks/useRings.ts
+++ b/frontend/hooks/useRings.ts
@@ -1,6 +1,8 @@
+import { useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { getRingsToday, getRingsHistory, claimRingReward } from "@/api/rings";
 import { RingState } from "@/api/types";
+import { showToast } from "@/utils/showToast";
 
 export function useRings() {
     const queryClient = useQueryClient();
@@ -41,6 +43,39 @@ export function useRings() {
     const score = todayData?.score ?? 0;
     const allClosed = rings?.all_closed ?? false;
     const canClaimReward = allClosed && !(rings?.reward_claimed ?? false);
+
+    // Auto-claim reward when all rings close
+    const claimedRef = useRef(false);
+
+    useEffect(() => {
+        if (!canClaimReward) {
+            // Reset ref when reward is no longer claimable (new day)
+            claimedRef.current = false;
+            return;
+        }
+
+        if (claimedRef.current) return;
+        claimedRef.current = true;
+
+        claimRewardMutation.mutateAsync().then((result) => {
+            if (result.claimed && result.credit_type && result.amount) {
+                const friendlyType =
+                    result.credit_type === "naturalLanguage"
+                        ? "Natural Language"
+                        : result.credit_type.charAt(0).toUpperCase() +
+                          result.credit_type.slice(1);
+
+                showToast(
+                    `All rings closed! +${result.amount} ${friendlyType} Credit(s)`,
+                    "success",
+                    "Reward Claimed"
+                );
+            }
+        }).catch(() => {
+            // Allow retry on failure
+            claimedRef.current = false;
+        });
+    }, [canClaimReward]);
 
     return {
         rings,


### PR DESCRIPTION
## Summary

- **Productivity Score (0-100):** Replaces points and visible streaks with a live score powered by three daily rings. Score starts at 50, builds over a 7-day rolling window, hidden below 30.
- **Three Rings (Plan, Do, Share):** Track task creation, task completion, and social actions. Each ring fills toward a daily target and displays as a tappable circle on profile and dashboard.
- **Variable Reward:** Closing all three rings in a day triggers a random AI credit drop (voice, natural language, or analytics credits).
- **Points removed:** Post creation no longer awards points. Points field hidden from profile API responses.
- **Streak hidden:** Streak still tracked internally (feeds score formula) but no longer visible to users.

### Backend
- New `rings` handler package with RingService, API routes, and 10 tests (394 total passing)
- Ring state tracked in `ring_states` MongoDB collection with TTL index (30-day auto-cleanup)
- Side-effect ring increments wired into task, post, encouragement, and congratulation handlers
- Profile API now exposes `productivity_score`, hides `points` and `streak` (for other users)

### Frontend
- New `ProductivityRings` component with three SVG ring circles, expand/collapse detail, and score display
- Replaces `TodayStats` 4-stat grid on profile
- Added to home dashboard as compact widget
- `useRings` hook with auto-refresh and auto-claim reward toast
- Ring API client (`getRingsToday`, `getRingsHistory`, `claimRingReward`)

## Test plan
- [x] Backend builds cleanly (`go build ./...`)
- [x] All 394 backend tests pass (`make test-backend`)
- [ ] Manual test: create tasks → Plan ring increments
- [ ] Manual test: complete tasks → Do ring increments
- [ ] Manual test: post/send kudos → Share ring increments
- [ ] Manual test: close all rings → reward toast appears with credit drop
- [ ] Manual test: profile shows rings + score instead of old stats grid
- [ ] Manual test: dashboard shows compact ring widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)