### PR TITLE
feat: productivity rings card redesign with arc gauge and blur expand

### DIFF
--- a/backend/internal/handlers/profile/profile.go
+++ b/backend/internal/handlers/profile/profile.go
@@ -5,13 +5,15 @@ import (
 	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Handler struct {
-	service *Service
+	service     *Service
+	ringService *rings.RingService
 }
 
 func (h *Handler) GetProfiles(ctx context.Context, input *GetProfilesInput) (*GetProfilesOutput, error) {
@@ -182,6 +184,18 @@ func (h *Handler) GetProfileHuma(ctx context.Context, input *GetProfileInput) (*
 	} else {
 		profile.Tasks = []types.TaskDocument{}
 		profile.CompletedTasks = []types.TaskDocument{}
+	}
+
+	// Embed today's ring state for connected users and self
+	if relationship.Status == RelationshipConnected || relationship.Status == RelationshipSelf {
+		timezone := auth.GetTimezoneOrDefault(ctx)
+		ringState, err := h.ringService.GetOrCreateToday(ctx, id, timezone)
+		if err != nil {
+			slog.Error("Failed to get ring state for profile", "profileId", id.Hex(), "error", err)
+			// Non-fatal: continue without ring state
+		} else {
+			profile.RingState = ringState
+		}
 	}
 
 	// Sanitize internal metrics before returning

--- a/backend/internal/handlers/profile/routes.go
+++ b/backend/internal/handlers/profile/routes.go
@@ -1,6 +1,7 @@
 package Profile
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/mongo"
 )
@@ -8,13 +9,14 @@ import (
 /*
 Router maps endpoints to handlers
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection) {
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *rings.RingService) {
 	// Initialize service
 	service := NewService(collections)
 
 	// Create handler
 	handler := Handler{
-		service: service,
+		service:     service,
+		ringService: ringService,
 	}
 
 	RegisterProfileOperations(api, &handler)

--- a/backend/internal/handlers/profile/types.go
+++ b/backend/internal/handlers/profile/types.go
@@ -1,6 +1,7 @@
 package Profile
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
@@ -33,6 +34,8 @@ type ProfileDocument struct {
 	Relationship   *RelationshipInfo    `bson:"-" json:"relationship,omitempty"`
 	Tasks          []types.TaskDocument `bson:"tasks" json:"tasks,omitempty"`
 	CompletedTasks []types.TaskDocument `bson:"-" json:"completed_tasks,omitempty"`
+	// Today's ring state - included for connected users and self
+	RingState *rings.RingState `bson:"-" json:"ring_state,omitempty"`
 }
 
 // RelationshipInfo contains details about the relationship between users

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -146,7 +146,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	auth.Routes(api, collections)
 	category.Routes(api, collections)
 	activity.Routes(api, collections)
-	profile.Routes(api, collections)
+	profile.Routes(api, collections, ringService)
 	task.Routes(api, collections, geminiService, ringService)
 
 	// SSE streaming routes for NLP flows (raw Fiber, bypass Huma)

--- a/docs/superpowers/plans/2026-05-17-productivity-rings-card-redesign.md
+++ b/docs/superpowers/plans/2026-05-17-productivity-rings-card-redesign.md
@@ -1,0 +1,1024 @@
+# Productivity Rings Card Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Redesign the profile page ProductivityRings into a card with an SVG arc gauge for the score, blur-overlay expand behavior with 7-day history and contextual CTAs, and remove rings from the dashboard.
+
+**Architecture:** Four new focused components (`ScoreArc`, `ExpandedRingDetail`, `RingsBlurOverlay`, rewritten `ProductivityRingsCard`) composed together on the profile page. Blur overlay is rendered at the profile ScrollView level and controlled via callback prop. All data comes from the existing `useRings` hook — no backend changes.
+
+**Tech Stack:** React Native, react-native-svg (existing), expo-blur (existing), Animated API, LayoutAnimation
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `frontend/components/profile/ScoreArc.tsx` | Create | Pure SVG semi-circle gauge |
+| `frontend/components/profile/ExpandedRingDetail.tsx` | Create | History dots, guidance text, CTAs |
+| `frontend/components/profile/RingsBlurOverlay.tsx` | Create | Full-screen BlurView overlay |
+| `frontend/components/profile/ProductivityRings.tsx` | Rewrite | Card wrapper composing arc + rings + expand |
+| `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx` | Modify | Add blur overlay, pass expand callback |
+| `frontend/components/dashboard/HomescrollContent.tsx` | Modify | Remove rings import and usage |
+
+---
+
+### Task 1: Create ScoreArc Component
+
+**Files:**
+- Create: `frontend/components/profile/ScoreArc.tsx`
+
+- [ ] **Step 1: Create the ScoreArc SVG component**
+
+Create `frontend/components/profile/ScoreArc.tsx`:
+
+```tsx
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import Svg, { Path } from "react-native-svg";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+const ARC_WIDTH = 200;
+const ARC_HEIGHT = 120;
+const STROKE_WIDTH = 10;
+const PRIMARY_COLOR = "#854DFF";
+
+// Semi-circle arc from left to right (180 degrees)
+const RADIUS = (ARC_WIDTH - STROKE_WIDTH) / 2;
+const CENTER_X = ARC_WIDTH / 2;
+const CENTER_Y = ARC_HEIGHT - 10; // bottom-aligned with padding
+
+function describeArc(startAngle: number, endAngle: number): string {
+    const startRad = (startAngle * Math.PI) / 180;
+    const endRad = (endAngle * Math.PI) / 180;
+    const startX = CENTER_X + RADIUS * Math.cos(startRad);
+    const startY = CENTER_Y - RADIUS * Math.sin(startRad);
+    const endX = CENTER_X + RADIUS * Math.cos(endRad);
+    const endY = CENTER_Y - RADIUS * Math.sin(endRad);
+    const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+    return `M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 ${largeArc} 0 ${endX} ${endY}`;
+}
+
+interface ScoreArcProps {
+    score: number;
+    maxScore?: number;
+}
+
+const ScoreArc: React.FC<ScoreArcProps> = ({ score, maxScore = 100 }) => {
+    const ThemedColor = useThemeColor();
+    const fraction = Math.min(Math.max(score / maxScore, 0), 1);
+
+    // Track goes from 180 degrees (left) to 0 degrees (right)
+    const trackPath = describeArc(0, 180);
+    // Fill arc: proportional sweep from left
+    const fillEndAngle = 180 - fraction * 180;
+    const fillPath = fraction > 0 ? describeArc(fillEndAngle, 180) : "";
+
+    const displayScore = score >= 30 ? score : "--";
+
+    return (
+        <View style={styles.container}>
+            <Svg width={ARC_WIDTH} height={ARC_HEIGHT}>
+                {/* Background track */}
+                <Path
+                    d={trackPath}
+                    stroke={ThemedColor.tertiary}
+                    strokeWidth={STROKE_WIDTH}
+                    fill="none"
+                    strokeLinecap="round"
+                />
+                {/* Score fill */}
+                {fillPath !== "" && (
+                    <Path
+                        d={fillPath}
+                        stroke={PRIMARY_COLOR}
+                        strokeWidth={STROKE_WIDTH}
+                        fill="none"
+                        strokeLinecap="round"
+                    />
+                )}
+            </Svg>
+            {/* Score number centered in arc */}
+            <View style={styles.scoreOverlay}>
+                <ThemedText style={[styles.scoreValue, { color: ThemedColor.text }]}>
+                    {displayScore}
+                </ThemedText>
+            </View>
+            {/* Min/max labels */}
+            <View style={styles.labelsRow}>
+                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                    0
+                </ThemedText>
+                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                    100
+                </ThemedText>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        width: ARC_WIDTH,
+        height: ARC_HEIGHT + 16,
+    },
+    scoreOverlay: {
+        position: "absolute",
+        bottom: 20,
+        alignItems: "center",
+    },
+    scoreValue: {
+        fontSize: 36,
+        fontWeight: "600",
+        fontFamily: "Fraunces",
+    },
+    labelsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        width: ARC_WIDTH - STROKE_WIDTH,
+        marginTop: -6,
+    },
+    label: {
+        fontSize: 11,
+        fontFamily: "Outfit",
+    },
+});
+
+export default ScoreArc;
+```
+
+- [ ] **Step 2: Verify the component renders**
+
+Start the dev server if not running (`bun expo start`), then manually import and render `<ScoreArc score={72} />` temporarily in `profile.tsx` to verify the arc renders correctly. Remove the temporary import after verification.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/profile/ScoreArc.tsx
+git commit -m "feat(profile): add ScoreArc SVG semi-circle gauge component"
+```
+
+---
+
+### Task 2: Create ExpandedRingDetail Component
+
+**Files:**
+- Create: `frontend/components/profile/ExpandedRingDetail.tsx`
+
+- [ ] **Step 1: Create the ExpandedRingDetail component**
+
+Create `frontend/components/profile/ExpandedRingDetail.tsx`:
+
+```tsx
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useRouter } from "expo-router";
+import { RingState } from "@/api/types";
+
+type RingKey = "plan" | "do" | "share";
+
+const PRIMARY_COLOR = "#854DFF";
+
+const RING_LABELS: Record<RingKey, string> = {
+    plan: "Plan",
+    do: "Do",
+    share: "Share",
+};
+
+const RING_GUIDANCE: Record<RingKey, string> = {
+    plan: "Create or schedule tasks to close this ring",
+    do: "Complete tasks to close this ring",
+    share: "Post an update or send kudos to close this ring",
+};
+
+interface CTA {
+    label: string;
+    route: string;
+}
+
+const RING_CTAS: Record<RingKey, CTA[]> = {
+    plan: [
+        { label: "Plan Today", route: "/(logged-in)/(tabs)/(task)/daily" },
+        { label: "Quick Add", route: "/(logged-in)/(tabs)/(task)/voice" },
+    ],
+    do: [
+        { label: "View Tasks", route: "/(logged-in)/(tabs)/(task)/today" },
+    ],
+    share: [
+        { label: "Make a Post", route: "/(logged-in)/posting/cameraview" },
+        { label: "Send Kudos", route: "/(logged-in)/kudos-rewards" },
+    ],
+};
+
+// Day labels starting from Monday
+const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+
+interface ExpandedRingDetailProps {
+    ringKey: RingKey;
+    todayRing: { current: number; target: number; closed: boolean };
+    history: RingState[];
+}
+
+/**
+ * Build a 7-day array of closed/not-closed for a specific ring,
+ * ordered from 6 days ago to today.
+ */
+function buildHistoryDots(
+    history: RingState[],
+    ringKey: RingKey
+): { dayLabel: string; closed: boolean }[] {
+    const today = new Date();
+    const dots: { dayLabel: string; closed: boolean }[] = [];
+
+    for (let i = 6; i >= 0; i--) {
+        const date = new Date(today);
+        date.setDate(date.getDate() - i);
+        const dayIndex = (date.getDay() + 6) % 7; // Monday=0
+        const dateStr = date.toISOString().split("T")[0];
+
+        const state = history.find((h) => {
+            const hDate = new Date(h.date).toISOString().split("T")[0];
+            return hDate === dateStr;
+        });
+
+        dots.push({
+            dayLabel: DAY_LABELS[dayIndex],
+            closed: state ? state[ringKey].closed : false,
+        });
+    }
+
+    return dots;
+}
+
+const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
+    ringKey,
+    todayRing,
+    history,
+}) => {
+    const ThemedColor = useThemeColor();
+    const router = useRouter();
+    const dots = buildHistoryDots(history, ringKey);
+    const ctas = RING_CTAS[ringKey];
+
+    return (
+        <View style={styles.container}>
+            {/* Ring header */}
+            <ThemedText style={[styles.header, { color: ThemedColor.text }]}>
+                {RING_LABELS[ringKey]} — {todayRing.current} / {todayRing.target}
+            </ThemedText>
+
+            {/* Guidance text */}
+            <ThemedText
+                style={[
+                    styles.guidance,
+                    todayRing.closed
+                        ? { color: ThemedColor.success }
+                        : { color: ThemedColor.caption },
+                ]}
+            >
+                {todayRing.closed ? "Closed!" : RING_GUIDANCE[ringKey]}
+            </ThemedText>
+
+            {/* 7-day history dots */}
+            <View style={styles.dotsRow}>
+                {dots.map((dot, idx) => (
+                    <View key={idx} style={styles.dotColumn}>
+                        <View
+                            style={[
+                                styles.dot,
+                                {
+                                    backgroundColor: dot.closed
+                                        ? PRIMARY_COLOR
+                                        : ThemedColor.tertiary,
+                                },
+                            ]}
+                        />
+                        <ThemedText
+                            style={[styles.dotLabel, { color: ThemedColor.caption }]}
+                        >
+                            {dot.dayLabel}
+                        </ThemedText>
+                    </View>
+                ))}
+            </View>
+
+            {/* CTAs */}
+            <View style={styles.ctaRow}>
+                {ctas.map((cta) => (
+                    <TouchableOpacity
+                        key={cta.label}
+                        style={styles.ctaButton}
+                        onPress={() => router.push(cta.route as any)}
+                        activeOpacity={0.7}
+                    >
+                        <ThemedText style={styles.ctaText}>{cta.label}</ThemedText>
+                    </TouchableOpacity>
+                ))}
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 12,
+        paddingTop: 16,
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderTopColor: "rgba(128, 128, 128, 0.2)",
+    },
+    header: {
+        fontSize: 14,
+        fontWeight: "600",
+        fontFamily: "Outfit",
+    },
+    guidance: {
+        fontSize: 13,
+        fontFamily: "Outfit",
+    },
+    dotsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        paddingHorizontal: 8,
+    },
+    dotColumn: {
+        alignItems: "center",
+        gap: 4,
+    },
+    dot: {
+        width: 12,
+        height: 12,
+        borderRadius: 6,
+    },
+    dotLabel: {
+        fontSize: 10,
+        fontFamily: "Outfit",
+    },
+    ctaRow: {
+        flexDirection: "row",
+        gap: 10,
+        marginTop: 4,
+    },
+    ctaButton: {
+        backgroundColor: PRIMARY_COLOR,
+        paddingHorizontal: 16,
+        paddingVertical: 8,
+        borderRadius: 20,
+    },
+    ctaText: {
+        color: "#FFFFFF",
+        fontSize: 13,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+});
+
+export default ExpandedRingDetail;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/components/profile/ExpandedRingDetail.tsx
+git commit -m "feat(profile): add ExpandedRingDetail with history dots and CTAs"
+```
+
+---
+
+### Task 3: Create RingsBlurOverlay Component
+
+**Files:**
+- Create: `frontend/components/profile/RingsBlurOverlay.tsx`
+
+- [ ] **Step 1: Create the RingsBlurOverlay component**
+
+This follows the exact same pattern as `FABBackdrop.tsx`.
+
+Create `frontend/components/profile/RingsBlurOverlay.tsx`:
+
+```tsx
+import React, { useEffect, useRef } from "react";
+import { TouchableWithoutFeedback, Animated, StyleSheet } from "react-native";
+import { BlurView } from "expo-blur";
+
+interface RingsBlurOverlayProps {
+    visible: boolean;
+    onDismiss: () => void;
+}
+
+const RingsBlurOverlay: React.FC<RingsBlurOverlayProps> = ({ visible, onDismiss }) => {
+    const opacity = useRef(new Animated.Value(0)).current;
+
+    useEffect(() => {
+        Animated.timing(opacity, {
+            toValue: visible ? 1 : 0,
+            duration: 250,
+            useNativeDriver: true,
+        }).start();
+    }, [visible]);
+
+    if (!visible) return null;
+
+    return (
+        <TouchableWithoutFeedback onPress={onDismiss}>
+            <Animated.View style={[styles.overlay, { opacity }]}>
+                <BlurView intensity={15} style={StyleSheet.absoluteFill} tint="dark" />
+            </Animated.View>
+        </TouchableWithoutFeedback>
+    );
+};
+
+const styles = StyleSheet.create({
+    overlay: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        zIndex: 998,
+    },
+});
+
+export default RingsBlurOverlay;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/components/profile/RingsBlurOverlay.tsx
+git commit -m "feat(profile): add RingsBlurOverlay with expo-blur backdrop"
+```
+
+---
+
+### Task 4: Rewrite ProductivityRings into ProductivityRingsCard
+
+**Files:**
+- Rewrite: `frontend/components/profile/ProductivityRings.tsx`
+
+- [ ] **Step 1: Rewrite ProductivityRings.tsx**
+
+Replace the entire contents of `frontend/components/profile/ProductivityRings.tsx` with:
+
+```tsx
+import React, { useState, useCallback } from "react";
+import {
+    View,
+    StyleSheet,
+    LayoutAnimation,
+    UIManager,
+    Platform,
+    TouchableOpacity,
+} from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Check } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useRings } from "@/hooks/useRings";
+import { RingProgress } from "@/api/types";
+import ScoreArc from "./ScoreArc";
+import ExpandedRingDetail from "./ExpandedRingDetail";
+
+if (
+    Platform.OS === "android" &&
+    UIManager.setLayoutAnimationEnabledExperimental
+) {
+    UIManager.setLayoutAnimationEnabledExperimental(true);
+}
+
+const RING_SIZE = 80;
+const STROKE_WIDTH = 6;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const PRIMARY_COLOR = "#854DFF";
+
+type RingKey = "plan" | "do" | "share";
+
+function RingCircle({
+    progress,
+    trackColor,
+}: {
+    progress: RingProgress;
+    trackColor: string;
+}) {
+    const fraction =
+        progress.target > 0
+            ? Math.min(progress.current / progress.target, 1)
+            : 0;
+    const strokeDashoffset = CIRCUMFERENCE * (1 - fraction);
+
+    return (
+        <Svg width={RING_SIZE} height={RING_SIZE}>
+            <Circle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RADIUS}
+                stroke={trackColor}
+                strokeWidth={STROKE_WIDTH}
+                fill="none"
+            />
+            <Circle
+                cx={RING_SIZE / 2}
+                cy={RING_SIZE / 2}
+                r={RADIUS}
+                stroke={PRIMARY_COLOR}
+                strokeWidth={STROKE_WIDTH}
+                fill="none"
+                strokeDasharray={`${CIRCUMFERENCE}`}
+                strokeDashoffset={strokeDashoffset}
+                strokeLinecap="round"
+                rotation={-90}
+                origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+            />
+        </Svg>
+    );
+}
+
+/**
+ * Count total closed rings across the 7-day history window.
+ */
+function countClosedRings(
+    history: { plan: { closed: boolean }; do: { closed: boolean }; share: { closed: boolean } }[]
+): number {
+    let count = 0;
+    for (const state of history) {
+        if (state.plan.closed) count++;
+        if (state.do.closed) count++;
+        if (state.share.closed) count++;
+    }
+    return count;
+}
+
+interface ProductivityRingsCardProps {
+    expanded?: boolean;
+    onExpandChange?: (expanded: boolean) => void;
+}
+
+const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
+    expanded,
+    onExpandChange,
+}) => {
+    const ThemedColor = useThemeColor();
+    const { rings, score, isLoading, history } = useRings();
+    const [expandedRing, setExpandedRing] = useState<RingKey | null>(null);
+
+    // Sync with parent: when blur overlay is dismissed, clear internal state
+    React.useEffect(() => {
+        if (expanded === false && expandedRing !== null) {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+            setExpandedRing(null);
+        }
+    }, [expanded]);
+
+    const trackColor = ThemedColor.tertiary;
+    const closedRings = countClosedRings(history);
+
+    // Count streak from useRings — todayData has current_streak but useRings
+    // doesn't expose it yet. We'll derive it from history for now:
+    // consecutive days from today where all_closed is true.
+    let streak = 0;
+    const sortedHistory = [...history].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+    for (const state of sortedHistory) {
+        if (state.all_closed) {
+            streak++;
+        } else {
+            break;
+        }
+    }
+
+    const handleRingPress = useCallback(
+        (key: RingKey) => {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+            const newExpanded = expandedRing === key ? null : key;
+            setExpandedRing(newExpanded);
+            onExpandChange?.(newExpanded !== null);
+        },
+        [expandedRing, onExpandChange]
+    );
+
+    const handleDismiss = useCallback(() => {
+        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+        setExpandedRing(null);
+        onExpandChange?.(false);
+    }, [onExpandChange]);
+
+    if (isLoading || !rings) {
+        return null;
+    }
+
+    const ringEntries: { key: RingKey; label: string; progress: RingProgress }[] = [
+        { key: "plan", label: "Plan", progress: rings.plan },
+        { key: "do", label: "Do", progress: rings.do },
+        { key: "share", label: "Share", progress: rings.share },
+    ];
+
+    const isExpanded = expandedRing !== null;
+
+    return (
+        <View
+            style={[
+                styles.card,
+                {
+                    backgroundColor: ThemedColor.lightened,
+                },
+                isExpanded && styles.cardExpanded,
+            ]}
+        >
+            {/* Score Arc */}
+            <View style={styles.arcSection}>
+                <ScoreArc score={score} />
+                {/* Stat pills */}
+                <View style={styles.pillsRow}>
+                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
+                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
+                            Rings: {closedRings}/21
+                        </ThemedText>
+                    </View>
+                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
+                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
+                            Streak: {streak} days
+                        </ThemedText>
+                    </View>
+                </View>
+            </View>
+
+            {/* Rings Row */}
+            <View style={styles.ringsRow}>
+                {ringEntries.map(({ key, label, progress }) => (
+                    <TouchableOpacity
+                        key={key}
+                        style={[
+                            styles.ringItem,
+                            isExpanded &&
+                                expandedRing !== key && { opacity: 0.3 },
+                        ]}
+                        onPress={() => handleRingPress(key)}
+                        activeOpacity={0.7}
+                    >
+                        <View style={styles.ringWrapper}>
+                            <RingCircle
+                                progress={progress}
+                                trackColor={trackColor}
+                            />
+                            <View style={styles.ringCenter}>
+                                {progress.closed ? (
+                                    <Check
+                                        size={24}
+                                        color={PRIMARY_COLOR}
+                                        weight="bold"
+                                    />
+                                ) : (
+                                    <ThemedText
+                                        style={[
+                                            styles.ringText,
+                                            { color: ThemedColor.text },
+                                        ]}
+                                    >
+                                        {progress.current}/{progress.target}
+                                    </ThemedText>
+                                )}
+                            </View>
+                        </View>
+                        <ThemedText
+                            style={[
+                                styles.ringLabel,
+                                { color: ThemedColor.caption },
+                            ]}
+                        >
+                            {label.toUpperCase()}
+                        </ThemedText>
+                    </TouchableOpacity>
+                ))}
+            </View>
+
+            {/* Expanded detail */}
+            {expandedRing && (
+                <ExpandedRingDetail
+                    ringKey={expandedRing}
+                    todayRing={rings[expandedRing]}
+                    history={history}
+                />
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    card: {
+        borderRadius: 16,
+        padding: 20,
+        gap: 20,
+        // Shadow
+        shadowColor: "#000",
+        shadowOpacity: 0.08,
+        shadowOffset: { width: 0, height: 4 },
+        shadowRadius: 12,
+        elevation: 3,
+    },
+    cardExpanded: {
+        transform: [{ scale: 1.03 }],
+        shadowOpacity: 0.15,
+        shadowRadius: 20,
+        elevation: 6,
+        zIndex: 999,
+    },
+    arcSection: {
+        alignItems: "center",
+        gap: 8,
+    },
+    pillsRow: {
+        flexDirection: "row",
+        gap: 10,
+    },
+    pill: {
+        paddingHorizontal: 12,
+        paddingVertical: 4,
+        borderRadius: 12,
+    },
+    pillText: {
+        fontSize: 12,
+        fontFamily: "Outfit",
+        fontWeight: "500",
+    },
+    ringsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+    },
+    ringItem: {
+        alignItems: "center",
+        gap: 6,
+    },
+    ringWrapper: {
+        width: 80,
+        height: 80,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringCenter: {
+        position: "absolute",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringText: {
+        fontSize: 14,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+    ringLabel: {
+        fontSize: 11,
+        fontFamily: "Outfit",
+        letterSpacing: 1,
+    },
+});
+
+export { ProductivityRingsCard };
+export default ProductivityRingsCard;
+```
+
+- [ ] **Step 2: Verify the card renders on the profile page**
+
+The profile page already imports `ProductivityRings` as the default export from this file, so it should pick up the new card automatically. Open the profile page in the app and verify:
+- Arc gauge renders with the score
+- Three rings show below the arc
+- Stat pills show beneath the arc
+- Card has visible rounded corners and shadow
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/profile/ProductivityRings.tsx
+git commit -m "feat(profile): rewrite ProductivityRings as card with arc gauge and expand"
+```
+
+---
+
+### Task 5: Wire Blur Overlay into Profile Page
+
+**Files:**
+- Modify: `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx`
+
+- [ ] **Step 1: Add blur overlay state and import**
+
+In `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx`, add the import for `RingsBlurOverlay` and a state variable for the expand callback:
+
+Add to the imports at the top of the file (after the existing `ProductivityRings` import):
+
+```tsx
+import RingsBlurOverlay from "@/components/profile/RingsBlurOverlay";
+```
+
+Inside the `Profile` component, add state:
+
+```tsx
+const [ringsExpanded, setRingsExpanded] = useState(false);
+```
+
+(Also add `useState` to the React import if not already destructured — it is already imported.)
+
+- [ ] **Step 2: Render the blur overlay and pass callback to ProductivityRings**
+
+In the JSX return, add `RingsBlurOverlay` just inside the `Animated.ScrollView`, before `ParallaxBanner`:
+
+```tsx
+<RingsBlurOverlay
+    visible={ringsExpanded}
+    onDismiss={() => setRingsExpanded(false)}
+/>
+```
+
+Update the `ProductivityRings` usage (around line 112) to pass the callback:
+
+Change:
+```tsx
+<ProductivityRings userId={user?._id} />
+```
+
+To:
+```tsx
+<ProductivityRings expanded={ringsExpanded} onExpandChange={setRingsExpanded} />
+```
+
+(The `userId` prop is no longer used — the rewritten component gets data from `useRings` directly. The `expanded` prop syncs the blur overlay dismiss back to the card's internal state.)
+
+- [ ] **Step 3: Verify blur behavior**
+
+Open the profile page, tap a ring circle. Verify:
+- BlurView overlay appears behind the card with fade-in
+- Tapping the blur overlay dismisses the expanded ring
+- Card scales up slightly when expanded
+- Non-selected rings dim to 0.3 opacity
+- Expanded detail shows history dots, guidance text, and CTAs
+- CTA buttons navigate to the correct screens
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/app/\(logged-in\)/\(tabs\)/\(profile\)/profile.tsx
+git commit -m "feat(profile): wire RingsBlurOverlay into profile page"
+```
+
+---
+
+### Task 6: Expose streak from useRings hook
+
+**Files:**
+- Modify: `frontend/hooks/useRings.ts`
+
+- [ ] **Step 1: Expose current_streak from the API response**
+
+The backend returns `current_streak` in the today response, but `useRings` doesn't expose it. Add it so the card can use the authoritative value instead of deriving from history.
+
+In `frontend/hooks/useRings.ts`, update the derived state section:
+
+Change:
+```ts
+    // Derived state
+    const rings: RingState | null = todayData?.ring_state ?? null;
+    const score = todayData?.productivity_score ?? 0;
+    const allClosed = rings?.all_closed ?? false;
+    const canClaimReward = todayData?.reward_available ?? false;
+```
+
+To:
+```ts
+    // Derived state
+    const rings: RingState | null = todayData?.ring_state ?? null;
+    const score = todayData?.productivity_score ?? 0;
+    const streak = todayData?.current_streak ?? 0;
+    const allClosed = rings?.all_closed ?? false;
+    const canClaimReward = todayData?.reward_available ?? false;
+```
+
+Update the return object — change:
+```ts
+    return {
+        rings,
+        score,
+        allClosed,
+        canClaimReward,
+        isLoading: isLoadingToday,
+        history: historyData?.history ?? [],
+        claimReward: claimRewardMutation.mutateAsync,
+        isClaiming: claimRewardMutation.isPending,
+        refetch,
+    };
+```
+
+To:
+```ts
+    return {
+        rings,
+        score,
+        streak,
+        allClosed,
+        canClaimReward,
+        isLoading: isLoadingToday,
+        history: historyData?.history ?? [],
+        claimReward: claimRewardMutation.mutateAsync,
+        isClaiming: claimRewardMutation.isPending,
+        refetch,
+    };
+```
+
+- [ ] **Step 2: Use streak from hook in ProductivityRingsCard**
+
+In `frontend/components/profile/ProductivityRings.tsx`, update the hook destructure:
+
+Change:
+```ts
+const { rings, score, isLoading, history } = useRings();
+```
+
+To:
+```ts
+const { rings, score, streak, isLoading, history } = useRings();
+```
+
+Then remove the streak derivation block (the `let streak = 0; const sortedHistory = ...` block and the `for` loop) and use `streak` directly from the hook.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useRings.ts frontend/components/profile/ProductivityRings.tsx
+git commit -m "feat(profile): expose streak from useRings hook, remove local derivation"
+```
+
+---
+
+### Task 7: Remove Rings from Dashboard
+
+**Files:**
+- Modify: `frontend/components/dashboard/HomescrollContent.tsx`
+
+- [ ] **Step 1: Remove ProductivityRings import and usage**
+
+In `frontend/components/dashboard/HomescrollContent.tsx`:
+
+Remove the import line (line 14):
+```tsx
+import ProductivityRings from "@/components/profile/ProductivityRings";
+```
+
+Remove the rings section (lines 316-319):
+```tsx
+                {/* Productivity Rings */}
+                <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>
+                    <ProductivityRings compact />
+                </View>
+```
+
+- [ ] **Step 2: Verify dashboard still renders correctly**
+
+Open the dashboard home screen. Verify:
+- No rings visible
+- DashboardStats and other cards render normally
+- No console errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/dashboard/HomescrollContent.tsx
+git commit -m "chore(dashboard): remove ProductivityRings from home screen"
+```
+
+---
+
+### Task 8: Clean Up Unused Props
+
+**Files:**
+- Modify: `frontend/components/profile/ProductivityRings.tsx`
+
+- [ ] **Step 1: Remove the compact prop**
+
+The rewritten `ProductivityRingsCard` no longer accepts or uses a `compact` prop (the dashboard was the only consumer). Verify the interface only has `expanded` and `onExpandChange`:
+
+```tsx
+interface ProductivityRingsCardProps {
+    expanded?: boolean;
+    onExpandChange?: (expanded: boolean) => void;
+}
+```
+
+If there is still a `compact` or `userId` prop in the interface, remove it.
+
+- [ ] **Step 2: Final visual check**
+
+Open the profile page and verify the full flow:
+1. Card renders with arc gauge, stat pills, and three rings
+2. Tapping a ring: blur overlay appears, card lifts, detail expands with history dots + CTAs
+3. Tapping blur: dismisses back to collapsed state
+4. CTA buttons navigate correctly
+5. Dashboard no longer shows rings
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/profile/ProductivityRings.tsx
+git commit -m "chore(profile): clean up unused compact/userId props from rings card"
+```

--- a/docs/superpowers/specs/2026-05-17-productivity-rings-card-redesign.md
+++ b/docs/superpowers/specs/2026-05-17-productivity-rings-card-redesign.md
@@ -1,0 +1,138 @@
+# Productivity Rings Card Redesign
+
+## Summary
+
+Redesign the ProductivityRings component on the profile page into a prominent card with an arc gauge for the productivity score, a score breakdown, and an expanded ring detail view with 7-day history and contextual CTAs. Tapping a ring triggers a full-screen blur overlay (expo-blur) that focuses attention on the card.
+
+## Motivation
+
+The current rings display is flat and easily overlooked. The score is shown as plain text with no visual weight. There is no way to act on a ring's guidance directly, and no historical context for how a ring has performed over the past week.
+
+## Design
+
+### Default (Collapsed) State
+
+A single card with subtle drop shadow containing two vertical zones:
+
+**Top: Score Arc Gauge**
+
+- Semi-circle (180 degrees) SVG arc rendered with `react-native-svg`
+- Arc fill color: `#854DFF` (primary purple), proportional to `score / 100`
+- Arc track color: theme `tertiary`
+- Score number centered inside the arc, Fraunces 600, 36px
+- Min label "0" bottom-left of arc, "100" bottom-right, Outfit caption size
+- Two stat pills beneath the arc:
+  - "Rings: X/21" (closed rings in the 7-day window)
+  - "Streak: X days"
+
+**Bottom: Rings Row**
+
+- Three tappable ring circles in a horizontal row: Plan, Do, Share
+- Each shows `current/target` text or a checkmark icon when closed
+- Labels beneath each ring: "PLAN", "DO", "SHARE" in Outfit 11px, letter-spacing 1
+
+**Card Styling**
+
+- `borderRadius: 16`
+- Background: theme `card` or `secondary`
+- Shadow: `shadowColor: #000`, `shadowOpacity: 0.08`, `shadowOffset: { width: 0, height: 4 }`, `shadowRadius: 12`, `elevation: 3`
+- Horizontal padding: 20, vertical padding: 20
+- Gap between arc section and rings row: 20
+
+### Expanded State (Ring Tapped)
+
+#### Blur Overlay
+
+- `BlurView` from `expo-blur` covering the full screen behind the card
+- Intensity: 15, tint: "dark"
+- Background dim: `rgba(0, 0, 0, 0.4)`
+- Rendered as a sibling at the `profile.tsx` ScrollView level (portal pattern, same as FABBackdrop)
+- Tapping the overlay dismisses the expanded state
+- Fade-in: `Animated.timing`, 250ms
+
+#### Card Behavior
+
+- Card scales to `1.03` with a stronger shadow to lift off the page
+- Non-selected rings dim to 0.3 opacity
+- Selected ring stays fully opaque
+- Transition: `LayoutAnimation.easeInEaseOut`
+
+#### Expanded Content (within card, below rings row)
+
+1. **Ring header**: Ring name + progress, e.g. "Do - 2 / 3", Outfit 600 14px
+2. **Guidance text**: Contextual hint per ring type:
+   - Plan: "Create or schedule tasks to close this ring"
+   - Do: "Complete tasks to close this ring"
+   - Share: "Post an update or send kudos to close this ring"
+3. **7-day history row**: Seven small circles (diameter ~12px) representing the last 7 days. Filled purple if that ring was closed on that day, theme `tertiary` fill if not. Day-of-week labels (M, T, W, T, F, S, S) beneath each dot in Outfit 10px caption color.
+4. **CTAs**: Pill-shaped buttons in primary purple, Outfit font, white text.
+
+| Ring  | CTA 1                                          | CTA 2                                            |
+|-------|------------------------------------------------|--------------------------------------------------|
+| Plan  | "Plan Today" -> `/(tabs)/(task)/daily`         | "Quick Add" -> `/(tabs)/(task)/voice`            |
+| Do    | "View Tasks" -> `/(tabs)/(task)/today`         | -                                                |
+| Share | "Make a Post" -> `/(logged-in)/posting/cameraview` | "Send Kudos" -> `/(logged-in)/kudos-rewards` |
+
+### Score Breakdown (Future / On-Tap)
+
+The full formula breakdown (base 50 + ring bonus up to 50 + streak bonus up to 7) is not shown by default. The two stat pills (Rings X/21, Streak X days) provide enough context. A future iteration could show the full breakdown when tapping the score number, but this is out of scope for this iteration.
+
+## Architecture
+
+### Component Tree
+
+```
+ProductivityRingsCard (new wrapper, replaces ProductivityRings)
+  ScoreArc (new) - pure SVG semi-circle gauge
+  RingsRow (extracted) - three ring circles, tap handlers
+  ExpandedRingDetail (new) - history dots, guidance, CTAs
+```
+
+```
+profile.tsx
+  RingsBlurOverlay (new) - full-screen BlurView, rendered at ScrollView level
+  ...
+  ProductivityRingsCard
+  ...
+```
+
+### State Management
+
+- `expandedRing: RingKey | null` lives in `ProductivityRingsCard`
+- Passed up to `profile.tsx` via a callback prop `onExpandChange(expanded: boolean)` to control blur overlay visibility (same pattern as DashboardStats `onExpandChange`)
+- No new context or global state
+
+### Data Flow
+
+- `useRings()` hook already provides: `rings` (today's state), `score`, `history` (7-day array)
+- History is filtered client-side by selected ring type to produce the 7-day dot row
+- Closed ring count for the "Rings: X/21" pill is computed by iterating `history` and counting closed rings across all three types
+- No backend changes required
+
+### New Dependencies
+
+None. `expo-blur` and `react-native-svg` are already in the project.
+
+## Dashboard Cleanup
+
+The rings are currently rendered on the dashboard home screen (`HomescrollContent.tsx:318`) in compact mode. For now, rings should only appear on the profile page. Remove the `ProductivityRings` import and usage from `HomescrollContent.tsx`.
+
+## Files (updated)
+
+| File | Change |
+|------|--------|
+| `components/profile/ProductivityRings.tsx` | Rewrite into `ProductivityRingsCard` with arc, card wrapper, expand logic |
+| `components/profile/ScoreArc.tsx` | New - SVG semi-circle gauge component |
+| `components/profile/ExpandedRingDetail.tsx` | New - history dots, guidance text, CTAs |
+| `components/profile/RingsBlurOverlay.tsx` | New - full-screen BlurView overlay |
+| `app/(logged-in)/(tabs)/(profile)/profile.tsx` | Render `RingsBlurOverlay`, pass expand state from card |
+| `components/dashboard/HomescrollContent.tsx` | Remove `ProductivityRings` import and usage |
+| `hooks/useRings.ts` | No changes |
+| `api/rings.ts` | No changes |
+
+## Out of Scope
+
+- Full formula breakdown overlay (tapping score to see base/ring/streak segments)
+- Animated ring fill on mount (can add later as polish)
+- Horizontal bar alternative layout (will revisit if arc feels too large in practice)
+- Rings on dashboard (may revisit placement later, excluded for now)

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -179,6 +179,7 @@ export interface Profile {
     productivity_score?: number;
     friends: string[];
     relationship?: RelationshipInfo;
+    ring_state?: RingState;
 }
 
 // Notification types for custom Fiber endpoints (not in OpenAPI spec)
@@ -247,8 +248,10 @@ export interface RingState {
 }
 
 export interface RingTodayResponse {
-    rings: RingState;
-    score: number;
+    ring_state: RingState;
+    productivity_score: number;
+    current_streak: number;
+    reward_available: boolean;
 }
 
 export interface RingHistoryResponse {

--- a/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
@@ -22,6 +22,7 @@ import { useThemeColor } from "@/hooks/useThemeColor";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
 import ProfileStats from "@/components/profile/ProfileStats";
 import TodayStats from "@/components/profile/TodayStats";
+import { FriendRings } from "@/components/profile/ProductivityRings";
 import ProfileGallery from "@/components/profile/ProfileGallery";
 import ProfileHeader from "@/components/profile/ProfileHeader";
 import WeeklyActivity from "@/components/profile/WeeklyActivity";
@@ -190,7 +191,11 @@ export default function Profile() {
                         />
                     </View>
 
-                    <TodayStats userId={profile?.id} />
+                    {profile?.ring_state ? (
+                        <FriendRings ringState={profile.ring_state} />
+                    ) : (
+                        <TodayStats userId={profile?.id} />
+                    )}
                 </View>
                 {canViewPersonalContent ? (
                     <>

--- a/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
@@ -12,6 +12,7 @@ import { useThemeColor } from "@/hooks/useThemeColor";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
 import ProfileStats from "@/components/profile/ProfileStats";
 import ProductivityRings from "@/components/profile/ProductivityRings";
+import RingsBlurOverlay from "@/components/profile/RingsBlurOverlay";
 import ProfileGallery from "@/components/profile/ProfileGallery";
 import ProfileHeader from "@/components/profile/ProfileHeader";
 import WeeklyActivity from "@/components/profile/WeeklyActivity";
@@ -34,6 +35,7 @@ export default function Profile() {
     let ThemedColor = useThemeColor();
 
     const [activeTab, setActiveTab] = useState(0);
+    const [ringsExpanded, setRingsExpanded] = useState(false);
 
     const DEFAULT_PICTURE = "https://notioly.com/wp-content/uploads/2025/02/506.Adventurous-Cat.png";
     const hasDefaultAvatar = !user?.profile_picture || user.profile_picture === DEFAULT_PICTURE;
@@ -94,6 +96,10 @@ export default function Profile() {
             scrollEventThrottle={16}
             showsVerticalScrollIndicator={false}
             style={[styles.scrollView, { backgroundColor: ThemedColor.background }]}>
+            <RingsBlurOverlay
+                visible={ringsExpanded}
+                onDismiss={() => setRingsExpanded(false)}
+            />
             <ParallaxBanner
                 scrollRef={scrollRef}
                 backgroundImage={user?.profile_picture || Icons.luffy}
@@ -109,7 +115,7 @@ export default function Profile() {
 
                 <CompleteProfileCard />
 
-                <ProductivityRings userId={user?._id} />
+                <ProductivityRings expanded={ringsExpanded} onExpandChange={setRingsExpanded} />
 
                 <ReferralCard />
 

--- a/frontend/components/dashboard/HomescrollContent.tsx
+++ b/frontend/components/dashboard/HomescrollContent.tsx
@@ -11,7 +11,6 @@ import { useRouter } from "expo-router";
 import { KudosCards } from "../cards/KudosCard";
 import { HorseIcon, PlusIcon } from "phosphor-react-native";
 import { HORIZONTAL_PADDING } from "@/constants/spacing";
-import ProductivityRings from "@/components/profile/ProductivityRings";
 import TodaySection from "./TodaySection";
 import RecentlyCompletedTasks from "./RecentlyCompletedTasks";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -313,10 +312,6 @@ export const HomeScrollContent: React.FC<HomeScrollContentProps> = ({
                     </View>
                 </BasicCard> */}
 
-                {/* Productivity Rings */}
-                <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>
-                    <ProductivityRings compact />
-                </View>
 
                 {/* Dashboard Stats */}
                 <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8 }}>

--- a/frontend/components/profile/ExpandedRingDetail.tsx
+++ b/frontend/components/profile/ExpandedRingDetail.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
+import Svg, { Circle } from "react-native-svg";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useRouter } from "expo-router";
@@ -48,12 +49,23 @@ interface ExpandedRingDetailProps {
     history: RingState[];
 }
 
-function buildHistoryDots(
+const MINI_RING_SIZE = 28;
+const MINI_STROKE = 3;
+const MINI_RADIUS = (MINI_RING_SIZE - MINI_STROKE) / 2;
+const MINI_CIRCUMFERENCE = 2 * Math.PI * MINI_RADIUS;
+
+interface HistoryEntry {
+    dayLabel: string;
+    closed: boolean;
+    fraction: number;
+}
+
+function buildHistoryEntries(
     history: RingState[],
     ringKey: RingKey
-): { dayLabel: string; closed: boolean }[] {
+): HistoryEntry[] {
     const today = new Date();
-    const dots: { dayLabel: string; closed: boolean }[] = [];
+    const entries: HistoryEntry[] = [];
 
     for (let i = 6; i >= 0; i--) {
         const date = new Date(today);
@@ -66,13 +78,19 @@ function buildHistoryDots(
             return hDate === dateStr;
         });
 
-        dots.push({
+        const ring = state ? state[ringKey] : null;
+        const fraction = ring && ring.target > 0
+            ? Math.min(ring.current / ring.target, 1)
+            : 0;
+
+        entries.push({
             dayLabel: DAY_LABELS[dayIndex],
-            closed: state ? state[ringKey].closed : false,
+            closed: ring ? ring.closed : false,
+            fraction,
         });
     }
 
-    return dots;
+    return entries;
 }
 
 const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
@@ -82,7 +100,7 @@ const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
 }) => {
     const ThemedColor = useThemeColor();
     const router = useRouter();
-    const dots = buildHistoryDots(history, ringKey);
+    const entries = buildHistoryEntries(history, ringKey);
     const ctas = RING_CTAS[ringKey];
 
     return (
@@ -103,25 +121,43 @@ const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
             </ThemedText>
 
             <View style={styles.dotsRow}>
-                {dots.map((dot, idx) => (
-                    <View key={idx} style={styles.dotColumn}>
-                        <View
-                            style={[
-                                styles.dot,
-                                {
-                                    backgroundColor: dot.closed
-                                        ? PRIMARY_COLOR
-                                        : ThemedColor.tertiary,
-                                },
-                            ]}
-                        />
-                        <ThemedText
-                            style={[styles.dotLabel, { color: ThemedColor.caption }]}
-                        >
-                            {dot.dayLabel}
-                        </ThemedText>
-                    </View>
-                ))}
+                {entries.map((entry, idx) => {
+                    const strokeDashoffset = MINI_CIRCUMFERENCE * (1 - entry.fraction);
+                    return (
+                        <View key={idx} style={styles.dotColumn}>
+                            <Svg width={MINI_RING_SIZE} height={MINI_RING_SIZE}>
+                                <Circle
+                                    cx={MINI_RING_SIZE / 2}
+                                    cy={MINI_RING_SIZE / 2}
+                                    r={MINI_RADIUS}
+                                    stroke={ThemedColor.tertiary}
+                                    strokeWidth={MINI_STROKE}
+                                    fill="none"
+                                />
+                                {entry.fraction > 0 && (
+                                    <Circle
+                                        cx={MINI_RING_SIZE / 2}
+                                        cy={MINI_RING_SIZE / 2}
+                                        r={MINI_RADIUS}
+                                        stroke={PRIMARY_COLOR}
+                                        strokeWidth={MINI_STROKE}
+                                        fill="none"
+                                        strokeDasharray={`${MINI_CIRCUMFERENCE}`}
+                                        strokeDashoffset={strokeDashoffset}
+                                        strokeLinecap="round"
+                                        rotation={-90}
+                                        origin={`${MINI_RING_SIZE / 2}, ${MINI_RING_SIZE / 2}`}
+                                    />
+                                )}
+                            </Svg>
+                            <ThemedText
+                                style={[styles.dotLabel, { color: ThemedColor.caption }]}
+                            >
+                                {entry.dayLabel}
+                            </ThemedText>
+                        </View>
+                    );
+                })}
             </View>
 
             <View style={styles.ctaRow}>
@@ -164,11 +200,6 @@ const styles = StyleSheet.create({
     dotColumn: {
         alignItems: "center",
         gap: 4,
-    },
-    dot: {
-        width: 12,
-        height: 12,
-        borderRadius: 6,
     },
     dotLabel: {
         fontSize: 10,

--- a/frontend/components/profile/ExpandedRingDetail.tsx
+++ b/frontend/components/profile/ExpandedRingDetail.tsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useRouter } from "expo-router";
+import { RingState } from "@/api/types";
+
+type RingKey = "plan" | "do" | "share";
+
+const PRIMARY_COLOR = "#854DFF";
+
+const RING_LABELS: Record<RingKey, string> = {
+    plan: "Plan",
+    do: "Do",
+    share: "Share",
+};
+
+const RING_GUIDANCE: Record<RingKey, string> = {
+    plan: "Create or schedule tasks to close this ring",
+    do: "Complete tasks to close this ring",
+    share: "Post an update or send kudos to close this ring",
+};
+
+interface CTA {
+    label: string;
+    route: string;
+}
+
+const RING_CTAS: Record<RingKey, CTA[]> = {
+    plan: [
+        { label: "Plan Today", route: "/(logged-in)/(tabs)/(task)/daily" },
+        { label: "Quick Add", route: "/(logged-in)/(tabs)/(task)/voice" },
+    ],
+    do: [
+        { label: "View Tasks", route: "/(logged-in)/(tabs)/(task)/today" },
+    ],
+    share: [
+        { label: "Make a Post", route: "/(logged-in)/posting/cameraview" },
+        { label: "Send Kudos", route: "/(logged-in)/kudos-rewards" },
+    ],
+};
+
+const DAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+
+interface ExpandedRingDetailProps {
+    ringKey: RingKey;
+    todayRing: { current: number; target: number; closed: boolean };
+    history: RingState[];
+}
+
+function buildHistoryDots(
+    history: RingState[],
+    ringKey: RingKey
+): { dayLabel: string; closed: boolean }[] {
+    const today = new Date();
+    const dots: { dayLabel: string; closed: boolean }[] = [];
+
+    for (let i = 6; i >= 0; i--) {
+        const date = new Date(today);
+        date.setDate(date.getDate() - i);
+        const dayIndex = (date.getDay() + 6) % 7;
+        const dateStr = date.toISOString().split("T")[0];
+
+        const state = history.find((h) => {
+            const hDate = new Date(h.date).toISOString().split("T")[0];
+            return hDate === dateStr;
+        });
+
+        dots.push({
+            dayLabel: DAY_LABELS[dayIndex],
+            closed: state ? state[ringKey].closed : false,
+        });
+    }
+
+    return dots;
+}
+
+const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
+    ringKey,
+    todayRing,
+    history,
+}) => {
+    const ThemedColor = useThemeColor();
+    const router = useRouter();
+    const dots = buildHistoryDots(history, ringKey);
+    const ctas = RING_CTAS[ringKey];
+
+    return (
+        <View style={styles.container}>
+            <ThemedText style={[styles.header, { color: ThemedColor.text }]}>
+                {RING_LABELS[ringKey]} — {todayRing.current} / {todayRing.target}
+            </ThemedText>
+
+            <ThemedText
+                style={[
+                    styles.guidance,
+                    todayRing.closed
+                        ? { color: ThemedColor.success }
+                        : { color: ThemedColor.caption },
+                ]}
+            >
+                {todayRing.closed ? "Closed!" : RING_GUIDANCE[ringKey]}
+            </ThemedText>
+
+            <View style={styles.dotsRow}>
+                {dots.map((dot, idx) => (
+                    <View key={idx} style={styles.dotColumn}>
+                        <View
+                            style={[
+                                styles.dot,
+                                {
+                                    backgroundColor: dot.closed
+                                        ? PRIMARY_COLOR
+                                        : ThemedColor.tertiary,
+                                },
+                            ]}
+                        />
+                        <ThemedText
+                            style={[styles.dotLabel, { color: ThemedColor.caption }]}
+                        >
+                            {dot.dayLabel}
+                        </ThemedText>
+                    </View>
+                ))}
+            </View>
+
+            <View style={styles.ctaRow}>
+                {ctas.map((cta) => (
+                    <TouchableOpacity
+                        key={cta.label}
+                        style={styles.ctaButton}
+                        onPress={() => router.push(cta.route as any)}
+                        activeOpacity={0.7}
+                    >
+                        <ThemedText style={styles.ctaText}>{cta.label}</ThemedText>
+                    </TouchableOpacity>
+                ))}
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        gap: 12,
+        paddingTop: 16,
+        borderTopWidth: StyleSheet.hairlineWidth,
+        borderTopColor: "rgba(128, 128, 128, 0.2)",
+    },
+    header: {
+        fontSize: 14,
+        fontWeight: "600",
+        fontFamily: "Outfit",
+    },
+    guidance: {
+        fontSize: 13,
+        fontFamily: "Outfit",
+    },
+    dotsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        paddingHorizontal: 8,
+    },
+    dotColumn: {
+        alignItems: "center",
+        gap: 4,
+    },
+    dot: {
+        width: 12,
+        height: 12,
+        borderRadius: 6,
+    },
+    dotLabel: {
+        fontSize: 10,
+        fontFamily: "Outfit",
+    },
+    ctaRow: {
+        flexDirection: "row",
+        gap: 10,
+        marginTop: 4,
+    },
+    ctaButton: {
+        backgroundColor: PRIMARY_COLOR,
+        paddingHorizontal: 16,
+        paddingVertical: 8,
+        borderRadius: 20,
+    },
+    ctaText: {
+        color: "#FFFFFF",
+        fontSize: 13,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+});
+
+export default ExpandedRingDetail;

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -93,7 +93,7 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
     onExpandChange,
 }) => {
     const ThemedColor = useThemeColor();
-    const { rings, score, isLoading, history } = useRings();
+    const { rings, score, streak, isLoading, history } = useRings();
     const [expandedRing, setExpandedRing] = useState<RingKey | null>(null);
 
     // Sync with parent: when blur overlay is dismissed, clear internal state
@@ -106,19 +106,6 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
 
     const trackColor = ThemedColor.tertiary;
     const closedRings = countClosedRings(history);
-
-    // Derive streak from history: consecutive days from most recent where all_closed
-    let streak = 0;
-    const sortedHistory = [...history].sort(
-        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
-    );
-    for (const state of sortedHistory) {
-        if (state.all_closed) {
-            streak++;
-        } else {
-            break;
-        }
-    }
 
     const handleRingPress = useCallback(
         (key: RingKey) => {

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -71,17 +71,6 @@ function RingCircle({
     );
 }
 
-function countClosedRings(
-    history: { plan: { closed: boolean }; do: { closed: boolean }; share: { closed: boolean } }[]
-): number {
-    let count = 0;
-    for (const state of history) {
-        if (state.plan.closed) count++;
-        if (state.do.closed) count++;
-        if (state.share.closed) count++;
-    }
-    return count;
-}
 
 interface ProductivityRingsCardProps {
     expanded?: boolean;
@@ -105,7 +94,6 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
     }, [expanded]);
 
     const trackColor = ThemedColor.tertiary;
-    const closedRings = countClosedRings(history);
 
     const handleRingPress = useCallback(
         (key: RingKey) => {
@@ -142,18 +130,6 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
             {/* Score Arc */}
             <View style={styles.arcSection}>
                 <ScoreArc score={score} />
-                <View style={styles.pillsRow}>
-                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
-                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
-                            Rings: {closedRings}/21
-                        </ThemedText>
-                    </View>
-                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
-                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
-                            Streak: {streak} days
-                        </ThemedText>
-                    </View>
-                </View>
             </View>
 
             {/* Rings Row */}
@@ -229,29 +205,10 @@ const styles = StyleSheet.create({
         elevation: 3,
     },
     cardExpanded: {
-        transform: [{ scale: 1.03 }],
-        shadowOpacity: 0.15,
-        shadowRadius: 20,
-        elevation: 6,
         zIndex: 999,
     },
     arcSection: {
         alignItems: "center",
-        gap: 8,
-    },
-    pillsRow: {
-        flexDirection: "row",
-        gap: 10,
-    },
-    pill: {
-        paddingHorizontal: 12,
-        paddingVertical: 4,
-        borderRadius: 12,
-    },
-    pillText: {
-        fontSize: 12,
-        fontFamily: "Outfit",
-        fontWeight: "500",
     },
     ringsRow: {
         flexDirection: "row",

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -13,6 +13,8 @@ import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useRings } from "@/hooks/useRings";
 import { RingProgress } from "@/api/types";
+import ScoreArc from "./ScoreArc";
+import ExpandedRingDetail from "./ExpandedRingDetail";
 
 if (
     Platform.OS === "android" &&
@@ -29,17 +31,6 @@ const PRIMARY_COLOR = "#854DFF";
 
 type RingKey = "plan" | "do" | "share";
 
-const RING_GUIDANCE: Record<RingKey, string> = {
-    plan: "Create or schedule tasks to close this ring",
-    do: "Complete tasks to close this ring",
-    share: "Post an update or send kudos to close this ring",
-};
-
-interface ProductivityRingsProps {
-    userId?: string;
-    compact?: boolean;
-}
-
 function RingCircle({
     progress,
     trackColor,
@@ -47,14 +38,14 @@ function RingCircle({
     progress: RingProgress;
     trackColor: string;
 }) {
-    const fraction = progress.target > 0
-        ? Math.min(progress.current / progress.target, 1)
-        : 0;
+    const fraction =
+        progress.target > 0
+            ? Math.min(progress.current / progress.target, 1)
+            : 0;
     const strokeDashoffset = CIRCUMFERENCE * (1 - fraction);
 
     return (
         <Svg width={RING_SIZE} height={RING_SIZE}>
-            {/* Background track */}
             <Circle
                 cx={RING_SIZE / 2}
                 cy={RING_SIZE / 2}
@@ -63,7 +54,6 @@ function RingCircle({
                 strokeWidth={STROKE_WIDTH}
                 fill="none"
             />
-            {/* Progress arc */}
             <Circle
                 cx={RING_SIZE / 2}
                 cy={RING_SIZE / 2}
@@ -81,18 +71,64 @@ function RingCircle({
     );
 }
 
-const ProductivityRings: React.FC<ProductivityRingsProps> = ({ compact }) => {
+function countClosedRings(
+    history: { plan: { closed: boolean }; do: { closed: boolean }; share: { closed: boolean } }[]
+): number {
+    let count = 0;
+    for (const state of history) {
+        if (state.plan.closed) count++;
+        if (state.do.closed) count++;
+        if (state.share.closed) count++;
+    }
+    return count;
+}
+
+interface ProductivityRingsCardProps {
+    expanded?: boolean;
+    onExpandChange?: (expanded: boolean) => void;
+}
+
+const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
+    expanded,
+    onExpandChange,
+}) => {
     const ThemedColor = useThemeColor();
-    const { rings, score, isLoading } = useRings();
+    const { rings, score, isLoading, history } = useRings();
     const [expandedRing, setExpandedRing] = useState<RingKey | null>(null);
 
-    const trackColor = ThemedColor.tertiary;
-    const displayScore = score >= 30 ? score : null;
+    // Sync with parent: when blur overlay is dismissed, clear internal state
+    React.useEffect(() => {
+        if (expanded === false && expandedRing !== null) {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+            setExpandedRing(null);
+        }
+    }, [expanded]);
 
-    const handleRingPress = useCallback((key: RingKey) => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
-        setExpandedRing((prev) => (prev === key ? null : key));
-    }, []);
+    const trackColor = ThemedColor.tertiary;
+    const closedRings = countClosedRings(history);
+
+    // Derive streak from history: consecutive days from most recent where all_closed
+    let streak = 0;
+    const sortedHistory = [...history].sort(
+        (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+    );
+    for (const state of sortedHistory) {
+        if (state.all_closed) {
+            streak++;
+        } else {
+            break;
+        }
+    }
+
+    const handleRingPress = useCallback(
+        (key: RingKey) => {
+            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
+            const newExpanded = expandedRing === key ? null : key;
+            setExpandedRing(newExpanded);
+            onExpandChange?.(newExpanded !== null);
+        },
+        [expandedRing, onExpandChange]
+    );
 
     if (isLoading || !rings) {
         return null;
@@ -104,36 +140,45 @@ const ProductivityRings: React.FC<ProductivityRingsProps> = ({ compact }) => {
         { key: "share", label: "Share", progress: rings.share },
     ];
 
-    return (
-        <View style={styles.container}>
-            {/* Productivity Score */}
-            {!compact && (
-                <View style={styles.scoreSection}>
-                    <ThemedText
-                        style={[
-                            styles.scoreValue,
-                            { color: ThemedColor.text },
-                        ]}
-                    >
-                        {displayScore !== null ? displayScore : "--"}
-                    </ThemedText>
-                    <ThemedText
-                        style={[
-                            styles.scoreLabel,
-                            { color: ThemedColor.caption },
-                        ]}
-                    >
-                        PRODUCTIVITY SCORE
-                    </ThemedText>
-                </View>
-            )}
+    const isExpanded = expandedRing !== null;
 
-            {/* Rings row */}
+    return (
+        <View
+            style={[
+                styles.card,
+                {
+                    backgroundColor: ThemedColor.lightened,
+                },
+                isExpanded && styles.cardExpanded,
+            ]}
+        >
+            {/* Score Arc */}
+            <View style={styles.arcSection}>
+                <ScoreArc score={score} />
+                <View style={styles.pillsRow}>
+                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
+                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
+                            Rings: {closedRings}/21
+                        </ThemedText>
+                    </View>
+                    <View style={[styles.pill, { backgroundColor: ThemedColor.tertiary }]}>
+                        <ThemedText style={[styles.pillText, { color: ThemedColor.text }]}>
+                            Streak: {streak} days
+                        </ThemedText>
+                    </View>
+                </View>
+            </View>
+
+            {/* Rings Row */}
             <View style={styles.ringsRow}>
                 {ringEntries.map(({ key, label, progress }) => (
                     <TouchableOpacity
                         key={key}
-                        style={styles.ringItem}
+                        style={[
+                            styles.ringItem,
+                            isExpanded &&
+                                expandedRing !== key && { opacity: 0.3 },
+                        ]}
                         onPress={() => handleRingPress(key)}
                         activeOpacity={0.7}
                     >
@@ -175,61 +220,51 @@ const ProductivityRings: React.FC<ProductivityRingsProps> = ({ compact }) => {
 
             {/* Expanded detail */}
             {expandedRing && (
-                <View style={styles.expandedSection}>
-                    {(() => {
-                        const entry = ringEntries.find(
-                            (e) => e.key === expandedRing
-                        )!;
-                        const { progress } = entry;
-                        return (
-                            <>
-                                <ThemedText
-                                    style={[
-                                        styles.expandedProgress,
-                                        { color: ThemedColor.text },
-                                    ]}
-                                >
-                                    {progress.current} / {progress.target}
-                                </ThemedText>
-                                <ThemedText
-                                    style={[
-                                        styles.expandedGuidance,
-                                        progress.closed
-                                            ? { color: ThemedColor.success }
-                                            : { color: ThemedColor.caption },
-                                    ]}
-                                >
-                                    {progress.closed
-                                        ? "Closed!"
-                                        : RING_GUIDANCE[expandedRing]}
-                                </ThemedText>
-                            </>
-                        );
-                    })()}
-                </View>
+                <ExpandedRingDetail
+                    ringKey={expandedRing}
+                    todayRing={rings[expandedRing]}
+                    history={history}
+                />
             )}
         </View>
     );
 };
 
 const styles = StyleSheet.create({
-    container: {
-        gap: 16,
+    card: {
+        borderRadius: 16,
+        padding: 20,
+        gap: 20,
+        shadowColor: "#000",
+        shadowOpacity: 0.08,
+        shadowOffset: { width: 0, height: 4 },
+        shadowRadius: 12,
+        elevation: 3,
     },
-    scoreSection: {
-        alignItems: "flex-start",
-        marginBottom: 4,
+    cardExpanded: {
+        transform: [{ scale: 1.03 }],
+        shadowOpacity: 0.15,
+        shadowRadius: 20,
+        elevation: 6,
+        zIndex: 999,
     },
-    scoreValue: {
-        fontSize: 36,
-        fontWeight: "600",
-        fontFamily: "Fraunces",
+    arcSection: {
+        alignItems: "center",
+        gap: 8,
     },
-    scoreLabel: {
+    pillsRow: {
+        flexDirection: "row",
+        gap: 10,
+    },
+    pill: {
+        paddingHorizontal: 12,
+        paddingVertical: 4,
+        borderRadius: 12,
+    },
+    pillText: {
         fontSize: 12,
         fontFamily: "Outfit",
-        letterSpacing: 1,
-        marginTop: 2,
+        fontWeight: "500",
     },
     ringsRow: {
         flexDirection: "row",
@@ -240,8 +275,8 @@ const styles = StyleSheet.create({
         gap: 6,
     },
     ringWrapper: {
-        width: RING_SIZE,
-        height: RING_SIZE,
+        width: 80,
+        height: 80,
         justifyContent: "center",
         alignItems: "center",
     },
@@ -260,19 +295,7 @@ const styles = StyleSheet.create({
         fontFamily: "Outfit",
         letterSpacing: 1,
     },
-    expandedSection: {
-        alignItems: "flex-start",
-        gap: 4,
-    },
-    expandedProgress: {
-        fontSize: 14,
-        fontFamily: "Outfit",
-        fontWeight: "600",
-    },
-    expandedGuidance: {
-        fontSize: 13,
-        fontFamily: "Outfit",
-    },
 });
 
-export default ProductivityRings;
+export { ProductivityRingsCard };
+export default ProductivityRingsCard;

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -8,11 +8,11 @@ import {
     TouchableOpacity,
 } from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { Check } from "phosphor-react-native";
+import { Check, LockSimple } from "phosphor-react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useRings } from "@/hooks/useRings";
-import { RingProgress } from "@/api/types";
+import { RingProgress, RingState } from "@/api/types";
 import ScoreArc from "./ScoreArc";
 import ExpandedRingDetail from "./ExpandedRingDetail";
 
@@ -130,6 +130,12 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
             {/* Score Arc */}
             <View style={styles.arcSection}>
                 <ScoreArc score={score} />
+                <View style={styles.privateRow}>
+                    <LockSimple size={12} color={ThemedColor.caption} />
+                    <ThemedText style={[styles.privateText, { color: ThemedColor.caption }]}>
+                        Only visible to you
+                    </ThemedText>
+                </View>
             </View>
 
             {/* Rings Row */}
@@ -209,6 +215,16 @@ const styles = StyleSheet.create({
     },
     arcSection: {
         alignItems: "center",
+        gap: 4,
+    },
+    privateRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 4,
+    },
+    privateText: {
+        fontSize: 11,
+        fontFamily: "Outfit",
     },
     ringsRow: {
         flexDirection: "row",
@@ -241,5 +257,52 @@ const styles = StyleSheet.create({
     },
 });
 
-export { ProductivityRingsCard };
+/**
+ * Simplified rings-only view for friend profiles.
+ * No card, no arc gauge, no expand behavior.
+ */
+interface FriendRingsProps {
+    ringState: RingState;
+}
+
+const FriendRings: React.FC<FriendRingsProps> = ({ ringState }) => {
+    const ThemedColor = useThemeColor();
+    const trackColor = ThemedColor.tertiary;
+
+    const ringEntries: { label: string; progress: RingProgress }[] = [
+        { label: "Plan", progress: ringState.plan },
+        { label: "Do", progress: ringState.do },
+        { label: "Share", progress: ringState.share },
+    ];
+
+    return (
+        <View style={styles.ringsRow}>
+            {ringEntries.map(({ label, progress }) => (
+                <View key={label} style={styles.ringItem}>
+                    <View style={styles.ringWrapper}>
+                        <RingCircle progress={progress} trackColor={trackColor} />
+                        <View style={styles.ringCenter}>
+                            {progress.closed ? (
+                                <Check size={24} color={PRIMARY_COLOR} weight="bold" />
+                            ) : (
+                                <ThemedText
+                                    style={[styles.ringText, { color: ThemedColor.text }]}
+                                >
+                                    {progress.current}/{progress.target}
+                                </ThemedText>
+                            )}
+                        </View>
+                    </View>
+                    <ThemedText
+                        style={[styles.ringLabel, { color: ThemedColor.caption }]}
+                    >
+                        {label.toUpperCase()}
+                    </ThemedText>
+                </View>
+            ))}
+        </View>
+    );
+};
+
+export { ProductivityRingsCard, FriendRings };
 export default ProductivityRingsCard;

--- a/frontend/components/profile/RingsBlurOverlay.tsx
+++ b/frontend/components/profile/RingsBlurOverlay.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useRef } from "react";
+import { TouchableWithoutFeedback, Animated, StyleSheet } from "react-native";
+import { BlurView } from "expo-blur";
+
+interface RingsBlurOverlayProps {
+    visible: boolean;
+    onDismiss: () => void;
+}
+
+const RingsBlurOverlay: React.FC<RingsBlurOverlayProps> = ({ visible, onDismiss }) => {
+    const opacity = useRef(new Animated.Value(0)).current;
+
+    useEffect(() => {
+        Animated.timing(opacity, {
+            toValue: visible ? 1 : 0,
+            duration: 250,
+            useNativeDriver: true,
+        }).start();
+    }, [visible]);
+
+    if (!visible) return null;
+
+    return (
+        <TouchableWithoutFeedback onPress={onDismiss}>
+            <Animated.View style={[styles.overlay, { opacity }]}>
+                <BlurView intensity={15} style={StyleSheet.absoluteFill} tint="dark" />
+            </Animated.View>
+        </TouchableWithoutFeedback>
+    );
+};
+
+const styles = StyleSheet.create({
+    overlay: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        zIndex: 998,
+    },
+});
+
+export default RingsBlurOverlay;

--- a/frontend/components/profile/RingsBlurOverlay.tsx
+++ b/frontend/components/profile/RingsBlurOverlay.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { TouchableWithoutFeedback, Animated, StyleSheet } from "react-native";
 import { BlurView } from "expo-blur";
 
@@ -9,16 +9,28 @@ interface RingsBlurOverlayProps {
 
 const RingsBlurOverlay: React.FC<RingsBlurOverlayProps> = ({ visible, onDismiss }) => {
     const opacity = useRef(new Animated.Value(0)).current;
+    const [mounted, setMounted] = useState(false);
 
     useEffect(() => {
-        Animated.timing(opacity, {
-            toValue: visible ? 1 : 0,
-            duration: 250,
-            useNativeDriver: true,
-        }).start();
+        if (visible) {
+            setMounted(true);
+            Animated.timing(opacity, {
+                toValue: 1,
+                duration: 250,
+                useNativeDriver: true,
+            }).start();
+        } else {
+            Animated.timing(opacity, {
+                toValue: 0,
+                duration: 250,
+                useNativeDriver: true,
+            }).start(({ finished }) => {
+                if (finished) setMounted(false);
+            });
+        }
     }, [visible]);
 
-    if (!visible) return null;
+    if (!mounted) return null;
 
     return (
         <TouchableWithoutFeedback onPress={onDismiss}>
@@ -36,7 +48,7 @@ const styles = StyleSheet.create({
         left: 0,
         right: 0,
         bottom: 0,
-        backgroundColor: "rgba(0, 0, 0, 0.4)",
+        backgroundColor: "transparent",
         zIndex: 998,
     },
 });

--- a/frontend/components/profile/ScoreArc.tsx
+++ b/frontend/components/profile/ScoreArc.tsx
@@ -65,10 +65,13 @@ const ScoreArc: React.FC<ScoreArcProps> = ({ score, maxScore = 100 }) => {
                 </ThemedText>
             </View>
             <View style={styles.labelsRow}>
-                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                <ThemedText style={[styles.endLabel, { color: ThemedColor.caption }]}>
                     0
                 </ThemedText>
-                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                <ThemedText style={[styles.meterLabel, { color: ThemedColor.caption }]}>
+                    PRODUCTIVITY METER
+                </ThemedText>
+                <ThemedText style={[styles.endLabel, { color: ThemedColor.caption }]}>
                     100
                 </ThemedText>
             </View>
@@ -80,11 +83,11 @@ const styles = StyleSheet.create({
     container: {
         alignItems: "center",
         width: ARC_WIDTH,
-        height: ARC_HEIGHT + 16,
+        height: ARC_HEIGHT + 20,
     },
     scoreOverlay: {
         position: "absolute",
-        bottom: 20,
+        bottom: 24,
         alignItems: "center",
     },
     scoreValue: {
@@ -95,12 +98,19 @@ const styles = StyleSheet.create({
     labelsRow: {
         flexDirection: "row",
         justifyContent: "space-between",
-        width: ARC_WIDTH - STROKE_WIDTH,
-        marginTop: -6,
+        alignItems: "center",
+        width: ARC_WIDTH,
+        marginTop: -4,
     },
-    label: {
-        fontSize: 11,
+    endLabel: {
+        fontSize: 10,
         fontFamily: "Outfit",
+    },
+    meterLabel: {
+        fontSize: 9,
+        fontFamily: "Outfit",
+        letterSpacing: 1.2,
+        fontWeight: "500",
     },
 });
 

--- a/frontend/components/profile/ScoreArc.tsx
+++ b/frontend/components/profile/ScoreArc.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import Svg, { Path } from "react-native-svg";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+const ARC_WIDTH = 200;
+const ARC_HEIGHT = 120;
+const STROKE_WIDTH = 10;
+const PRIMARY_COLOR = "#854DFF";
+
+const RADIUS = (ARC_WIDTH - STROKE_WIDTH) / 2;
+const CENTER_X = ARC_WIDTH / 2;
+const CENTER_Y = ARC_HEIGHT - 10;
+
+function describeArc(startAngle: number, endAngle: number): string {
+    const startRad = (startAngle * Math.PI) / 180;
+    const endRad = (endAngle * Math.PI) / 180;
+    const startX = CENTER_X + RADIUS * Math.cos(startRad);
+    const startY = CENTER_Y - RADIUS * Math.sin(startRad);
+    const endX = CENTER_X + RADIUS * Math.cos(endRad);
+    const endY = CENTER_Y - RADIUS * Math.sin(endRad);
+    const largeArc = endAngle - startAngle > 180 ? 1 : 0;
+    return `M ${startX} ${startY} A ${RADIUS} ${RADIUS} 0 ${largeArc} 0 ${endX} ${endY}`;
+}
+
+interface ScoreArcProps {
+    score: number;
+    maxScore?: number;
+}
+
+const ScoreArc: React.FC<ScoreArcProps> = ({ score, maxScore = 100 }) => {
+    const ThemedColor = useThemeColor();
+    const fraction = Math.min(Math.max(score / maxScore, 0), 1);
+
+    const trackPath = describeArc(0, 180);
+    const fillEndAngle = 180 - fraction * 180;
+    const fillPath = fraction > 0 ? describeArc(fillEndAngle, 180) : "";
+
+    const displayScore = score >= 30 ? score : "--";
+
+    return (
+        <View style={styles.container}>
+            <Svg width={ARC_WIDTH} height={ARC_HEIGHT}>
+                <Path
+                    d={trackPath}
+                    stroke={ThemedColor.tertiary}
+                    strokeWidth={STROKE_WIDTH}
+                    fill="none"
+                    strokeLinecap="round"
+                />
+                {fillPath !== "" && (
+                    <Path
+                        d={fillPath}
+                        stroke={PRIMARY_COLOR}
+                        strokeWidth={STROKE_WIDTH}
+                        fill="none"
+                        strokeLinecap="round"
+                    />
+                )}
+            </Svg>
+            <View style={styles.scoreOverlay}>
+                <ThemedText style={[styles.scoreValue, { color: ThemedColor.text }]}>
+                    {displayScore}
+                </ThemedText>
+            </View>
+            <View style={styles.labelsRow}>
+                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                    0
+                </ThemedText>
+                <ThemedText style={[styles.label, { color: ThemedColor.caption }]}>
+                    100
+                </ThemedText>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    container: {
+        alignItems: "center",
+        width: ARC_WIDTH,
+        height: ARC_HEIGHT + 16,
+    },
+    scoreOverlay: {
+        position: "absolute",
+        bottom: 20,
+        alignItems: "center",
+    },
+    scoreValue: {
+        fontSize: 36,
+        fontWeight: "600",
+        fontFamily: "Fraunces",
+    },
+    labelsRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        width: ARC_WIDTH - STROKE_WIDTH,
+        marginTop: -6,
+    },
+    label: {
+        fontSize: 11,
+        fontFamily: "Outfit",
+    },
+});
+
+export default ScoreArc;

--- a/frontend/hooks/useRings.ts
+++ b/frontend/hooks/useRings.ts
@@ -39,10 +39,11 @@ export function useRings() {
     });
 
     // Derived state
-    const rings: RingState | null = todayData?.rings ?? null;
-    const score = todayData?.score ?? 0;
+    const rings: RingState | null = todayData?.ring_state ?? null;
+    const score = todayData?.productivity_score ?? 0;
+    const streak = todayData?.current_streak ?? 0;
     const allClosed = rings?.all_closed ?? false;
-    const canClaimReward = allClosed && !(rings?.reward_claimed ?? false);
+    const canClaimReward = todayData?.reward_available ?? false;
 
     // Auto-claim reward when all rings close
     const claimedRef = useRef(false);
@@ -80,6 +81,7 @@ export function useRings() {
     return {
         rings,
         score,
+        streak,
         allClosed,
         canClaimReward,
         isLoading: isLoadingToday,


### PR DESCRIPTION
## Summary
- Redesign ProductivityRings on profile into a card with SVG arc gauge for productivity score, "PRODUCTIVITY METER" label, and contextual ring expand with blur overlay
- Tapping a ring shows 7-day history (mini ring circles), guidance text, and action CTAs (Plan Today, View Tasks, Make a Post, etc.)
- Embed today's ring state in profile API response for connected users — friend profiles show rings-only view (no arc/card)
- Add privacy indicator ("Only visible to you" with lock icon) on own profile's score meter
- Remove rings from dashboard home screen (profile-only for now)
- Fix frontend/backend field name mismatch (`ring_state`/`productivity_score` vs `rings`/`score`) that prevented rings from rendering

## Test plan
- [ ] Open own profile — verify arc gauge renders with score, "PRODUCTIVITY METER" label, privacy lock indicator
- [ ] Tap a ring circle — verify blur overlay appears (no dim), expanded detail shows history mini-rings + CTAs
- [ ] Tap blur overlay — verify it dismisses with smooth fade transition
- [ ] Verify CTA buttons navigate correctly (Plan Today, View Tasks, Make a Post, Send Kudos)
- [ ] Open a connected friend's profile — verify rings-only view (no arc, no card) appears
- [ ] Open a non-connected profile — verify TodayStats fallback renders
- [ ] Verify dashboard home screen no longer shows rings
- [ ] Run backend tests: `go test ./internal/handlers/rings/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)