### PR TITLE
feat: redesign Live Activities with Active Task Timer & Deadline Countdown

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -80,7 +80,7 @@ func run(stderr io.Writer, args []string) {
 	if err != nil {
 		slog.Warn("OTel initialization failed, tracing will be disabled", "error", err)
 	} else {
-		defer shutdownOtel(ctx)
+		defer func() { _ = shutdownOtel(ctx) }()
 	}
 
 	port, err := strconv.Atoi(config.App.Port)

--- a/backend/internal/handlers/auth/google_verifier.go
+++ b/backend/internal/handlers/auth/google_verifier.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-const googleTokenInfoURL = "https://oauth2.googleapis.com/tokeninfo"
+const googleTokenInfoURL = "https://oauth2.googleapis.com/tokeninfo" //nolint:gosec // URL, not credentials
 
 // GoogleTokenClaims holds the verified claims from a Google ID token.
 type GoogleTokenClaims struct {

--- a/backend/internal/handlers/rings/service.go
+++ b/backend/internal/handlers/rings/service.go
@@ -326,7 +326,7 @@ func pickRandomReward() RewardDrop {
 		totalWeight += r.Weight
 	}
 
-	roll := rand.Intn(totalWeight)
+	roll := rand.Intn(totalWeight) //nolint:gosec // reward rolling doesn't need crypto/rand
 	cumulative := 0
 	for _, r := range RewardPool {
 		cumulative += r.Weight

--- a/backend/internal/handlers/task/live_activity_test.go
+++ b/backend/internal/handlers/task/live_activity_test.go
@@ -1,0 +1,540 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/abhikaboy/Kindred/xutils"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type LiveActivityTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+	handler Handler
+}
+
+func (s *LiveActivityTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+	s.handler = Handler{
+		service:       s.service,
+		geminiService: nil,
+	}
+}
+
+func TestLiveActivity(t *testing.T) {
+	suite.Run(t, new(LiveActivityTestSuite))
+}
+
+// ========================================
+// Helper: insert a category with a task
+// ========================================
+
+func (s *LiveActivityTestSuite) insertCategoryWithTask(user *types.User, task TaskDocument) (primitive.ObjectID, primitive.ObjectID) {
+	categoryID := primitive.NewObjectID()
+	category := &types.CategoryDocument{
+		ID:            categoryID,
+		Name:          "Test Category",
+		User:          user.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{task},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+	return categoryID, task.ID
+}
+
+// ========================================
+// GetTasksWithStartTimeInWindow Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestGetTasksWithStartTimeInWindow_FindsTaskInWindow() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second) // 30s ago — within a 2-min window
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Task starting now",
+		Priority:  1,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	catID, _ := s.insertCategoryWithTask(user, task)
+	_ = catID
+
+	windowStart := now.Add(-2 * time.Minute)
+	windowEnd := now
+
+	results, err := s.service.GetTasksWithStartTimeInWindow(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 1)
+	s.Equal("Task starting now", results[0].Content)
+}
+
+func (s *LiveActivityTestSuite) TestGetTasksWithStartTimeInWindow_IgnoresCompletedTasks() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+	completedAt := now
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:            taskID,
+		UserID:        user.ID,
+		Content:       "Completed task",
+		Priority:      1,
+		Value:         5.0,
+		Active:        true,
+		StartTime:     &startTime,
+		TimeCompleted: &completedAt,
+		Timestamp:     now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(-2 * time.Minute)
+	windowEnd := now
+
+	results, err := s.service.GetTasksWithStartTimeInWindow(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 0, "completed tasks should not be returned")
+}
+
+func (s *LiveActivityTestSuite) TestGetTasksWithStartTimeInWindow_IgnoresInactiveTasks() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Inactive task",
+		Priority:  1,
+		Value:     5.0,
+		Active:    false,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(-2 * time.Minute)
+	windowEnd := now
+
+	results, err := s.service.GetTasksWithStartTimeInWindow(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 0, "inactive tasks should not be returned")
+}
+
+func (s *LiveActivityTestSuite) TestGetTasksWithStartTimeInWindow_IgnoresTasksOutsideWindow() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-10 * time.Minute) // 10 min ago — outside the 2-min window
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Old task",
+		Priority:  1,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(-2 * time.Minute)
+	windowEnd := now
+
+	results, err := s.service.GetTasksWithStartTimeInWindow(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 0, "tasks outside the window should not be returned")
+}
+
+// ========================================
+// GetTasksWithDeadlineApproaching Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestGetTasksWithDeadlineApproaching_FindsTaskInWindow() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	deadline := now.Add(60 * time.Minute) // exactly 1 hour from now
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Task due in 1 hour",
+		Priority:  2,
+		Value:     5.0,
+		Active:    true,
+		Deadline:  &deadline,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(59 * time.Minute)
+	windowEnd := now.Add(61 * time.Minute)
+
+	results, err := s.service.GetTasksWithDeadlineApproaching(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 1)
+	s.Equal("Task due in 1 hour", results[0].Content)
+}
+
+func (s *LiveActivityTestSuite) TestGetTasksWithDeadlineApproaching_IgnoresCompletedTasks() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	deadline := now.Add(60 * time.Minute)
+	completedAt := now
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:            taskID,
+		UserID:        user.ID,
+		Content:       "Completed task with deadline",
+		Priority:      2,
+		Value:         5.0,
+		Active:        true,
+		Deadline:      &deadline,
+		TimeCompleted: &completedAt,
+		Timestamp:     now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(59 * time.Minute)
+	windowEnd := now.Add(61 * time.Minute)
+
+	results, err := s.service.GetTasksWithDeadlineApproaching(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 0, "completed tasks should not be returned")
+}
+
+func (s *LiveActivityTestSuite) TestGetTasksWithDeadlineApproaching_IgnoresDistantDeadlines() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	deadline := now.Add(5 * time.Hour) // 5 hours away
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Far-off deadline",
+		Priority:  1,
+		Value:     5.0,
+		Active:    true,
+		Deadline:  &deadline,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	windowStart := now.Add(59 * time.Minute)
+	windowEnd := now.Add(61 * time.Minute)
+
+	results, err := s.service.GetTasksWithDeadlineApproaching(windowStart, windowEnd)
+	s.NoError(err)
+	s.Len(results, 0, "tasks with distant deadlines should not be returned")
+}
+
+// ========================================
+// getCategoryWorkspaceName Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestGetCategoryWorkspaceName_ReturnsWorkspaceName() {
+	user := s.GetUser(0)
+	categoryID := primitive.NewObjectID()
+	category := &types.CategoryDocument{
+		ID:            categoryID,
+		Name:          "Test",
+		User:          user.ID,
+		WorkspaceName: "My Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	name := s.service.getCategoryWorkspaceName(categoryID)
+	s.Equal("My Workspace", name)
+}
+
+func (s *LiveActivityTestSuite) TestGetCategoryWorkspaceName_DefaultsToTasks() {
+	nonExistentID := primitive.NewObjectID()
+	name := s.service.getCategoryWorkspaceName(nonExistentID)
+	s.Equal("Tasks", name)
+}
+
+func (s *LiveActivityTestSuite) TestGetCategoryWorkspaceName_DefaultsWhenEmpty() {
+	user := s.GetUser(0)
+	categoryID := primitive.NewObjectID()
+	category := &types.CategoryDocument{
+		ID:            categoryID,
+		Name:          "Test",
+		User:          user.ID,
+		WorkspaceName: "",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	name := s.service.getCategoryWorkspaceName(categoryID)
+	s.Equal("Tasks", name)
+}
+
+// ========================================
+// HandleStartTimeNotifications Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_SendsNotification() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Start this task",
+		Priority:  2,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	catID, _ := s.insertCategoryWithTask(user, task)
+	_ = catID
+
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(1, result["notifications_sent"])
+
+	// Verify push notification was sent with correct data
+	notifications := s.GetSentPushNotifications()
+	s.Len(notifications, 1)
+	s.Equal(user.PushToken, notifications[0].Token)
+	s.Equal("live_activity", notifications[0].Data["type"])
+	s.Equal("activeTask", notifications[0].Data["liveActivityType"])
+	s.Equal(taskID.Hex(), notifications[0].Data["taskId"])
+	s.Equal("Start this task", notifications[0].Data["taskName"])
+	s.Equal("Test Workspace", notifications[0].Data["workspaceName"])
+}
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_NoTasksNoNotifications() {
+	// No tasks inserted — should send nothing
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(0, result["notifications_sent"])
+	s.AssertPushNotificationCount(0)
+}
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_SkipsUserWithoutPushToken() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+
+	// Clear the user's push token
+	_, err := s.Collections["users"].UpdateOne(s.Ctx,
+		bson.M{"_id": user.ID},
+		bson.M{"$set": bson.M{"push_token": ""}},
+	)
+	s.NoError(err)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "No token task",
+		Priority:  1,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(0, result["notifications_sent"])
+	s.AssertPushNotificationCount(0)
+}
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_IncludesEndTimeWhenDeadlineSet() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+	deadline := now.Add(2 * time.Hour)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Task with deadline",
+		Priority:  2,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Deadline:  &deadline,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(1, result["notifications_sent"])
+
+	notifications := s.GetSentPushNotifications()
+	s.Len(notifications, 1)
+	s.NotEmpty(notifications[0].Data["endTime"], "endTime should be set when task has a deadline")
+	s.NotEmpty(notifications[0].Data["startTime"], "startTime should be set")
+}
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_EmptyEndTimeWhenNoDeadline() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime := now.Add(-30 * time.Second)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Open-ended task",
+		Priority:  1,
+		Value:     5.0,
+		Active:    true,
+		StartTime: &startTime,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(1, result["notifications_sent"])
+
+	notifications := s.GetSentPushNotifications()
+	s.Equal("", notifications[0].Data["endTime"], "endTime should be empty when no deadline")
+}
+
+// ========================================
+// HandleDeadlineApproachingNotifications Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestHandleDeadlineApproachingNotifications_SendsNotification() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	deadline := now.Add(60 * time.Minute)
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Deadline approaching task",
+		Priority:  3,
+		Value:     8.0,
+		Active:    true,
+		Deadline:  &deadline,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	result, err := s.handler.HandleDeadlineApproachingNotifications()
+	s.NoError(err)
+	s.Equal(1, result["notifications_sent"])
+
+	notifications := s.GetSentPushNotifications()
+	s.Len(notifications, 1)
+	s.Equal(user.PushToken, notifications[0].Token)
+	s.Equal("live_activity", notifications[0].Data["type"])
+	s.Equal("deadlineCountdown", notifications[0].Data["liveActivityType"])
+	s.Equal(taskID.Hex(), notifications[0].Data["taskId"])
+	s.Equal("Deadline approaching task", notifications[0].Data["taskName"])
+	s.Equal("Test Workspace", notifications[0].Data["workspaceName"])
+	s.Equal("3", notifications[0].Data["priority"])
+}
+
+func (s *LiveActivityTestSuite) TestHandleDeadlineApproachingNotifications_NoTasksNoNotifications() {
+	result, err := s.handler.HandleDeadlineApproachingNotifications()
+	s.NoError(err)
+	s.Equal(0, result["notifications_sent"])
+	s.AssertPushNotificationCount(0)
+}
+
+func (s *LiveActivityTestSuite) TestHandleDeadlineApproachingNotifications_IgnoresNearDeadline() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	deadline := now.Add(10 * time.Minute) // 10 min away — not in the 59-61 min window
+
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{
+		ID:        taskID,
+		UserID:    user.ID,
+		Content:   "Imminent deadline",
+		Priority:  3,
+		Value:     5.0,
+		Active:    true,
+		Deadline:  &deadline,
+		Timestamp: now,
+	}
+	s.insertCategoryWithTask(user, task)
+
+	result, err := s.handler.HandleDeadlineApproachingNotifications()
+	s.NoError(err)
+	s.Equal(0, result["notifications_sent"], "should not notify for deadlines within 59 minutes")
+}
+
+// ========================================
+// Multiple Tasks Tests
+// ========================================
+
+func (s *LiveActivityTestSuite) TestHandleStartTimeNotifications_MultipleTasksMultipleNotifications() {
+	user := s.GetUser(0)
+	now := xutils.NowUTC()
+	startTime1 := now.Add(-30 * time.Second)
+	startTime2 := now.Add(-60 * time.Second)
+
+	// Insert two tasks in the same category
+	categoryID := primitive.NewObjectID()
+	category := &types.CategoryDocument{
+		ID:            categoryID,
+		Name:          "Multi Category",
+		User:          user.ID,
+		WorkspaceName: "Work",
+		Tasks: []TaskDocument{
+			{
+				ID:        primitive.NewObjectID(),
+				UserID:    user.ID,
+				Content:   "Task 1",
+				Priority:  1,
+				Value:     5.0,
+				Active:    true,
+				StartTime: &startTime1,
+				Timestamp: now,
+			},
+			{
+				ID:        primitive.NewObjectID(),
+				UserID:    user.ID,
+				Content:   "Task 2",
+				Priority:  2,
+				Value:     5.0,
+				Active:    true,
+				StartTime: &startTime2,
+				Timestamp: now,
+			},
+		},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	result, err := s.handler.HandleStartTimeNotifications()
+	s.NoError(err)
+	s.Equal(2, result["notifications_sent"])
+	s.AssertPushNotificationCount(2)
+}

--- a/backend/internal/handlers/task/stream_handlers.go
+++ b/backend/internal/handlers/task/stream_handlers.go
@@ -112,7 +112,7 @@ func (h *Handler) StreamIntentNaturalLanguage(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		sse := NewSSEWriter(w)
 
-		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
+		_ = sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
 
 		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming intent NL routing",
 			slog.String("userID", userID),
@@ -124,17 +124,17 @@ func (h *Handler) StreamIntentNaturalLanguage(c *fiber.Ctx) error {
 			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini intent flow failed, retrying",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+			_ = sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
 
 			intentOutput, err = h.callGeminiIntentFlow(ctx, userID, body.Text, body.Timezone)
 			if err != nil {
 				h.refundNLCredit(ctx, userObjID, userID)
-				sse.SendError("Failed to process natural language intent with AI after retry. Your credit has been refunded.")
+				_ = sse.SendError("Failed to process natural language intent with AI after retry. Your credit has been refunded.")
 				return
 			}
 		}
 
-		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Processing results..."})
+		_ = sse.Send("status", map[string]string{"stage": "processing_results", "message": "Processing results..."})
 
 		var responseOps []IntentOpResponse
 
@@ -194,7 +194,7 @@ func (h *Handler) StreamIntentNaturalLanguage(c *fiber.Ctx) error {
 			slog.String("userID", userID),
 			slog.Int("opCount", len(responseOps)))
 
-		sse.Send("result", map[string]interface{}{"ops": responseOps})
+		_ = sse.Send("result", map[string]interface{}{"ops": responseOps})
 	})
 
 	return nil
@@ -228,7 +228,7 @@ func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		sse := NewSSEWriter(w)
 
-		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
+		_ = sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your request..."})
 
 		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task creation",
 			slog.String("userID", userID),
@@ -240,24 +240,24 @@ func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
 			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini flow failed, retrying",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+			_ = sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
 
 			result, err = h.callGeminiFlow(ctx, userID, body.Text, body.Timezone)
 			if err != nil {
 				h.refundNLCredit(ctx, userObjID, userID)
-				sse.SendError("Failed to process natural language with AI after retry. Your credit has been refunded.")
+				_ = sse.SendError("Failed to process natural language with AI after retry. Your credit has been refunded.")
 				return
 			}
 		}
 
-		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Creating tasks..."})
+		_ = sse.Send("status", map[string]string{"stage": "processing_results", "message": "Creating tasks..."})
 
 		newCategoryTasks, newCategoryMetadata, categoriesCreated, newCategoryTaskCount, err := h.processNewCategories(ctx, result.Categories, userObjID)
 		if err != nil {
 			slog.LogAttrs(ctx, slog.LevelError, "Failed to process new categories",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.SendError(err.Error())
+			_ = sse.SendError(err.Error())
 			return
 		}
 
@@ -266,7 +266,7 @@ func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
 			slog.LogAttrs(ctx, slog.LevelError, "Failed to process existing category tasks",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.SendError(err.Error())
+			_ = sse.SendError(err.Error())
 			return
 		}
 
@@ -287,7 +287,7 @@ func (h *Handler) StreamCreateNaturalLanguage(c *fiber.Ctx) error {
 			slog.Int("totalTasks", totalTasks),
 			slog.Int("categoriesCreated", categoriesCreated))
 
-		sse.Send("result", map[string]interface{}{
+		_ = sse.Send("result", map[string]interface{}{
 			"categoriesCreated": categoriesCreated,
 			"newCategories":     newCategoryMetadata,
 			"tasksCreated":      totalTasks,
@@ -327,7 +327,7 @@ func (h *Handler) StreamQueryNaturalLanguage(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		sse := NewSSEWriter(w)
 
-		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your query..."})
+		_ = sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your query..."})
 
 		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task query",
 			slog.String("userID", userID),
@@ -339,29 +339,29 @@ func (h *Handler) StreamQueryNaturalLanguage(c *fiber.Ctx) error {
 			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini query flow failed, retrying",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+			_ = sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
 
 			queryOutput, err = h.callGeminiQueryFlow(ctx, userID, body.Text, body.Timezone)
 			if err != nil {
 				h.refundNLCredit(ctx, userObjID, userID)
-				sse.SendError("Failed to process natural language query with AI after retry. Your credit has been refunded.")
+				_ = sse.SendError("Failed to process natural language query with AI after retry. Your credit has been refunded.")
 				return
 			}
 		}
 
-		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Querying tasks..."})
+		_ = sse.Send("status", map[string]string{"stage": "processing_results", "message": "Querying tasks..."})
 
 		filters, err := convertQueryOutput(queryOutput)
 		if err != nil {
 			slog.Error("Failed to parse AI query response", "userId", userID, "error", err)
-			sse.SendError("The AI response could not be interpreted. Please try rephrasing your query.")
+			_ = sse.SendError("The AI response could not be interpreted. Please try rephrasing your query.")
 			return
 		}
 
 		tasks, err := h.service.QueryTasksByUser(userObjID, filters)
 		if err != nil {
 			slog.Error("Failed to execute NL task query", "userId", userID, "error", err)
-			sse.SendError("Unable to query tasks due to a server error. Please try again.")
+			_ = sse.SendError("Unable to query tasks due to a server error. Please try again.")
 			return
 		}
 
@@ -369,7 +369,7 @@ func (h *Handler) StreamQueryNaturalLanguage(c *fiber.Ctx) error {
 			slog.String("userID", userID),
 			slog.Int("taskCount", len(tasks)))
 
-		sse.Send("result", map[string]interface{}{
+		_ = sse.Send("result", map[string]interface{}{
 			"tasks": tasks,
 			"query": filters,
 		})
@@ -406,7 +406,7 @@ func (h *Handler) StreamEditNaturalLanguage(c *fiber.Ctx) error {
 	c.Context().SetBodyStreamWriter(func(w *bufio.Writer) {
 		sse := NewSSEWriter(w)
 
-		sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your edit..."})
+		_ = sse.Send("status", map[string]string{"stage": "starting", "message": "Processing your edit..."})
 
 		slog.LogAttrs(ctx, slog.LevelInfo, "Starting streaming NL task edit",
 			slog.String("userID", userID),
@@ -418,17 +418,17 @@ func (h *Handler) StreamEditNaturalLanguage(c *fiber.Ctx) error {
 			slog.LogAttrs(ctx, slog.LevelWarn, "First attempt to call Gemini edit flow failed, retrying",
 				slog.String("userID", userID),
 				slog.String("error", err.Error()))
-			sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
+			_ = sse.Send("status", map[string]string{"stage": "retrying", "message": "Retrying AI request..."})
 
 			editOutput, err = h.callGeminiEditFlow(ctx, userID, body.Text, body.Timezone)
 			if err != nil {
 				h.refundNLCredit(ctx, userObjID, userID)
-				sse.SendError("Failed to process natural language edit with AI after retry. Your credit has been refunded.")
+				_ = sse.SendError("Failed to process natural language edit with AI after retry. Your credit has been refunded.")
 				return
 			}
 		}
 
-		sse.Send("status", map[string]string{"stage": "processing_results", "message": "Applying edits..."})
+		_ = sse.Send("status", map[string]string{"stage": "processing_results", "message": "Applying edits..."})
 
 		editedTasks, editedTemplates, totalEdited := h.applyEditInstructions(ctx, userObjID, userID, editOutput)
 
@@ -447,7 +447,7 @@ func (h *Handler) StreamEditNaturalLanguage(c *fiber.Ctx) error {
 			slog.Int("editedTasks", len(editedTasks)),
 			slog.Int("editedTemplates", len(editedTemplates)))
 
-		sse.Send("result", map[string]interface{}{
+		_ = sse.Send("result", map[string]interface{}{
 			"tasks":       editedTasks,
 			"templates":   editedTemplates,
 			"editedCount": totalEdited,


### PR DESCRIPTION
## Summary
- **New Active Task Activity** — starts when a task's `startTime` arrives (via push notification) or manually via "Start Working" button. Shows live elapsed timer, progress bar when end time exists, green "Active" indicator
- **Redesigned Deadline Countdown Activity** — auto-starts 1 hour before deadline via push. Depleting progress bar, color escalation (purple → amber at 10min → gray when overdue), auto-dismisses 30min after overdue
- **Removed Encouragement Live Activity** — encouragements continue as push notifications only, no longer trigger a live activity
- **Backend cron handlers** — two new handlers in the 1-minute cron cycle: `HandleStartTimeNotifications` (tasks hitting startTime) and `HandleDeadlineApproachingNotifications` (tasks ~1hr from deadline)
- **19 backend tests** covering queries, notification payloads, edge cases (completed/inactive tasks, missing tokens, time windows)

### Files Changed

**Backend:**
- `backend/internal/handlers/task/live_activity.go` — new: query helpers + notification handlers
- `backend/internal/handlers/task/live_activity_test.go` — new: 19 tests
- `backend/internal/handlers/task/cron.go` — wire handlers into cron cycle

**Frontend Widgets:**
- `frontend/widgets/ActiveTaskActivity.tsx` — new: active task live activity with SwiftUI timer
- `frontend/widgets/DeadlineCountdownActivity.tsx` — rewritten with new design, native countdown timer, color escalation
- `frontend/widgets/EncouragementActivity.tsx` — deleted
- `frontend/widgets/widgetUpdaters.ts` — ActiveTaskActivityFactory replaces EncouragementActivityFactory

**Frontend Integration:**
- `frontend/app/(logged-in)/_layout.tsx` — notification handler intercepts `live_activity` push type
- `frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx` — "Start Working" button, updated deadline tracking
- `frontend/contexts/kudosContext.tsx` — removed all live activity code

## Test plan
- [x] Backend compiles cleanly (`go build ./...`)
- [x] 19 new backend tests pass (`go test ./internal/handlers/task/ -run TestLiveActivity`)
- [x] All existing backend tests pass (no regressions)
- [ ] Manual test: open task detail → tap "Start Working" → verify live activity appears on lock screen
- [ ] Manual test: create task with deadline 1 hour from now → wait for push → verify countdown activity starts
- [ ] Manual test: verify encouragement notifications still work (just no live activity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)