### PR TITLE
Fix feed, ghost popup, gallery freeze, claim reward, and splash logos

### DIFF
--- a/frontend/components/cards/PostCard.tsx
+++ b/frontend/components/cards/PostCard.tsx
@@ -643,7 +643,6 @@ const PostCard = React.memo(({
                     ref={bottomSheetModalRef}
                     onChange={handleSheetChanges}
                     snapPoints={["80%"]}
-                    index={0}
                     enablePanDownToClose={true}
                     enableDismissOnClose={true}
                     enableHandlePanningGesture={true}

--- a/frontend/components/modals/DefaultModal.tsx
+++ b/frontend/components/modals/DefaultModal.tsx
@@ -72,7 +72,6 @@ const DefaultModal = memo((props: Props) => {
     return (
         <BottomSheetModal
             ref={bottomSheetModalRef}
-            index={0}
             snapPoints={snapPoints}
             enableDynamicSizing={props.enableDynamicSizing ?? false}
             onChange={handleSheetChanges}

--- a/frontend/components/profile/ProfileGallery.tsx
+++ b/frontend/components/profile/ProfileGallery.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { View, StyleSheet, TouchableOpacity, Animated, Image, Dimensions, useColorScheme, ActivityIndicator } from "react-native";
-import { FlashList } from "@shopify/flash-list";
+import { FlatList } from "react-native";
 import { deletePost, getAllPosts, getUserPosts } from "@/api/post";
 import { router } from "expo-router";
 import { useAuth } from "@/hooks/useAuth";
@@ -98,7 +98,7 @@ const EmptyGallery = ({ ThemedColor }: { ThemedColor: any }) => {
     );
 };
 
-const GALLERY_PAGE_SIZE = 18;
+const GALLERY_PAGE_SIZE = 12;
 
 const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
     const { user } = useAuth();
@@ -176,9 +176,11 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
         fetchImages();
     }, [userId, images]);
 
+    const loadingMoreRef = useRef(false);
     const handleLoadMore = useCallback(async () => {
-        if (!hasMore || isLoadingMore || isLoading) return;
+        if (!hasMore || loadingMoreRef.current || isLoading) return;
 
+        loadingMoreRef.current = true;
         setIsLoadingMore(true);
         try {
             let response;
@@ -195,9 +197,10 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
         } catch (error) {
             console.error("Error loading more post images:", error);
         } finally {
+            loadingMoreRef.current = false;
             setIsLoadingMore(false);
         }
-    }, [hasMore, isLoadingMore, isLoading, userId, offset]);
+    }, [hasMore, isLoading, userId, offset]);
 
     const handleImagePress = (postId: string) => {
         if (postId.startsWith("legacy-")) {
@@ -351,21 +354,21 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
 
     return (
         <>
-            <View style={{ minHeight: 2, flex: 1 }}>
-                <FlashList
-                    numColumns={3}
-                    data={postImages}
-                    renderItem={renderItem}
-                    keyExtractor={(item, index) => `gallery-${item.postId}-${index}`}
-                    showsVerticalScrollIndicator={false}
-                    contentContainerStyle={styles.galleryContainer}
-                    removeClippedSubviews={true}
-                    onEndReached={handleLoadMore}
-                    onEndReachedThreshold={0.5}
-                    ListFooterComponent={renderFooter}
-                    drawDistance={250}
-                />
-            </View>
+            <FlatList
+                numColumns={3}
+                data={postImages}
+                renderItem={renderItem}
+                keyExtractor={(item, index) => `gallery-${item.postId}-${index}`}
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={styles.galleryContainer}
+                removeClippedSubviews={true}
+                onEndReached={handleLoadMore}
+                onEndReachedThreshold={0.3}
+                ListFooterComponent={renderFooter}
+                initialNumToRender={9}
+                maxToRenderPerBatch={6}
+                windowSize={5}
+            />
             {alertVisible && (
                 <CustomAlert
                     visible={alertVisible}


### PR DESCRIPTION
## Summary
- **Fix blank feed**: Replace FlashList with FlatList — FlashList silently failed to render despite having data
- **Fix ghost popup overlay**: Remove `index={0}` from DefaultModal's BottomSheetModal which auto-presented on mount
- **Fix profile gallery freeze**: Swap FlashList for FlatList, add render throttling, fix pagination race condition
- **Fix claim reward**: Style button with purple outline + Gift icon, fix API response mapping so unboxing modal opens
- **Real-time ring updates**: Invalidate rings query on task completion, creation, and kudos sends
- **Fix splash logos**: Replace baked-in background splash icons with transparent PNGs
- **Fix notification spam**: Stabilize markAllAsRead with useCallback
- **Fix "All rings closed" toast**: Only fire on actual transition, not every mount
- **Fix placeholder images**: Rename files to remove spaces causing Metro bundler errors
- **Align CongratulateModal styling** with EncourageModal

## Test plan
- [ ] Feed tab shows posts and task cards
- [ ] No ghost popup/overlay on feed or any screen
- [ ] Open profile with many posts — no freeze, images load progressively
- [ ] Close all rings and tap "Claim Reward" — unboxing modal opens
- [ ] Splash screen shows logo without background square
- [ ] Complete a task — rings update immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)