### PR TITLE
feat(onboarding): beak congrats with welcome credits + polish

### DIFF
--- a/backend/internal/handlers/congratulation/congratulation.go
+++ b/backend/internal/handlers/congratulation/congratulation.go
@@ -119,9 +119,19 @@ func (h *Handler) SendBeakCongratulationHuma(ctx context.Context, input *SendBea
 		return nil, huma.Error500InternalServerError("Failed to send congratulation", err)
 	}
 
-	return &SendBeakCongratulationOutput{Body: struct {
-		Message string `json:"message" example:"Congratulation sent successfully"`
-	}{Message: "Congratulation sent successfully"}}, nil
+	result := SendBeakCongratulationResult{Message: "Congratulation sent successfully"}
+
+	if input.Body.GrantCredits {
+		credits, err := h.service.GrantWelcomeCredits(receiverID)
+		if err != nil {
+			slog.Error("Failed to grant welcome credits", "error", err, "receiver_id", user_id)
+			// Don't fail the whole request, congrats was already sent
+		} else {
+			result.CreditsGranted = credits
+		}
+	}
+
+	return &SendBeakCongratulationOutput{Body: result}, nil
 }
 
 func (h *Handler) GetCongratulationsHuma(ctx context.Context, input *GetCongratulationsInput) (*GetCongratulationsOutput, error) {

--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -418,3 +418,44 @@ func (s *Service) SendBeakCongratulation(receiverID primitive.ObjectID, message,
 	slog.Info("Beak congratulation sent", "receiver_id", receiverID.Hex())
 	return nil
 }
+
+// GrantWelcomeCredits gives a user starter credits during onboarding.
+// Uses an atomic flag (welcomeCreditsGranted) to ensure it only happens once per user.
+func (s *Service) GrantWelcomeCredits(userID primitive.ObjectID) (map[string]int, error) {
+	if s.Users == nil {
+		return nil, fmt.Errorf("users collection not available")
+	}
+
+	credits := map[string]int{
+		"voice":           5,
+		"naturalLanguage": 5,
+		"analytics":       3,
+		"group":           3,
+	}
+
+	// Atomically set the flag and grant credits — only succeeds if flag is not already set
+	result, err := s.Users.UpdateOne(
+		context.Background(),
+		bson.M{"_id": userID, "welcomeCreditsGranted": bson.M{"$ne": true}},
+		bson.M{
+			"$inc": bson.M{
+				"credits.voice":           credits["voice"],
+				"credits.naturalLanguage": credits["naturalLanguage"],
+				"credits.analytics":       credits["analytics"],
+				"credits.group":           credits["group"],
+			},
+			"$set": bson.M{"welcomeCreditsGranted": true},
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to grant welcome credits: %w", err)
+	}
+
+	if result.ModifiedCount == 0 {
+		slog.Info("Welcome credits already granted, skipping", "user_id", userID.Hex())
+		return nil, nil // Already granted
+	}
+
+	slog.Info("Welcome credits granted", "user_id", userID.Hex(), "credits", credits)
+	return credits, nil
+}

--- a/backend/internal/handlers/congratulation/types.go
+++ b/backend/internal/handlers/congratulation/types.go
@@ -99,12 +99,16 @@ type SendBeakCongratulationParams struct {
 	Message      string `json:"message" example:"welcome! you just completed your first task!" doc:"Congratulation message" validate:"required"`
 	CategoryName string `json:"categoryName" example:"My Tasks" doc:"Category name" validate:"required"`
 	TaskName     string `json:"taskName" example:"Start my morning routine" doc:"Task name" validate:"required"`
+	GrantCredits bool   `json:"grantCredits,omitempty" doc:"Whether to grant welcome credits to the user"`
 }
 
 type SendBeakCongratulationOutput struct {
-	Body struct {
-		Message string `json:"message" example:"Congratulation sent successfully"`
-	}
+	Body SendBeakCongratulationResult
+}
+
+type SendBeakCongratulationResult struct {
+	Message        string         `json:"message" example:"Congratulation sent successfully"`
+	CreditsGranted map[string]int `json:"creditsGranted,omitempty" doc:"Credits granted to the user by type"`
 }
 
 // Data structures

--- a/frontend/app/(onboarding)/tutorial.tsx
+++ b/frontend/app/(onboarding)/tutorial.tsx
@@ -9,6 +9,7 @@ import {
 import React, { useEffect, useRef, useState, useCallback } from "react";
 import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
+import { BlurView } from "expo-blur";
 import ConfettiCannon from "react-native-confetti-cannon";
 
 import { ThemedView } from "@/components/ThemedView";
@@ -45,8 +46,15 @@ const BEAK = {
 const TAIL_SIZE = 10;
 const DISPLAY_WORKSPACE = "Example Workspace";
 const PREFILL_CATEGORY = "My Tasks";
-const PREFILL_TASK = "Start my morning routine";
-const CONGRATS_MESSAGE = "its beak, one of the founders of kindred. welcome :) you just completed your first task!";
+const PREFILL_TASK = "Finish Kindred Onboarding";
+const CONGRATS_MESSAGE = "it's beak, one of kindred's founders; welcome! and congrats on finishing your first (of many!) tasks :)";
+const CREDITS_MESSAGE = "here are some credits for features I think you'll like. you can get more by closing your rings";
+const CREDIT_LABELS: Record<string, string> = {
+    voice: "voice credits",
+    naturalLanguage: "AI credits",
+    analytics: "analytics credits",
+    group: "group credits",
+};
 
 export default function TutorialOnboarding() {
     const ThemedColor = useThemeColor();
@@ -56,7 +64,7 @@ export default function TutorialOnboarding() {
     const totalSteps = isSocialAuth ? 4 : 5;
     const router = useRouter();
     const { capture } = useAnalytics();
-    const { user } = useAuth();
+    const { user, updateUser } = useAuth();
     const { workspaces, fetchWorkspaces, setSelected, setCreateCategory, categories, selected, addToCategory } = useTasks();
     const { setTaskName, resetTaskCreation } = useTaskCreation();
     const { request } = useRequest();
@@ -72,6 +80,7 @@ export default function TutorialOnboarding() {
 
     // Create modal (step 1)
     const [showCreateModal, setShowCreateModal] = useState(false);
+    const [showContinue, setShowContinue] = useState(false);
 
     // Prompt card animation
     const promptOpacity = useRef(new Animated.Value(0)).current;
@@ -84,7 +93,6 @@ export default function TutorialOnboarding() {
     const bubbleOpacity = useRef(new Animated.Value(0)).current;
     const bubbleTranslateX = useRef(new Animated.Value(-28)).current;
     const avatarOpacity = useRef(new Animated.Value(0)).current;
-    const buttonOpacity = useRef(new Animated.Value(0)).current;
 
     const confettiRef = useRef<any>(null);
 
@@ -146,8 +154,7 @@ export default function TutorialOnboarding() {
         setCategoryId(id);
         setCategoryName(name);
         setIsCreatingCategory(false);
-
-        setTimeout(() => setStep(1), 400);
+        setStep(1);
     }, []);
 
     const handleCancelCategory = useCallback(() => {
@@ -215,7 +222,6 @@ export default function TutorialOnboarding() {
     }, [showCreateModal, step, categoryId, taskData, fetchWorkspaces]);
 
     // ─── Step 2: Detect swipe completion ──────────────────────────────
-    const [typedText, setTypedText] = useState("");
     const completionHandledRef = useRef(false);
 
     useEffect(() => {
@@ -256,34 +262,56 @@ export default function TutorialOnboarding() {
                     ]).start();
                     // Start typewriter after bubble slides in
                     setTimeout(() => startTypewriter(), 400);
-                    Animated.timing(buttonOpacity, {
-                        toValue: 1, duration: 400, delay: 1800, useNativeDriver: true,
-                    }).start();
+                    // Show continue after second congrats has time to appear + typewriter
+                    setTimeout(() => setShowContinue(true), 6000);
                 }, 1000);
             }, 1500);
         }
     }, [categories, workspaces, categoryId, taskData, step]);
 
-    // Send a real congratulation from beak via backend endpoint + push notification
+    // Send two congratulations from beak — first is welcome, second grants credits
+    const [creditsGranted, setCreditsGranted] = useState<Record<string, number> | null>(null);
+    const [showSecondCongrats, setShowSecondCongrats] = useState(false);
+    const [secondTypewriterActive, setSecondTypewriterActive] = useState(false);
+
     const sendCongratulation = () => {
+        // First congrats: welcome message
         request("POST", "/user/congratulations/beak", {
             message: CONGRATS_MESSAGE,
             categoryName: categoryName ?? PREFILL_CATEGORY,
             taskName: taskData?.content ?? PREFILL_TASK,
-        }).catch(() => {}); // fire-and-forget
+        }).catch(() => {});
+
+        // Second congrats: credits gift (3s delay)
+        setTimeout(async () => {
+            try {
+                const response = await request("POST", "/user/congratulations/beak", {
+                    message: CREDITS_MESSAGE,
+                    categoryName: categoryName ?? PREFILL_CATEGORY,
+                    taskName: taskData?.content ?? PREFILL_TASK,
+                    grantCredits: true,
+                });
+                if (response?.creditsGranted) {
+                    setCreditsGranted(response.creditsGranted);
+                    // Update local user credits
+                    if (user?.credits) {
+                        const updated = { ...user.credits };
+                        for (const [key, amount] of Object.entries(response.creditsGranted)) {
+                            if (key in updated) {
+                                (updated as any)[key] += amount;
+                            }
+                        }
+                        updateUser({ credits: updated });
+                    }
+                }
+            } catch {}
+            setShowSecondCongrats(true);
+            setTimeout(() => setSecondTypewriterActive(true), 300);
+        }, 3000);
     };
 
-    // Typewriter effect for congrats message
-    const startTypewriter = () => {
-        let i = 0;
-        const interval = setInterval(() => {
-            i++;
-            setTypedText(CONGRATS_MESSAGE.slice(0, i));
-            if (i >= CONGRATS_MESSAGE.length) {
-                clearInterval(interval);
-            }
-        }, 18);
-    };
+    const [typewriterActive, setTypewriterActive] = useState(false);
+    const startTypewriter = () => setTypewriterActive(true);
 
     const handleContinue = () => {
         capture(AnalyticsEvents.ONBOARDING_STEP_COMPLETED, {
@@ -390,11 +418,16 @@ export default function TutorialOnboarding() {
                     </View>
                 </View>
 
-                {/* Step 3: Congrats from beak — shown in the workspace area */}
+                {/* Blur overlay on workspace when showing congrats */}
+                {step === 3 && (
+                    <BlurView intensity={20} style={StyleSheet.absoluteFill} />
+                )}
+
+                {/* Step 3: Congrats from beak — shown over the blurred workspace */}
                 {step === 3 && (
                     <View style={{ paddingHorizontal: HORIZONTAL_PADDING, marginTop: 32 }}>
                         <Animated.View style={{ opacity: bubbleOpacity, marginBottom: 16 }}>
-                            <ThemedText type="caption" style={{ color: ThemedColor.primary, fontFamily: "Outfit", fontWeight: "600", fontSize: 13, letterSpacing: 0.5, textTransform: "uppercase" }}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.primary, textTransform: "uppercase", letterSpacing: 0.5 }}>
                                 Congratulation
                             </ThemedText>
                         </Animated.View>
@@ -420,6 +453,7 @@ export default function TutorialOnboarding() {
                             }]}>
                                 <View style={[styles.bubbleTail, { borderRightColor: ThemedColor.lightenedCard }]} />
                                 <View style={[styles.bubbleCard, { backgroundColor: ThemedColor.lightenedCard }]}>
+                                    <View style={{ position: "absolute", top: 8, right: 8, width: 8, height: 8, borderRadius: 4, backgroundColor: ThemedColor.error }} />
                                     <View style={styles.taskInfoRow}>
                                         <ThemedText style={[styles.taskInfoCategory, { color: ThemedColor.primary }]}>
                                             {categoryName ?? PREFILL_CATEGORY}
@@ -429,12 +463,54 @@ export default function TutorialOnboarding() {
                                             {taskData?.content ?? PREFILL_TASK}
                                         </ThemedText>
                                     </View>
-                                    <ThemedText style={[styles.messageText, { color: ThemedColor.text }]}>
-                                        {typedText}
-                                    </ThemedText>
+                                    {typewriterActive && (
+                                        <TypewriterText
+                                            message={CONGRATS_MESSAGE}
+                                            style={[styles.messageText, { color: ThemedColor.text }]}
+                                        />
+                                    )}
                                 </View>
                             </Animated.View>
                         </View>
+
+                        {/* Second congrats: credits gift */}
+                        {showSecondCongrats && (
+                            <View style={[styles.kudosRow, { marginTop: 16 }]}>
+                                <View style={styles.avatarSection}>
+                                    <CachedImage
+                                        source={{ uri: BEAK.picture }}
+                                        fallbackSource={require("@/assets/images/head.png")}
+                                        variant="thumbnail"
+                                        cachePolicy="memory-disk"
+                                        style={styles.avatar}
+                                    />
+                                </View>
+                                <View style={styles.bubbleWrapper}>
+                                    <View style={[styles.bubbleTail, { borderRightColor: ThemedColor.lightenedCard }]} />
+                                    <View style={[styles.bubbleCard, { backgroundColor: ThemedColor.lightenedCard }]}>
+                                        <View style={{ position: "absolute", top: 8, right: 8, width: 8, height: 8, borderRadius: 4, backgroundColor: ThemedColor.error }} />
+                                        {secondTypewriterActive && (
+                                            <TypewriterText
+                                                message={CREDITS_MESSAGE}
+                                                style={[styles.messageText, { color: ThemedColor.text }]}
+                                            />
+                                        )}
+                                        {creditsGranted && (
+                                            <View style={{ marginTop: 8, alignItems: "flex-end" }}>
+                                                {Object.entries(creditsGranted).map(([key, amount]) => {
+                                                    const label = CREDIT_LABELS[key] ?? key;
+                                                    return (
+                                                        <ThemedText key={key} type="caption" style={{ color: "#A855F7" }}>
+                                                            +{amount} {label}
+                                                        </ThemedText>
+                                                    );
+                                                })}
+                                            </View>
+                                        )}
+                                    </View>
+                                </View>
+                            </View>
+                        )}
                     </View>
                 )}
             </View>
@@ -456,17 +532,41 @@ export default function TutorialOnboarding() {
                     </Animated.View>
                 ) : null}
 
-                {step === 3 && (
-                    <Animated.View style={[styles.promptCard, { opacity: buttonOpacity, backgroundColor: ThemedColor.lightened }]}>
-                        <ThemedText style={[styles.promptSubtitle, { color: ThemedColor.caption, textAlign: "center", marginBottom: 12 }]}>
+                {step === 3 && showContinue && (
+                    <View style={[styles.promptCard, { backgroundColor: ThemedColor.lightened }]}>
+                        <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.caption, textAlign: "center", marginBottom: 12 }}>
                             When you complete tasks, your friends can congratulate you
                         </ThemedText>
                         <PrimaryButton title="Continue" onPress={handleContinue} />
-                    </Animated.View>
+                    </View>
                 )}
             </View>
         </ThemedView>
     );
+}
+
+// ─── Typewriter (isolated component to avoid re-rendering the whole tutorial) ─
+function TypewriterText({ message, style }: { message: string; style: any }) {
+    const [text, setText] = useState("");
+    useEffect(() => {
+        let i = 0;
+        let cancelled = false;
+        const tick = () => {
+            if (cancelled) return;
+            i++;
+            setText(message.slice(0, i));
+            if (i >= message.length) return;
+            const ch = message[i - 1];
+            if (".!:)".includes(ch)) {
+                setTimeout(tick, 200);
+            } else {
+                requestAnimationFrame(tick);
+            }
+        };
+        requestAnimationFrame(tick);
+        return () => { cancelled = true; };
+    }, [message]);
+    return <ThemedText style={style}>{text}</ThemedText>;
 }
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
@@ -531,7 +631,7 @@ const styles = StyleSheet.create({
     promptSubtitle: {
         fontSize: 15,
         fontFamily: "Outfit",
-        fontWeight: "300",
+        fontWeight: "400",
         lineHeight: 21,
     },
 
@@ -590,7 +690,7 @@ const styles = StyleSheet.create({
     taskInfoCategory: {
         fontSize: 15,
         fontFamily: "Outfit",
-        fontWeight: "600",
+        fontWeight: "400",
         flexShrink: 1,
     },
     taskInfoDot: {

--- a/frontend/components/modals/RewardUnboxingModal.tsx
+++ b/frontend/components/modals/RewardUnboxingModal.tsx
@@ -31,6 +31,7 @@ interface RewardUnboxingModalProps {
     setVisible: (v: boolean) => void;
     rewardType: string;
     rewardAmount: number;
+    newTotal?: number;
 }
 
 const SPIN_DURATION = 1500;
@@ -43,6 +44,7 @@ export default function RewardUnboxingModal({
     setVisible,
     rewardType,
     rewardAmount,
+    newTotal,
 }: RewardUnboxingModalProps) {
     const ThemedColor = useThemeColor();
     const confettiRef = useRef<any>(null);
@@ -223,13 +225,17 @@ export default function RewardUnboxingModal({
                     <ThemedText style={styles.rewardSubtitle}>
                         {winningType.label}
                     </ThemedText>
+                    {newTotal != null && (
+                        <ThemedText type="caption" style={{ color: "#E9D5FF", marginTop: 8 }}>
+                            You now have {newTotal} {winningType.label.toLowerCase()}
+                        </ThemedText>
+                    )}
                 </Animated.View>
 
                 {phase === "revealed" && (
                     <View style={styles.buttonContainer}>
                         <PrimaryButton
                             title="Done"
-                            outline
                             onPress={() => setVisible(false)}
                         />
                     </View>

--- a/frontend/components/profile/ProductivityRings.tsx
+++ b/frontend/components/profile/ProductivityRings.tsx
@@ -15,6 +15,7 @@ import { Check, LockSimple, Gift } from "phosphor-react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useRings } from "@/hooks/useRings";
+import { useAuth } from "@/hooks/useAuth";
 import { RingProgress, RingState, RingRewardResponse } from "@/api/types";
 import ScoreArc from "./ScoreArc";
 import ExpandedRingDetail from "./ExpandedRingDetail";
@@ -103,6 +104,7 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
     onExpandChange,
 }) => {
     const ThemedColor = useThemeColor();
+    const { user } = useAuth();
     const { rings, score, streak, isLoading, history, canClaimReward, allClosed, claimReward, isClaiming } = useRings();
     const [expandedRing, setExpandedRing] = useState<RingKey | null>(null);
     const [showUnboxing, setShowUnboxing] = useState(false);
@@ -123,15 +125,6 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
         }
     };
 
-    // Toast when all rings transition from open to closed (not on initial load)
-    const prevAllClosed = useRef<boolean | null>(null);
-
-    useEffect(() => {
-        if (prevAllClosed.current !== null && allClosed && !prevAllClosed.current) {
-            showToast("All rings closed!", "success");
-        }
-        prevAllClosed.current = allClosed;
-    }, [allClosed]);
 
     // Sync with parent: when blur overlay is dismissed, clear internal state
     React.useEffect(() => {
@@ -170,20 +163,22 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
             style={[
                 styles.card,
                 {
-                    backgroundColor: ThemedColor.lightened,
+                    backgroundColor: ThemedColor.background,
                 },
-                isExpanded && styles.cardExpanded,
+                styles.cardExpanded,
             ]}
         >
+            {/* Private label */}
+            <View style={styles.privateRow}>
+                <LockSimple size={12} color={ThemedColor.caption} />
+                <ThemedText type="caption" style={{ opacity: 0.6 }}>
+                    Only visible to you
+                </ThemedText>
+            </View>
+
             {/* Score Arc */}
-            <View style={styles.arcSection}>
+            <View style={[styles.arcSection, { marginBottom: 8 }]}>
                 <ScoreArc score={score} />
-                <View style={styles.privateRow}>
-                    <LockSimple size={12} color={ThemedColor.caption} />
-                    <ThemedText style={[styles.privateText, { color: ThemedColor.caption }]}>
-                        Only visible to you
-                    </ThemedText>
-                </View>
             </View>
 
             {/* Rings Row */}
@@ -276,21 +271,32 @@ const ProductivityRingsCard: React.FC<ProductivityRingsCardProps> = ({
                 setVisible={setShowUnboxing}
                 rewardType={rewardResult?.credit_type ?? "naturalLanguage"}
                 rewardAmount={rewardResult?.amount ?? 1}
+                newTotal={
+                    rewardResult?.credit_type && user?.credits
+                        ? (user.credits[rewardResult.credit_type as keyof typeof user.credits] ?? 0)
+                        : undefined
+                }
             />
         </View>
     );
 };
 
 const styles = StyleSheet.create({
+    privateRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4,
+    },
     card: {
         borderRadius: 16,
         padding: 20,
         gap: 20,
         shadowColor: "#000",
-        shadowOpacity: 0.08,
-        shadowOffset: { width: 0, height: 4 },
-        shadowRadius: 12,
-        elevation: 3,
+        shadowOpacity: 0.04,
+        shadowOffset: { width: 0, height: 2 },
+        shadowRadius: 6,
+        elevation: 1,
     },
     cardExpanded: {
         zIndex: 999,
@@ -298,15 +304,6 @@ const styles = StyleSheet.create({
     arcSection: {
         alignItems: "center",
         gap: 4,
-    },
-    privateRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: 4,
-    },
-    privateText: {
-        fontSize: 11,
-        fontFamily: "Outfit",
     },
     ringsRow: {
         flexDirection: "row",


### PR DESCRIPTION
## Summary
- **Two-part beak congratulation**: First message is a welcome typewriter, second (3s delay) grants starter credits (+5 voice, +5 AI, +3 analytics, +3 group) with purple credit breakdown
- **Backend `welcomeCreditsGranted` flag**: Atomic once-per-user guard so credits can't be exploited
- **Smooth typewriter**: Extracted to isolated `TypewriterText` component using `requestAnimationFrame` for 60fps, pauses on punctuation
- **BlurView overlay** on workspace during congrats step
- **Roulette "You now have X credits"** shown after claiming ring reward
- **Polish**: immediate category creation transition, reliable continue button, "Finish Kindred Onboarding" task name, design system typography

## Test plan
- [ ] Tutorial flow: create category → create task → swipe complete → see first congrats typewriter → see second congrats with credit amounts after 3s → continue
- [ ] Verify credits are actually added to user account (check profile/settings)
- [ ] Re-run tutorial — credits should NOT be double-granted (welcomeCreditsGranted flag)
- [ ] Roulette: claim ring reward → verify "You now have X credits" line appears
- [ ] Blur overlay covers workspace content during congrats step

🤖 Generated with [Claude Code](https://claude.com/claude-code)