### PR TITLE
feat: ring claims, onboarding tutorial, auth token refresh

### DIFF
--- a/backend/internal/handlers/auth/auth.go
+++ b/backend/internal/handlers/auth/auth.go
@@ -509,6 +509,54 @@ func (h *Handler) LoginWithAppleHuma(ctx context.Context, input *LoginWithAppleI
 	return resp, nil
 }
 
+// RefreshTokenHuma handles token refresh (PUBLIC ROUTE — no auth middleware)
+func (h *Handler) RefreshTokenHuma(ctx context.Context, input *RefreshTokenInput) (*RefreshTokenOutput, error) {
+	if input.RefreshToken == "" {
+		return nil, huma.Error400BadRequest("Refresh token is required", nil)
+	}
+
+	service := h.service
+
+	// Validate the refresh token and mark it as used atomically
+	userID, count, timezone, err := validateRefreshTokenCore(service, input.RefreshToken)
+	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelWarn, "Refresh token validation failed",
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error401Unauthorized("Invalid or expired refresh token. Please log in again.", err)
+	}
+
+	// Generate new token pair
+	newAccess, newRefresh, err := service.GenerateTokens(userID, count, timezone)
+	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to generate tokens during refresh",
+			slog.String("userId", userID),
+			slog.String("error", err.Error()),
+		)
+		return nil, huma.Error500InternalServerError("Unable to refresh session. Please try again.", err)
+	}
+
+	// Reset token_used so the new refresh token can be used in the future
+	id, _ := primitive.ObjectIDFromHex(userID)
+	if err := service.users.ResetTokenUsed(ctx, id); err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to reset token_used after refresh",
+			slog.String("userId", userID),
+			slog.String("error", err.Error()),
+		)
+		// Non-fatal: tokens were already generated, just log the error
+	}
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "Token refresh successful",
+		slog.String("userId", userID),
+	)
+
+	resp := &RefreshTokenOutput{}
+	resp.AccessToken = newAccess
+	resp.RefreshToken = newRefresh
+	resp.Body.Message = "Tokens refreshed successfully"
+	return resp, nil
+}
+
 // TestHuma handles the test authentication endpoint (PROTECTED ROUTE)
 func (h *Handler) TestHuma(ctx context.Context, input *TestInput) (*TestOutput, error) {
 	// Extract user_id from context to verify auth middleware is working

--- a/backend/internal/handlers/auth/fiber_middleware.go
+++ b/backend/internal/handlers/auth/fiber_middleware.go
@@ -9,6 +9,7 @@ import (
 	"github.com/abhikaboy/Kindred/internal/config"
 	"github.com/abhikaboy/Kindred/internal/xlog"
 	"github.com/gofiber/fiber/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
@@ -82,6 +83,10 @@ func FiberAuthMiddleware(collections map[string]*mongo.Collection, cfg config.Co
 					"status": 500,
 				})
 			}
+
+			// Reset token_used so the new refresh token can be used for future refreshes
+			id, _ := primitive.ObjectIDFromHex(userID)
+			_ = service.users.ResetTokenUsed(context.Background(), id)
 
 			// Set new tokens in response headers
 			c.Set("access_token", newAccess)

--- a/backend/internal/handlers/auth/middleware.go
+++ b/backend/internal/handlers/auth/middleware.go
@@ -89,6 +89,10 @@ func AuthMiddleware(collections map[string]*mongo.Collection, cfg config.Config)
 
 				slog.Info("✅ AUTH MIDDLEWARE: New tokens generated successfully")
 
+				// Reset token_used so the new refresh token can be used for future refreshes
+				id, _ := primitive.ObjectIDFromHex(userID)
+				_ = service.users.ResetTokenUsed(context.Background(), id)
+
 				// Set new tokens in response headers
 				w.Header().Set("access_token", newAccess)
 				w.Header().Set("refresh_token", newRefresh)

--- a/backend/internal/handlers/auth/operations.go
+++ b/backend/internal/handlers/auth/operations.go
@@ -129,6 +129,19 @@ type LoginWithOTPOutput struct {
 	Body         SafeUser `json:"body"`
 }
 
+// Refresh Token Operation Types
+type RefreshTokenInput struct {
+	RefreshToken string `header:"refresh_token" required:"true" doc:"Refresh token to exchange for new tokens"`
+}
+
+type RefreshTokenOutput struct {
+	AccessToken  string `header:"access_token"`
+	RefreshToken string `header:"refresh_token"`
+	Body         struct {
+		Message string `json:"message" example:"Tokens refreshed successfully"`
+	}
+}
+
 // Delete Account Operation Types
 type DeleteAccountInput struct {
 	Authorization string `header:"Authorization" required:"true" doc:"Bearer token for authentication"`
@@ -378,6 +391,20 @@ func RegisterAcceptTermsOperation(api huma.API, handler *Handler) {
 		Tags:        []string{"auth"},
 	}, func(ctx context.Context, input *AcceptTermsInput) (*AcceptTermsOutput, error) {
 		return handler.AcceptTermsHuma(ctx, input)
+	})
+}
+
+// RegisterRefreshTokenOperation registers the refresh token endpoint
+func RegisterRefreshTokenOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "refresh-token",
+		Method:      http.MethodPost,
+		Path:        "/v1/auth/refresh",
+		Summary:     "Refresh tokens",
+		Description: "Exchange a valid refresh token for new access and refresh tokens",
+		Tags:        []string{"auth"},
+	}, func(ctx context.Context, input *RefreshTokenInput) (*RefreshTokenOutput, error) {
+		return handler.RefreshTokenHuma(ctx, input)
 	})
 }
 

--- a/backend/internal/handlers/auth/routes.go
+++ b/backend/internal/handlers/auth/routes.go
@@ -55,6 +55,7 @@ func RegisterAuthOperations(api huma.API, handler *Handler) {
 	RegisterRegisterWithAppleOperation(api, handler)
 	RegisterLoginWithGoogleOperation(api, handler)
 	RegisterRegisterWithGoogleOperation(api, handler)
+	RegisterRefreshTokenOperation(api, handler)
 	RegisterTestOperation(api, handler)
 	RegisterLoginWithTokenOperation(api, handler)
 	RegisterUpdatePushTokenOperation(api, handler)

--- a/frontend/api/client.ts
+++ b/frontend/api/client.ts
@@ -51,9 +51,8 @@ function isTokenExpired(token: string, bufferMs = 60_000): boolean {
 }
 
 /**
- * Perform a token refresh by hitting a lightweight authenticated endpoint.
- * The server middleware detects the expired access token, validates the
- * refresh token, and returns new tokens in response headers.
+ * Perform a token refresh by calling the dedicated refresh endpoint.
+ * Sends the refresh token and receives new access + refresh tokens.
  *
  * Returns true if refresh succeeded (new tokens saved).
  */
@@ -62,17 +61,16 @@ async function performRefresh(): Promise<boolean> {
         const authData = await SecureStore.getItemAsync("auth_data");
         if (!authData) return false;
 
-        const { access_token, refresh_token } = JSON.parse(authData);
+        const { refresh_token } = JSON.parse(authData);
         if (!refresh_token) return false;
 
         logger.debug("Performing token refresh");
 
         const response = await fetch(
-            (process.env.EXPO_PUBLIC_URL ?? "") + "/api/v1/user/login",
+            (process.env.EXPO_PUBLIC_URL ?? "") + "/api/v1/auth/refresh",
             {
                 method: "POST",
                 headers: {
-                    "Authorization": `Bearer ${access_token}`,
                     "refresh_token": refresh_token,
                     "Content-Type": "application/json",
                 },
@@ -99,9 +97,6 @@ async function performRefresh(): Promise<boolean> {
             logger.debug("Token refresh succeeded, new tokens saved");
             return true;
         }
-
-        // No new tokens but request succeeded — tokens were still valid
-        if (response.ok) return true;
 
         return false;
     } catch (error) {
@@ -185,8 +180,7 @@ baseClient.use({
     },
 
     async onResponse({ response, request }) {
-        // Handle 401 — but don't immediately log out.
-        // Check if tokens were already refreshed by another concurrent request.
+        // Handle 401 — attempt one refresh + retry before logging out.
         if (response.status === 401) {
             const authData = await SecureStore.getItemAsync("auth_data");
 
@@ -200,11 +194,36 @@ baseClient.use({
                     logger.debug("401 on stale request — tokens already refreshed, skipping logout");
                     return response;
                 }
+
+                // Tokens match — force a refresh before giving up
+                logger.debug("401 with current tokens, attempting refresh + retry");
+                const refreshed = await performRefresh();
+                if (refreshed) {
+                    // Retry the original request with new tokens
+                    const freshAuthData = await SecureStore.getItemAsync("auth_data");
+                    if (freshAuthData) {
+                        const { access_token: newAccess, refresh_token: newRefresh } = JSON.parse(freshAuthData);
+                        const retryHeaders = new Headers(request.headers);
+                        retryHeaders.set("Authorization", `Bearer ${newAccess}`);
+                        retryHeaders.set("refresh_token", newRefresh);
+
+                        const retryResponse = await fetch(request.url, {
+                            method: request.method,
+                            headers: retryHeaders,
+                            body: request.method !== "GET" && request.method !== "HEAD" ? request.body : undefined,
+                        });
+
+                        if (retryResponse.status !== 401) {
+                            logger.debug("Retry after refresh succeeded");
+                            return retryResponse;
+                        }
+                    }
+                }
             }
 
-            // Tokens haven't changed — this is a genuine auth failure
+            // Refresh failed or no auth data — genuine auth failure
             if (onUnauthorized) {
-                logger.warn("Received 401 with current tokens, triggering logout");
+                logger.warn("Auth refresh exhausted, triggering logout");
                 await SecureStore.deleteItemAsync("auth_data");
                 onUnauthorized();
             }


### PR DESCRIPTION
## Summary
- **Productivity Ring Claims**: reward unboxing modal with slot roulette animation, claim button on rings card, manual claim flow when all rings close
- **Interactive Onboarding Tutorial**: 4-step core loop walkthrough (create category → add task → complete task → beak congratulation with welcome credits)
- **Auth Token Refresh Fix**: users were getting logged out after first token refresh because `token_used` was never reset. Added dedicated `POST /v1/auth/refresh` endpoint, fixed middleware to reset the flag, and client now retries once on 401 before logging out
- **Dashboard**: toggleable section visibility with persisted config, dashboard stats, Jump Back In section
- **Live Activities**: CTA buttons, keep-alive intervals, alignment fixes
- **UI Polish**: safe area insets on onboarding/post screens, splash logo fix, feed FlashList→FlatList, profile gallery perf fix

## Test plan
- [ ] Log in, wait >1 hour (or manually expire token), confirm requests succeed without logout
- [ ] Call `POST /v1/auth/refresh` with a valid refresh token, verify new tokens returned
- [ ] Complete onboarding tutorial flow end-to-end (new account)
- [ ] Close all 3 rings, tap Claim Reward, verify unboxing modal + credits granted
- [ ] Toggle dashboard section visibility, kill app, reopen — verify persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)