### PR TITLE
UI polish: posting, profile, activity, kudos fixes

### DIFF
--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -262,6 +263,13 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		}
 	}
 
+	// Get friends' ring closure events
+	ringClosures, ringsTotal, err := h.service.GetFriendsRingClosures(userID, 5, offset/4)
+	if err != nil {
+		ringClosures = []FeedRingsClosedData{}
+		ringsTotal = 0
+	}
+
 	// Convert posts to API format
 	var apiPosts []types.PostDocumentAPI
 	for _, post := range posts {
@@ -343,56 +351,53 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		feedTasks = append(feedTasks, feedTask)
 	}
 
-	// Interleave posts and tasks: 1 task as 2nd item, then 1 task after every 5 posts
+	// Build timestamped items for chronological merge
+	type timestampedItem struct {
+		feedItem FeedItem
+		time     time.Time
+	}
+
+	var allItems []timestampedItem
+
+	for i := range apiPosts {
+		post := apiPosts[i]
+		allItems = append(allItems, timestampedItem{
+			feedItem: FeedItem{Type: "post", Post: &post},
+			time:     post.Metadata.CreatedAt,
+		})
+	}
+
+	for i := range feedTasks {
+		task := feedTasks[i]
+		t, _ := time.Parse(time.RFC3339, task.Timestamp)
+		allItems = append(allItems, timestampedItem{
+			feedItem: FeedItem{Type: "task", Task: &task},
+			time:     t,
+		})
+	}
+
+	for i := range ringClosures {
+		rc := ringClosures[i]
+		t, _ := time.Parse(time.RFC3339, rc.Timestamp)
+		allItems = append(allItems, timestampedItem{
+			feedItem: FeedItem{Type: "rings_closed", RingsClosed: &rc},
+			time:     t,
+		})
+	}
+
+	// Sort by time descending (newest first)
+	sort.Slice(allItems, func(i, j int) bool {
+		return allItems[i].time.After(allItems[j].time)
+	})
+
+	// Take up to limit items
 	var feedItems []FeedItem
-	postIdx := 0
-	taskIdx := 0
-
-	// Add first post if available
-	if postIdx < len(apiPosts) && len(feedItems) < limit {
-		post := apiPosts[postIdx]
-		feedItems = append(feedItems, FeedItem{
-			Type: "post",
-			Post: &post,
-		})
-		postIdx++
-	}
-
-	// Add first task as 2nd item if available
-	if taskIdx < len(feedTasks) && len(feedItems) < limit {
-		task := feedTasks[taskIdx]
-		feedItems = append(feedItems, FeedItem{
-			Type: "task",
-			Task: &task,
-		})
-		taskIdx++
-	}
-
-	// Continue interleaving: 5 posts, then 1 task
-	for len(feedItems) < limit && (postIdx < len(apiPosts) || taskIdx < len(feedTasks)) {
-		// Add up to 5 posts
-		for i := 0; i < 5 && postIdx < len(apiPosts) && len(feedItems) < limit; i++ {
-			post := apiPosts[postIdx]
-			feedItems = append(feedItems, FeedItem{
-				Type: "post",
-				Post: &post,
-			})
-			postIdx++
-		}
-
-		// Add 1 task after 5 posts
-		if taskIdx < len(feedTasks) && len(feedItems) < limit {
-			task := feedTasks[taskIdx]
-			feedItems = append(feedItems, FeedItem{
-				Type: "task",
-				Task: &task,
-			})
-			taskIdx++
-		}
+	for i := 0; i < len(allItems) && i < limit; i++ {
+		feedItems = append(feedItems, allItems[i].feedItem)
 	}
 
 	// Calculate total items and pagination
-	totalItems := postsTotal + tasksTotal
+	totalItems := postsTotal + tasksTotal + ringsTotal
 	hasMore := offset+len(feedItems) < totalItems
 
 	output := &GetFeedOutput{}

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -1269,3 +1269,64 @@ func (s *Service) NotifyRandomFriendsOfPost(postID primitive.ObjectID, posterID 
 
 	return nil
 }
+
+// GetFriendsRingClosures returns ring closure notifications from friends, sorted by time descending.
+func (s *Service) GetFriendsRingClosures(userID primitive.ObjectID, limit, offset int) ([]FeedRingsClosedData, int, error) {
+	ctx := context.Background()
+
+	notifColl := s.NotificationService.Notifications
+
+	filter := bson.M{
+		"receiver":         userID,
+		"notificationType": "RINGS_CLOSED",
+		"user._id":         bson.M{"$ne": userID},
+	}
+
+	total, err := notifColl.CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	opts := options.Find().
+		SetSort(bson.D{{Key: "time", Value: -1}}).
+		SetLimit(int64(limit)).
+		SetSkip(int64(offset))
+
+	cursor, err := notifColl.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer cursor.Close(ctx)
+
+	var results []FeedRingsClosedData
+	for cursor.Next(ctx) {
+		var doc struct {
+			ID      primitive.ObjectID `bson:"_id"`
+			Time    time.Time          `bson:"time"`
+			Content string             `bson:"content"`
+			User    struct {
+				ID             primitive.ObjectID `bson:"_id"`
+				DisplayName    string             `bson:"display_name"`
+				Handle         string             `bson:"handle"`
+				ProfilePicture string             `bson:"profile_picture"`
+			} `bson:"user"`
+		}
+		if err := cursor.Decode(&doc); err != nil {
+			continue
+		}
+
+		results = append(results, FeedRingsClosedData{
+			ID:        doc.ID.Hex(),
+			Timestamp: doc.Time.Format(time.RFC3339),
+			Content:   doc.Content,
+			User: &types.UserExtendedReference{
+				ID:             doc.User.ID.Hex(),
+				Handle:         doc.User.Handle,
+				DisplayName:    doc.User.DisplayName,
+				ProfilePicture: doc.User.ProfilePicture,
+			},
+		})
+	}
+
+	return results, int(total), nil
+}

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -73,9 +73,17 @@ type GetFeedInput struct {
 }
 
 type FeedItem struct {
-	Type string                 `json:"type" doc:"Type of feed item: 'post' or 'task'"`
-	Post *types.PostDocumentAPI `json:"post,omitempty" doc:"Post data (only present if type is 'post')"`
-	Task *FeedTaskData          `json:"task,omitempty" doc:"Task data (only present if type is 'task')"`
+	Type        string                 `json:"type" doc:"Type of feed item: 'post', 'task', or 'rings_closed'"`
+	Post        *types.PostDocumentAPI `json:"post,omitempty" doc:"Post data (only present if type is 'post')"`
+	Task        *FeedTaskData          `json:"task,omitempty" doc:"Task data (only present if type is 'task')"`
+	RingsClosed *FeedRingsClosedData   `json:"ringsClosed,omitempty" doc:"Rings closed data (only present if type is 'rings_closed')"`
+}
+
+type FeedRingsClosedData struct {
+	ID        string                       `json:"id"`
+	Timestamp string                       `json:"timestamp"`
+	Content   string                       `json:"content"`
+	User      *types.UserExtendedReference `json:"user" doc:"User who closed their rings"`
 }
 
 type FeedTaskData struct {

--- a/backend/internal/storage/xmongo/indexes.go
+++ b/backend/internal/storage/xmongo/indexes.go
@@ -151,6 +151,27 @@ var Indexes = []Index{
 	// 		}),
 	// 	},
 	// },
+	// Notifications collection indexes
+	// Compound index for fetching a user's notifications sorted by time (covers the main query)
+	{
+		Collection: "notifications",
+		Model: mongo.IndexModel{
+			Keys: bson.D{
+				{Key: "receiver", Value: 1},
+				{Key: "time", Value: -1},
+			},
+		},
+	},
+	// Compound index for unread count queries
+	{
+		Collection: "notifications",
+		Model: mongo.IndexModel{
+			Keys: bson.D{
+				{Key: "receiver", Value: 1},
+				{Key: "read", Value: 1},
+			},
+		},
+	},
 	// Calendar processed events indexes
 	{
 		Collection: "calendar_processed_events",

--- a/frontend/android/app/src/main/java/com/kindred/kindredtsl/MainApplication.kt
+++ b/frontend/android/app/src/main/java/com/kindred/kindredtsl/MainApplication.kt
@@ -14,29 +14,26 @@ import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint
 import com.facebook.react.defaults.DefaultReactNativeHost
 
 import expo.modules.ApplicationLifecycleDispatcher
-import expo.modules.ReactNativeHostWrapper
+import expo.modules.ExpoReactHostFactory
 
 class MainApplication : Application(), ReactApplication {
 
-  override val reactNativeHost: ReactNativeHost = ReactNativeHostWrapper(
-      this,
-      object : DefaultReactNativeHost(this) {
-        override fun getPackages(): List<ReactPackage> =
-            PackageList(this).packages.apply {
-              // Packages that cannot be autolinked yet can be added manually here, for example:
-              // add(MyReactNativePackage())
-            }
+  override val reactNativeHost: ReactNativeHost = object : DefaultReactNativeHost(this) {
+    override fun getPackages(): List<ReactPackage> =
+        PackageList(this).packages.apply {
+          // Packages that cannot be autolinked yet can be added manually here, for example:
+          // add(MyReactNativePackage())
+        }
 
-          override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
+    override fun getJSMainModuleName(): String = ".expo/.virtual-metro-entry"
 
-          override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
+    override fun getUseDeveloperSupport(): Boolean = BuildConfig.DEBUG
 
-          override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
-      }
-  )
+    override val isNewArchEnabled: Boolean = BuildConfig.IS_NEW_ARCHITECTURE_ENABLED
+  }
 
   override val reactHost: ReactHost
-    get() = ReactNativeHostWrapper.createReactHost(applicationContext, reactNativeHost)
+    get() = ExpoReactHostFactory.getDefaultReactHost(applicationContext, PackageList(this).packages)
 
   override fun onCreate() {
     super.onCreate()

--- a/frontend/api/post.ts
+++ b/frontend/api/post.ts
@@ -149,10 +149,23 @@ export interface FeedTask {
     };
 }
 
+export interface FeedRingsClosed {
+    id: string;
+    timestamp: string;
+    content: string;
+    user: {
+        _id: string;
+        handle: string;
+        display_name: string;
+        profile_picture: string;
+    };
+}
+
 export interface FeedItem {
-    type: 'post' | 'task';
+    type: 'post' | 'task' | 'rings_closed';
     post?: Post;
     task?: FeedTask;
+    ringsClosed?: FeedRingsClosed;
 }
 
 export interface PaginatedFeedResponse {

--- a/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
@@ -198,6 +198,18 @@ const Activity = () => {
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
             >
+                {/* Lifetime Stats */}
+                {!loading && !error && userId && (
+                    <View style={styles.statsCard}>
+                        <ThemedText type="fancyFrauncesHeading" style={{ fontSize: 24, color: ThemedColor.text }}>
+                            {yearTotal}
+                        </ThemedText>
+                        <ThemedText type="caption" style={{ color: ThemedColor.caption, marginLeft: 8 }}>
+                            total tasks completed this year
+                        </ThemedText>
+                    </View>
+                )}
+
                 {/* Recurring Tasks Section - only for own activity */}
                 {isOwnActivity && templates.length > 0 && (
                     <View style={styles.recurringSection}>
@@ -265,18 +277,6 @@ const Activity = () => {
                     <View style={styles.emptyState}>
                         <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
                             No recurring tasks yet. Create one to track your habits!
-                        </ThemedText>
-                    </View>
-                )}
-
-                {/* Lifetime Stats */}
-                {!loading && !error && userId && (
-                    <View style={styles.statsCard}>
-                        <ThemedText type="fancyFrauncesHeading" style={{ fontSize: 24, color: ThemedColor.text }}>
-                            {yearTotal}
-                        </ThemedText>
-                        <ThemedText type="caption" style={{ color: ThemedColor.caption, marginLeft: 8 }}>
-                            total tasks completed this year
                         </ThemedText>
                     </View>
                 )}

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -1,5 +1,5 @@
-import { Dimensions, StyleSheet, View, ScrollView, TouchableOpacity, ActivityIndicator, Animated } from "react-native";
-import React, { useState, useEffect, useRef } from "react";
+import { Dimensions, StyleSheet, View, SectionList, TouchableOpacity, ActivityIndicator, Animated, InteractionManager, RefreshControl } from "react-native";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
 import Ionicons from "@expo/vector-icons/Ionicons";
@@ -234,11 +234,49 @@ const Notifications = () => {
     const { notifications: rawNotifications, loading, error, refreshNotifications, markAllAsRead } = useNotifications();
     const hasMarkedAsRead = useRef(false);
     const { capture } = useAnalytics();
+    const [ready, setReady] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const followRequestsRef = useRef<{ refresh: () => Promise<void> }>(null);
+
+    const onRefresh = useCallback(async () => {
+        setRefreshing(true);
+        await Promise.all([
+            refreshNotifications(),
+            followRequestsRef.current?.refresh(),
+        ]);
+        setRefreshing(false);
+    }, [refreshNotifications]);
+
+    // Defer heavy rendering until the navigation transition completes
+    useEffect(() => {
+        const task = InteractionManager.runAfterInteractions(() => {
+            setReady(true);
+        });
+        return () => task.cancel();
+    }, []);
 
     const handleNotificationPress = (notification: ProcessedNotification) => {
         capture(AnalyticsEvents.NOTIFICATION_TAPPED, {
             notification_type: notification.type,
         });
+
+        switch (notification.type) {
+            case "encouragement":
+                router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=encouragements");
+                break;
+            case "congratulation":
+                router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=congratulations");
+                break;
+            case "friend_request":
+            case "friend_request_accepted":
+                // Already on the notifications page which shows friend requests
+                break;
+            case "comment":
+                if (notification.referenceId) {
+                    router.push(`/(logged-in)/posting/${notification.referenceId}`);
+                }
+                break;
+        }
     };
 
     // Mark all notifications as read when the page is focused (only once per mount)
@@ -319,6 +357,13 @@ const Notifications = () => {
     const thisMonthNotifications = filterByTimePeriod(notifications, isThisMonth);
     const olderNotifications = filterByTimePeriod(notifications, isOlder);
 
+    const sections = [
+        { title: "Today", data: todayNotifications },
+        { title: "This Week", data: thisWeekNotifications },
+        { title: "This Month", data: thisMonthNotifications },
+        { title: "Older", data: olderNotifications },
+    ].filter((s) => s.data.length > 0);
+
     return (
         <ThemedView style={styles.container}>
             <View style={styles.headerContainer}>
@@ -327,37 +372,55 @@ const Notifications = () => {
                 </TouchableOpacity>
                 <ThemedText type="subtitle">Notifications</ThemedText>
             </View>
-            <ScrollView contentContainerStyle={styles.scrollViewContent}>
-                <FollowRequestsSection styles={styles} maxVisible={4} />
-                {loading ? (
+            {!ready || loading ? (
+                <View style={styles.scrollViewContent}>
                     <NotificationsSkeleton ThemedColor={ThemedColor} />
-                ) : error ? (
-                    <View style={styles.section}>
-                        <ThemedText style={{ textAlign: "center", color: "red" }}>{error}</ThemedText>
-                        <TouchableOpacity
-                            onPress={() => refreshNotifications()}
-                            style={{ marginTop: 16, alignItems: "center" }}>
-                            <ThemedText style={{ color: ThemedColor.text }}>Tap to retry</ThemedText>
-                        </TouchableOpacity>
-                    </View>
-                ) : notifications.length === 0 ? (
-                    <View style={styles.section}>
-                        <ThemedText style={{ textAlign: "center" }}>No notifications yet</ThemedText>
-                    </View>
-                ) : (
-                    <>
-                        <NotificationSection title="Today" notifications={todayNotifications} styles={styles} onNotificationPress={handleNotificationPress} />
-                        <NotificationSection title="This Week" notifications={thisWeekNotifications} styles={styles} onNotificationPress={handleNotificationPress} />
-                        <NotificationSection
-                            title="This Month"
-                            notifications={thisMonthNotifications}
+                </View>
+            ) : error ? (
+                <View style={[styles.scrollViewContent, styles.section]}>
+                    <ThemedText style={{ textAlign: "center", color: "red" }}>{error}</ThemedText>
+                    <TouchableOpacity
+                        onPress={() => refreshNotifications()}
+                        style={{ marginTop: 16, alignItems: "center" }}>
+                        <ThemedText style={{ color: ThemedColor.text }}>Tap to retry</ThemedText>
+                    </TouchableOpacity>
+                </View>
+            ) : notifications.length === 0 ? (
+                <View style={[styles.scrollViewContent, styles.section]}>
+                    <ThemedText style={{ textAlign: "center" }}>No notifications yet</ThemedText>
+                </View>
+            ) : (
+                <SectionList
+                    sections={sections}
+                    keyExtractor={(item, index) => `${item.type}-${item.id}-${index}`}
+                    renderItem={({ item, index }) => (
+                        <NotificationItem
+                            notification={item}
+                            index={index}
                             styles={styles}
                             onNotificationPress={handleNotificationPress}
                         />
-                        <NotificationSection title="Older" notifications={olderNotifications} styles={styles} onNotificationPress={handleNotificationPress} />
-                    </>
-                )}
-            </ScrollView>
+                    )}
+                    renderSectionHeader={({ section: { title } }) => (
+                        <View style={styles.sectionHeader}>
+                            <ThemedText type="defaultSemiBold">{title}</ThemedText>
+                        </View>
+                    )}
+                    ListHeaderComponent={<FollowRequestsSection ref={followRequestsRef} styles={styles} maxVisible={4} />}
+                    contentContainerStyle={styles.scrollViewContent}
+                    stickySectionHeadersEnabled={false}
+                    initialNumToRender={10}
+                    maxToRenderPerBatch={10}
+                    windowSize={5}
+                    refreshControl={
+                        <RefreshControl
+                            refreshing={refreshing}
+                            onRefresh={onRefresh}
+                            tintColor={ThemedColor.text}
+                        />
+                    }
+                />
+            )}
         </ThemedView>
     );
 };
@@ -383,6 +446,10 @@ const stylesheet = (ThemedColor: any) => {
         },
         listItem: {
             marginVertical: 10,
+        },
+        sectionHeader: {
+            marginBottom: 4,
+            marginTop: 12,
         },
     });
 };

--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -3,6 +3,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import PostCard from "@/components/cards/PostCard";
 import ReportedPostCard from "@/components/cards/ReportedPostCard";
 import TaskFeedCard from "@/components/cards/TaskFeedCard";
+import RingsClosedFeedCard from "@/components/cards/RingsClosedFeedCard";
 import { Icons } from "@/constants/Icons";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/ThemedText";
@@ -462,6 +463,16 @@ export default function Feed() {
                         user={task.user}
                     />
                 );
+            } else if (item.type === "rings_closed" && item.ringsClosed) {
+                const rc = item.ringsClosed;
+                return (
+                    <RingsClosedFeedCard
+                        id={rc.id}
+                        timestamp={rc.timestamp}
+                        content={rc.content}
+                        user={rc.user}
+                    />
+                );
             } else if (item.type === "post" && item.post) {
                 const post = item.post as any;
 
@@ -705,9 +716,12 @@ export default function Feed() {
                 keyExtractor={(item) => {
                     if (currentFeed.id === "feed") {
                         const feedItem = item as FeedItem;
-                        return feedItem.type === "post" && feedItem.post
-                            ? `post-${feedItem.post._id}`
-                            : `task-${feedItem.task?.id}`;
+                        if (feedItem.type === "post" && feedItem.post) {
+                            return `post-${feedItem.post._id}`;
+                        } else if (feedItem.type === "rings_closed" && feedItem.ringsClosed) {
+                            return `rings-${feedItem.ringsClosed.id}`;
+                        }
+                        return `task-${feedItem.task?.id}`;
                     }
                     return (item as PostData)._id;
                 }}

--- a/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
@@ -10,7 +10,7 @@ import {
 } from "react-native";
 
 import { ThemedText } from "@/components/ThemedText";
-import React, { useEffect, useRef, useState, useMemo } from "react";
+import React, { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { Icons } from "@/constants/Icons";
 import { SvgUri } from "react-native-svg";
 import { LinearGradient } from "expo-linear-gradient";
@@ -23,7 +23,7 @@ import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTa
 import ProfileStats from "@/components/profile/ProfileStats";
 import TodayStats from "@/components/profile/TodayStats";
 import { FriendRings } from "@/components/profile/ProductivityRings";
-import ProfileGallery from "@/components/profile/ProfileGallery";
+import ProfileGallery, { type ProfileGalleryHandle } from "@/components/profile/ProfileGallery";
 import ProfileHeader from "@/components/profile/ProfileHeader";
 import WeeklyActivity from "@/components/profile/WeeklyActivity";
 import TaskList from "@/components/profile/TaskList";
@@ -75,8 +75,18 @@ export default function Profile() {
     const [activeTab, setActiveTab] = useState(0);
 
     const scrollRef = useAnimatedRef<Animated.ScrollView>();
+    const galleryRef = useRef<ProfileGalleryHandle>(null);
 
     const HEADER_HEIGHT = Dimensions.get("window").height * 0.4;
+
+    const handleScroll = useCallback((event: any) => {
+        if (activeTab !== 1) return;
+        const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+        const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
+        if (distanceFromBottom < 500 && galleryRef.current?.hasMore) {
+            galleryRef.current.loadMore();
+        }
+    }, [activeTab]);
 
     const { data: profile, isLoading } = useQuery({
         queryKey: ["profile", id],
@@ -158,6 +168,7 @@ export default function Profile() {
         <Animated.ScrollView
             ref={scrollRef}
             scrollEventThrottle={16}
+            onScroll={handleScroll}
             style={[styles.scrollView, { backgroundColor: ThemedColor.background }]}>
             <ParallaxBanner
                 scrollRef={scrollRef}
@@ -191,16 +202,18 @@ export default function Profile() {
                         />
                     </View>
 
-                    {profile?.ring_state ? (
-                        <FriendRings
-                            ringState={profile.ring_state}
-                            userId={profile.id}
-                            userHandle={profile.handle}
-                            userName={profile.display_name}
-                        />
-                    ) : (
-                        <TodayStats userId={profile?.id} />
-                    )}
+                    <View style={{ marginTop: 8 }}>
+                        {profile?.ring_state ? (
+                            <FriendRings
+                                ringState={profile.ring_state}
+                                userId={profile.id}
+                                userHandle={profile.handle}
+                                userName={profile.display_name}
+                            />
+                        ) : (
+                            <TodayStats userId={profile?.id} />
+                        )}
+                    </View>
                 </View>
                 {canViewPersonalContent ? (
                     <>
@@ -216,9 +229,9 @@ export default function Profile() {
 
                         <AnimatedTabs tabs={["Tasks", "Gallery"]} activeTab={activeTab} setActiveTab={setActiveTab} />
 
-                        <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab}>
+                        <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab} lazy>
                             <TaskList {...tasks} />
-                            <ProfileGallery userId={galleryUserId} />
+                            <ProfileGallery ref={galleryRef} userId={galleryUserId} />
                         </AnimatedTabContent>
                     </>
                 ) : profile.relationship?.status === "blocked" ? (

--- a/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/blueprint/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/blueprint/[id].tsx
@@ -12,10 +12,11 @@ import PreviewIcon from "@/components/profile/PreviewIcon";
 import ParallaxScrollView from "@/components/ParallaxScrollView";
 import { Category } from "@/components/category";
 import Entypo from "@expo/vector-icons/Entypo";
-import * as Sharing from "expo-sharing";
 import * as SMS from "expo-sms";
-import { getBlueprintById } from "@/api/blueprint";
+import { getBlueprintById, deleteBlueprintToBackend } from "@/api/blueprint";
 import { useTasks } from "@/contexts/tasksContext";
+import { useAuth } from "@/hooks/useAuth";
+import { useAlert } from "@/contexts/AlertContext";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
 import BlueprintGallery from "@/components/profile/BlueprintGallery";
 
@@ -245,6 +246,8 @@ export default function BlueprintDetailScreen() {
         setSelectedBlueprint,
     } = useBlueprints();
     const { fetchWorkspaces } = useTasks();
+    const { user } = useAuth();
+    const { showAlert } = useAlert();
 
     const [activeTab, setActiveTab] = useState(0);
     const [isLoadingBlueprint, setIsLoadingBlueprint] = useState(true);
@@ -252,6 +255,7 @@ export default function BlueprintDetailScreen() {
     const [isSubscribed, setIsSubscribed] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [currentSubscriberCount, setCurrentSubscriberCount] = useState(0);
+    const isOwner = user?._id === selectedBlueprint?.owner?._id;
 
     // Fetch blueprint data when ID changes
     useEffect(() => {
@@ -340,13 +344,43 @@ export default function BlueprintDetailScreen() {
                         </View>
                     </TouchableOpacity>
 
-                    <PrimaryButton
-                        style={{ height: 38, width: 100, paddingVertical: 10, paddingHorizontal: 10 }}
-                        title={isLoading ? "..." : isSubscribed ? "Subscribed" : "Subscribe"}
-                        secondary={isSubscribed}
-                        onPress={onSubscribePress}
-                        disabled={isLoading}
-                    />
+                    {isOwner ? (
+                        <PrimaryButton
+                            style={{ height: 38, paddingVertical: 10, paddingHorizontal: 16 }}
+                            title="Delete"
+                            ghost
+                            textStyle={{ color: ThemedColor.error }}
+                            onPress={() => {
+                                showAlert({
+                                    title: "Delete Blueprint",
+                                    message: "Are you sure you want to delete this blueprint? This can't be undone.",
+                                    buttons: [
+                                        { text: "Cancel", style: "cancel" },
+                                        {
+                                            text: "Delete",
+                                            style: "destructive",
+                                            onPress: async () => {
+                                                try {
+                                                    await deleteBlueprintToBackend(selectedBlueprint.id);
+                                                    router.back();
+                                                } catch (e) {
+                                                    showAlert({ title: "Error", message: "Failed to delete blueprint. Please try again." });
+                                                }
+                                            },
+                                        },
+                                    ],
+                                });
+                            }}
+                        />
+                    ) : (
+                        <PrimaryButton
+                            style={{ height: 38, width: 100, paddingVertical: 10, paddingHorizontal: 10 }}
+                            title={isLoading ? "..." : isSubscribed ? "Subscribed" : "Subscribe"}
+                            secondary={isSubscribed}
+                            onPress={onSubscribePress}
+                            disabled={isLoading}
+                        />
+                    )}
                 </View>
 
                 <ThemedText type="subtitle">{selectedBlueprint.name}</ThemedText>

--- a/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
@@ -1,7 +1,7 @@
 import { StyleSheet, ScrollView, Image, Dimensions, View, TouchableOpacity } from "react-native";
 
 import { ThemedText } from "@/components/ThemedText";
-import React, { useEffect, useRef, useState, useMemo } from "react";
+import React, { useEffect, useRef, useState, useMemo, useCallback } from "react";
 import { Icons } from "@/constants/Icons";
 import { LinearGradient } from "expo-linear-gradient";
 import ActivityPoint from "@/components/profile/ActivityPoint";
@@ -13,7 +13,7 @@ import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTa
 import ProfileStats from "@/components/profile/ProfileStats";
 import ProductivityRings from "@/components/profile/ProductivityRings";
 import RingsBlurOverlay from "@/components/profile/RingsBlurOverlay";
-import ProfileGallery from "@/components/profile/ProfileGallery";
+import ProfileGallery, { type ProfileGalleryHandle } from "@/components/profile/ProfileGallery";
 import ProfileHeader from "@/components/profile/ProfileHeader";
 import WeeklyActivity from "@/components/profile/WeeklyActivity";
 import TaskList from "@/components/profile/TaskList";
@@ -41,8 +41,18 @@ export default function Profile() {
     const hasDefaultAvatar = !user?.profile_picture || user.profile_picture === DEFAULT_PICTURE;
 
     const scrollRef = useAnimatedRef<Animated.ScrollView>();
+    const galleryRef = useRef<ProfileGalleryHandle>(null);
 
     const HEADER_HEIGHT = Dimensions.get("screen").height * 0.4;
+
+    const handleScroll = useCallback((event: any) => {
+        if (activeTab !== 1) return; // Only load more on Gallery tab
+        const { layoutMeasurement, contentOffset, contentSize } = event.nativeEvent;
+        const distanceFromBottom = contentSize.height - layoutMeasurement.height - contentOffset.y;
+        if (distanceFromBottom < 500 && galleryRef.current?.hasMore) {
+            galleryRef.current.loadMore();
+        }
+    }, [activeTab]);
 
     type TaskDocument = components["schemas"]["TaskDocument"];
 
@@ -95,6 +105,7 @@ export default function Profile() {
             ref={scrollRef}
             scrollEventThrottle={16}
             showsVerticalScrollIndicator={false}
+            onScroll={handleScroll}
             style={[styles.scrollView, { backgroundColor: ThemedColor.background }]}>
             <RingsBlurOverlay
                 visible={ringsExpanded}
@@ -131,9 +142,9 @@ export default function Profile() {
 
                 <AnimatedTabs tabs={["Tasks", "Gallery"]} activeTab={activeTab} setActiveTab={setActiveTab} />
 
-                <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab}>
+                <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab} lazy>
                     <TaskList {...tasks} />
-                    <ProfileGallery userId={user?._id} />
+                    <ProfileGallery ref={galleryRef} userId={user?._id} />
                 </AnimatedTabContent>
             </View>
         </Animated.ScrollView>

--- a/frontend/app/(logged-in)/(tabs)/(task)/index.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/index.tsx
@@ -32,6 +32,7 @@ import { List } from "phosphor-react-native";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { useRouter } from "expo-router";
 import { AnalyticsEvents } from "@/utils/analytics";
+import { useKudos } from "@/contexts/kudosContext";
 
 type Props = {};
 
@@ -57,6 +58,7 @@ const Home = (props: Props) => {
     const [refreshing, setRefreshing] = useState(false);
     const queryClient = useQueryClient();
     const { capture } = useAnalytics();
+    const { fetchKudosData } = useKudos();
 
     const insets = useSafeAreaInsets();
     const safeAsync = useSafeAsync();
@@ -201,19 +203,18 @@ const Home = (props: Props) => {
         });
         setRefreshing(true);
         try {
-            console.log("Refreshing all data...");
             await Promise.all([
-                fetchWorkspaces(true), // Force refresh workspaces
-                fetchKudosCounts(true), // Force refresh kudos
-                queryClient.invalidateQueries({ queryKey: ["completedTasks"] }),
+                fetchWorkspaces(true),
+                fetchKudosCounts(true),
+                fetchKudosData(),
+                queryClient.invalidateQueries(),
             ]);
-            console.log("Refresh complete");
         } catch (error) {
             console.error("Error refreshing data:", error);
         } finally {
             setRefreshing(false);
         }
-    }, [fetchWorkspaces, fetchKudosCounts, queryClient, capture]);
+    }, [fetchWorkspaces, fetchKudosCounts, fetchKudosData, queryClient, capture]);
 
     const drawerRef = useRef<DrawerLayout>(null);
 

--- a/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
@@ -1,7 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { View, StyleSheet, TouchableOpacity, FlatList, ViewToken } from "react-native";
+import { View, StyleSheet, TouchableOpacity, FlatList, ViewToken, RefreshControl } from "react-native";
 import KudosItem from "@/components/cards/KudosItem";
-import KudosProgressCard from "@/components/cards/KudosProgressCard";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -9,8 +8,6 @@ import { HORIZONTAL_PADDING } from "@/constants/spacing";
 import { router, useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { formatDistanceToNow } from "date-fns";
-import { KUDOS_CONSTANTS } from "@/constants/kudos";
-import { useUserKudos } from "@/hooks/useUserKudos";
 import { useKudos } from "@/contexts/kudosContext";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
 
@@ -21,14 +18,21 @@ export default function Kudos() {
     const { tab } = useLocalSearchParams<{ tab?: string }>();
     const ThemedColor = useThemeColor();
     const insets = useSafeAreaInsets();
-    const { sentEncouragements, sentCongratulations } = useUserKudos();
     const {
         encouragements,
         congratulations,
         loading,
+        fetchKudosData,
         markEncouragementsAsRead,
         markCongratulationsAsRead,
     } = useKudos();
+    const [refreshing, setRefreshing] = useState(false);
+
+    const onRefresh = useCallback(async () => {
+        setRefreshing(true);
+        await fetchKudosData();
+        setRefreshing(false);
+    }, [fetchKudosData]);
 
     const initialTab = tab === "congratulations" ? 1 : 0;
     const [activeTab, setActiveTab] = useState(initialTab);
@@ -84,26 +88,6 @@ export default function Kudos() {
 
     const styles = createStyles(ThemedColor, insets);
 
-    const encouragementHeader = (
-        <View style={styles.progressCardWrapper}>
-            <KudosProgressCard
-                current={sentEncouragements}
-                max={KUDOS_CONSTANTS.ENCOURAGEMENTS_MAX}
-                type="encouragements"
-            />
-        </View>
-    );
-
-    const congratulationHeader = (
-        <View style={styles.progressCardWrapper}>
-            <KudosProgressCard
-                current={sentCongratulations}
-                max={KUDOS_CONSTANTS.CONGRATULATIONS_MAX}
-                type="congratulations"
-            />
-        </View>
-    );
-
     const renderEncouragementList = () => {
         if (!loading && encouragements.length === 0) {
             return (
@@ -125,10 +109,16 @@ export default function Kudos() {
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
                 style={styles.scrollView}
-                ListHeaderComponent={encouragementHeader}
                 ItemSeparatorComponent={KudosItemSeparator}
                 onViewableItemsChanged={onEncouragementViewableItemsChanged}
                 viewabilityConfig={encouragementViewabilityConfig}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={refreshing}
+                        onRefresh={onRefresh}
+                        tintColor={ThemedColor.text}
+                    />
+                }
                 renderItem={({ item, index }) => (
                     <KudosItem
                         kudos={item}
@@ -162,10 +152,16 @@ export default function Kudos() {
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator={false}
                 style={styles.scrollView}
-                ListHeaderComponent={congratulationHeader}
                 ItemSeparatorComponent={KudosItemSeparator}
                 onViewableItemsChanged={onCongratulationViewableItemsChanged}
                 viewabilityConfig={congratulationViewabilityConfig}
+                refreshControl={
+                    <RefreshControl
+                        refreshing={refreshing}
+                        onRefresh={onRefresh}
+                        tintColor={ThemedColor.text}
+                    />
+                }
                 renderItem={({ item, index }) => (
                     <KudosItem
                         kudos={item}
@@ -250,8 +246,5 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>, insets: any
             color: ThemedColor.caption,
             textAlign: "center",
             width: "65%",
-        },
-        progressCardWrapper: {
-            marginBottom: 8,
         },
     });

--- a/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
@@ -71,7 +71,7 @@ export default function Task() {
     const [time, setTime] = useState(new Date());
     const [baseTime, setBaseTime] = useState(new Date());
     const [localNotes, setLocalNotes] = useState("");
-    const [isHeaderSticky, setIsHeaderSticky] = useState(false);
+    // Removed sticky header state - was blocking scroll on long notes
     const [showDeadlineModal, setShowDeadlineModal] = useState(false);
     const [deadlineLiveActivity, setDeadlineLiveActivity] = useState<LiveActivity<DeadlineCountdownProps> | null>(null);
     const [activeTaskLiveActivity, setActiveTaskLiveActivity] = useState<LiveActivity<ActiveTaskActivityProps> | null>(null);
@@ -412,12 +412,7 @@ export default function Task() {
         }
     }, 2000);
 
-    const handleScroll = (event: any) => {
-        const scrollY = event.nativeEvent.contentOffset.y;
-        // Adjust this threshold based on when you want the header to become sticky
-        const stickyThreshold = 120; // Adjust this value as needed
-        setIsHeaderSticky(scrollY > stickyThreshold);
-    };
+    // Removed handleScroll - sticky header removed
 
     // Removed handleTabChange - no longer using PagerView
     // const handleTabChange = (index: number) => {
@@ -541,63 +536,39 @@ export default function Task() {
                 position: "relative",
                 paddingTop: Dimensions.get("screen").height * 0.07,
             }}>
-            {/* Sticky Header - Only shows when scrolled */}
-            <ConditionalView condition={isHeaderSticky}>
-                <View
-                    style={{
-                        position: "absolute",
-                        top: 0,
-                        left: 0,
-                        right: 0,
-                        zIndex: 1000,
-                        backgroundColor: ThemedColor.background,
-                        paddingHorizontal: HORIZONTAL_PADDING,
-                        paddingTop: Dimensions.get("screen").height * 0.07,
-                        paddingBottom: 16,
-                        borderBottomWidth: 1,
-                        borderBottomColor: ThemedColor.lightened,
-                    }}>
-                </View>
-            </ConditionalView>
-
-            {/* Header Section - Always visible */}
-            <View style={{ paddingBottom: 16 }}>
-                <TouchableOpacity
-                    onPress={() => router.back()}
-                    style={{
-                        zIndex: 1000,
-                        paddingVertical: 16,
-                        left: 0,
-                    }}>
-                    <Ionicons name="arrow-back" size={24} color={ThemedColor.text} />
-                </TouchableOpacity>
-                <View
-                    style={{
-                        flexDirection: "row",
-                        alignItems: "center",
-                        gap: 8,
-                        justifyContent: "space-between",
-                    }}>
-                    <ThemedText type="title" style={{ flexWrap: "wrap", width: "80%" }}>
-                        {name}
-                        {isRunning ? <MaterialIcons name="timer" size={24} color={ThemedColor.text} /> : ""}
-                    </ThemedText>
-                    <TouchableOpacity onPress={handleEditPress}>
-                        <PencilSimple size={24} color={ThemedColor.text} weight="regular" />
-                    </TouchableOpacity>
-                </View>
-                <View style={{ paddingBottom: 16 }} />
-                {/* <TaskTabs tabs={["Details", "Timer"]} activeTab={activeTab} setActiveTab={handleTabChange} /> */}
-            </View>
-
-            {/* Replaced PagerView with simple ScrollView */}
             <ScrollView
                 ref={scrollViewRef}
                 style={{ flex: 1 }}
                 showsVerticalScrollIndicator={false}
                 contentContainerStyle={{ paddingBottom: 128 }}
-                onScroll={handleScroll}
                 scrollEventThrottle={16}>
+                {/* Header Section */}
+                <View style={{ paddingBottom: 16 }}>
+                    <TouchableOpacity
+                        onPress={() => router.back()}
+                        style={{
+                            paddingVertical: 16,
+                            left: 0,
+                        }}>
+                        <Ionicons name="arrow-back" size={24} color={ThemedColor.text} />
+                    </TouchableOpacity>
+                    <View
+                        style={{
+                            flexDirection: "row",
+                            alignItems: "center",
+                            gap: 8,
+                            justifyContent: "space-between",
+                        }}>
+                        <ThemedText type="title" style={{ flexWrap: "wrap", width: "80%" }}>
+                            {name}
+                            {isRunning ? <MaterialIcons name="timer" size={24} color={ThemedColor.text} /> : ""}
+                        </ThemedText>
+                        <TouchableOpacity onPress={handleEditPress}>
+                            <PencilSimple size={24} color={ThemedColor.text} weight="regular" />
+                        </TouchableOpacity>
+                    </View>
+                    <View style={{ paddingBottom: 16 }} />
+                </View>
                 <KeyboardAvoidingView
                     behavior={Platform.OS === "ios" ? "padding" : "height"}
                     style={{ flex: 1 }}

--- a/frontend/app/(logged-in)/_layout.tsx
+++ b/frontend/app/(logged-in)/_layout.tsx
@@ -2,8 +2,8 @@
 
 import BackButton from "@/components/BackButton";
 import { useAuth } from "@/hooks/useAuth";
-import { Redirect, Slot, Stack, router } from "expo-router";
-import React, { useEffect, useState, useRef } from "react";
+import { Redirect, Slot, Stack, router, usePathname } from "expo-router";
+import React, { useCallback, useEffect, useState, useRef } from "react";
 
 import { ScrollView, View, ActivityIndicator, Animated, AppState, InteractionManager, LogBox } from "react-native";
 import { updateStreakWidget } from "@/widgets/updateStreakWidget";
@@ -38,6 +38,75 @@ import { ActiveTaskActivityFactory, DeadlineCountdownActivityFactory } from "@/w
 export const unstable_settings = {
     initialRouteName: "index",
 };
+
+/** Known push notification types sent by the backend. */
+type NotificationType =
+    | "encouragement"
+    | "congratulation"
+    | "task_completion"
+    | "friend_request"
+    | "friend_request_accepted"
+    | "new_post"
+    | "comment"
+    | "rings_closed"
+    | "TASK_MISSED"
+    | "TASK_REGENERATED"
+    | "ABSOLUTE"
+    | "RELATIVE"
+    | "FOLLOW_UP"
+    | "live_activity";
+
+interface NotificationData {
+    type?: NotificationType;
+    url?: string;
+    // Social
+    accepter_id?: string;
+    user_id?: string;
+    // Task
+    taskId?: string;
+    categoryId?: string;
+    taskName?: string;
+}
+
+/** Derive a navigation URL from push notification data. */
+function getNotificationRoute(data: NotificationData | undefined): string | null {
+    if (!data) return null;
+    // Explicit url always wins
+    if (data.url) return data.url;
+
+    switch (data.type) {
+        case "encouragement":
+            return "/(logged-in)/(tabs)/(task)/kudos?tab=encouragements";
+        case "congratulation":
+            return "/(logged-in)/(tabs)/(task)/kudos?tab=congratulations";
+        case "task_completion":
+            return "/(logged-in)/(tabs)/(task)/kudos?tab=congratulations";
+        case "friend_request":
+            return "/(logged-in)/(tabs)/(activity)";
+        case "friend_request_accepted":
+            if (data.accepter_id) {
+                return `/(logged-in)/(tabs)/(feed,search,profile)/account/${data.accepter_id}`;
+            }
+            return "/(logged-in)/(tabs)/(activity)";
+        case "new_post":
+            return "/(logged-in)/(tabs)/(feed)/feed";
+        case "comment":
+            return "/(logged-in)/(tabs)/(feed)/feed";
+        case "rings_closed":
+            if (data.user_id) {
+                return `/(logged-in)/(tabs)/(feed,search,profile)/account/${data.user_id}`;
+            }
+            return "/(logged-in)/(tabs)/(profile)/profile";
+        case "TASK_MISSED":
+        case "TASK_REGENERATED":
+        case "ABSOLUTE":
+        case "RELATIVE":
+        case "FOLLOW_UP":
+            return "/(logged-in)/(tabs)/(task)";
+        default:
+            return null;
+    }
+}
 
 export function ErrorBoundary({ error, retry }: ErrorBoundaryProps) {
     const ThemedColor = useThemeColor();
@@ -75,6 +144,9 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     const authInitialized = useRef(false);
     const [canTransition, setCanTransition] = useState(false);
     const ThemedColor = useThemeColor();
+    const pathname = usePathname();
+    const pathnameRef = useRef(pathname);
+    useEffect(() => { pathnameRef.current = pathname; }, [pathname]);
 
     // Handle initial authentication and routing - only run once
     useEffect(() => {
@@ -176,7 +248,7 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     useEffect(() => {
         initNotificationHandler();
         notificationListener.current = addNotificationListener((notification) => {
-            const data = notification.request.content.data;
+            const data = notification.request.content.data as NotificationData | undefined;
 
             // Handle live activity triggers from push notifications
             if (data?.type === 'live_activity') {
@@ -246,15 +318,18 @@ const layout = ({ children }: { children: React.ReactNode }) => {
                 duration: 3000,
                 renderContent: (props) => <DefaultToast {...props} />,
                 onPress: () => {
-                    if (data?.url) {
-                        router.push(data.url);
+                    // Don't navigate during onboarding — user can get stuck
+                    if (pathnameRef.current?.includes("onboarding")) return;
+                    const route = getNotificationRoute(data);
+                    if (route) {
+                        router.navigate(route);
                     }
                 }
             });
         });
 
         responseListener.current = addNotificationResponseListener((response) => {
-            const data = response.notification.request.content.data;
+            const data = response.notification.request.content.data as NotificationData | undefined;
 
             // Start live activity when user taps the notification
             if (data?.type === 'live_activity') {
@@ -289,8 +364,11 @@ const layout = ({ children }: { children: React.ReactNode }) => {
                 return;
             }
 
-            if (data?.url) {
-                router.push(data.url);
+            // Don't navigate during onboarding — user can get stuck
+            if (pathnameRef.current?.includes("onboarding")) return;
+            const route = getNotificationRoute(data);
+            if (route) {
+                router.navigate(route);
             }
         });
 

--- a/frontend/app/(logged-in)/posting/caption.tsx
+++ b/frontend/app/(logged-in)/posting/caption.tsx
@@ -1,7 +1,6 @@
-import React, { useRef, useState, useEffect } from "react";
+import React, { useState } from "react";
 import { useLocalSearchParams, router } from "expo-router";
-import { FlatList } from "react-native-gesture-handler";
-import { View, Image, Dimensions, TouchableOpacity } from "react-native";
+import { View, TouchableOpacity, ScrollView, KeyboardAvoidingView, Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedView } from "@/components/ThemedView";
 import LongTextInput from "@/components/inputs/LongTextInput";
@@ -16,14 +15,16 @@ import { useSelectedGroup } from "@/contexts/SelectedGroupContext";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
+import { Ionicons } from "@expo/vector-icons";
+import PostCardHeader from "@/components/cards/PostCardHeader";
+import PostCardMedia from "@/components/cards/PostCardMedia";
+import PostCardFooter from "@/components/cards/PostCardFooter";
 
 export default function Caption() {
     const insets = useSafeAreaInsets();
     const params = useLocalSearchParams();
     const photos = params.photos ? JSON.parse(params.photos as string) : [];
     const dualPhoto = params.dualPhoto ? (params.dualPhoto as string) : null;
-    const flatListRef = useRef<FlatList>(null);
-    const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0);
     const [data, setData] = useState({ caption: "" });
     const [isPosting, setIsPosting] = useState(false);
     const taskInfo = params.taskInfo ? JSON.parse(params.taskInfo as string) : null;
@@ -35,20 +36,13 @@ export default function Caption() {
     const [alertButtons, setAlertButtons] = useState<AlertButton[]>([]);
 
     const ThemedColor = useThemeColor();
-    const { updateUser } = useAuth();
+    const { user, updateUser } = useAuth();
     const { capture } = useAnalytics();
     const { selectedGroupId, selectedGroupName, getGroupIds } = useSelectedGroup();
 
     // Compute display text based on state
     const groupDisplayText = selectedGroupId === null ? "All Friends" : (selectedGroupName || "Selected Group");
 
-    // Use theme-appropriate placeholder
-    const isDark = ThemedColor.background === '#000000' || ThemedColor.background === '#1a1a1a';
-    const placeholderImage = isDark
-        ? require('@/assets/images/placeholder-dark.jpg')
-        : require('@/assets/images/placeholder-light.jpg');
-
-    const displayItems = photos.length > 0 ? photos : [placeholderImage];
     const hasActualPhotos = photos.length > 0;
     const handleCaptionChange = (text: string) => {
         setData({
@@ -178,92 +172,122 @@ export default function Caption() {
 
     return (
         <ThemedView style={{ flex: 1 }}>
-            <FlatList
-                ref={flatListRef}
-                data={displayItems}
-                horizontal
-                pagingEnabled
-                showsHorizontalScrollIndicator={false}
-                onMomentumScrollEnd={(event) => {
-                    const index = Math.round(event.nativeEvent.contentOffset.x / Dimensions.get("window").width);
-                    setCurrentPhotoIndex(index);
-                }}
-                renderItem={({ item }) => (
+            <KeyboardAvoidingView
+                style={{ flex: 1 }}
+                behavior={Platform.OS === "ios" ? "padding" : undefined}
+                keyboardVerticalOffset={0}>
+                <ScrollView
+                    style={{ flex: 1 }}
+                    contentContainerStyle={{
+                        paddingTop: insets.top,
+                        paddingBottom: 24 + insets.bottom,
+                    }}
+                    keyboardShouldPersistTaps="handled">
+                    {/* Header with back button */}
                     <View
                         style={{
-                            width: Dimensions.get("window").width,
+                            flexDirection: "row",
+                            alignItems: "center",
+                            paddingHorizontal: 16,
+                            paddingVertical: 12,
                         }}>
-                        <Image
-                            source={{ uri: item || Icons.coffee }}
+                        <TouchableOpacity
+                            onPress={() => router.back()}
+                            activeOpacity={0.7}
+                            style={{
+                                width: 36,
+                                height: 36,
+                                borderRadius: 18,
+                                backgroundColor: ThemedColor.lightened,
+                                alignItems: "center",
+                                justifyContent: "center",
+                            }}>
+                            <Ionicons name="arrow-back" size={20} color={ThemedColor.text} />
+                        </TouchableOpacity>
+                        <ThemedText type="subtitle" style={{ marginLeft: 12 }}>
+                            New Post
+                        </ThemedText>
+                    </View>
+
+                    {/* Post preview card */}
+                    <View style={{ paddingHorizontal: 16 }}>
+                        <View
+                            style={{
+                                borderRadius: 16,
+                                overflow: "hidden",
+                                backgroundColor: ThemedColor.background,
+                                shadowColor: "#000",
+                                shadowOffset: { width: 0, height: 4 },
+                                shadowOpacity: 0.15,
+                                shadowRadius: 12,
+                                elevation: 6,
+                            }}>
+                            <PostCardHeader
+                                icon={user?.profile_picture}
+                                name={user?.display_name ?? "You"}
+                                username={user?.handle ? `${user.handle}` : undefined}
+                                timeLabel="Just now"
+                                disableNavigation
+                            />
+                            {hasActualPhotos && (
+                                <PostCardMedia
+                                    images={photos}
+                                    dual={dualPhoto}
+                                />
+                            )}
+                            <PostCardFooter
+                                category={taskInfo?.categoryName}
+                                taskName={taskInfo?.name}
+                                readOnly
+                            />
+                        </View>
+                    </View>
+
+                    {/* Caption and options */}
+                    <View style={{ padding: 16, gap: 12 }}>
+                        <LongTextInput
+                            placeholder="Enter a caption"
+                            value={data.caption}
+                            setValue={handleCaptionChange}
+                            fontSize={16}
+                            minHeight={120}
+                        />
+                        <View
                             style={{
                                 width: "100%",
-                                height: "100%",
-                                position: "absolute",
-                                top: 0,
-                                left: 0,
+                                padding: 20,
+                                justifyContent: "space-between",
+                                backgroundColor: ThemedColor.lightened,
+                                borderRadius: 8,
+                                flexDirection: "row",
+                            }}>
+                            <ThemedText>Points Gained</ThemedText>
+                            <ThemedText>{taskInfo?.points || 1} points</ThemedText>
+                        </View>
+                        <TouchableOpacity
+                            style={{
+                                width: "100%",
+                                padding: 20,
+                                justifyContent: "space-between",
+                                backgroundColor: ThemedColor.lightened,
+                                borderRadius: 8,
+                                flexDirection: "row",
                             }}
-                            resizeMode="cover"
+                            onPress={() => {
+                                router.push("/(logged-in)/posting/groups");
+                            }}
+                            activeOpacity={0.7}>
+                            <ThemedText>Who can see this post?</ThemedText>
+                            <ThemedText>{groupDisplayText}</ThemedText>
+                        </TouchableOpacity>
+                        <PrimaryButton
+                            title={isPosting ? "Posting..." : "Post"}
+                            onPress={handlePost}
+                            disabled={isPosting}
                         />
                     </View>
-                )}
-                keyExtractor={(item, index) => index.toString()}
-            />
-            <View
-                style={{
-                    width: "100%",
-                    padding: 24,
-                    paddingBottom: 24 + insets.bottom,
-                    borderRadius: 20,
-                    borderTopLeftRadius: 20,
-                    borderTopRightRadius: 20,
-                    backgroundColor: ThemedColor.background,
-                }}>
-                <LongTextInput
-                    placeholder="Enter a caption"
-                    value={data.caption}
-                    setValue={handleCaptionChange}
-                    fontSize={16}
-                    minHeight={300}
-                />
-                <View
-                    style={{
-                        gap: 8,
-                    }}>
-                    <View
-                        style={{
-                            width: "100%",
-                            padding: 20,
-                            justifyContent: "space-between",
-                            backgroundColor: ThemedColor.lightened,
-                            borderRadius: 8,
-                            flexDirection: "row",
-                        }}>
-                        <ThemedText>Points Gained</ThemedText>
-                        <ThemedText>{taskInfo?.points || 1} points</ThemedText>
-                    </View>
-                    <TouchableOpacity
-                        style={{
-                            width: "100%",
-                            padding: 20,
-                            justifyContent: "space-between",
-                            backgroundColor: ThemedColor.lightened,
-                            borderRadius: 8,
-                            flexDirection: "row",
-                        }}
-                        onPress={() => {
-                            router.push("/(logged-in)/posting/groups");
-                        }}
-                        activeOpacity={0.7}>
-                        <ThemedText>Who can see this post?</ThemedText>
-                        <ThemedText>{groupDisplayText}</ThemedText>
-                    </TouchableOpacity>
-                    <PrimaryButton
-                        title={isPosting ? "Posting..." : "Post"}
-                        onPress={handlePost}
-                        disabled={isPosting}
-                    />
-                </View>
-            </View>
+                </ScrollView>
+            </KeyboardAvoidingView>
             <CustomAlert
                 visible={alertVisible}
                 setVisible={setAlertVisible}

--- a/frontend/app/(onboarding)/calendar.tsx
+++ b/frontend/app/(onboarding)/calendar.tsx
@@ -152,7 +152,7 @@ const CalendarOnboarding = () => {
                 }]}>
                     <CalendarBlank size={24} color={ThemedColor.primary} weight="fill" />
                     <ThemedText style={[styles.statText, { color: ThemedColor.text }]}>
-                        Most Kindred users link their calendar to stay on top of deadlines and plan their week
+                        Kindred users who connect their calendar complete their tasks 3x as often
                     </ThemedText>
                 </Animated.View>
             </View>

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -77,12 +77,12 @@ try {
 const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
-            refetchOnWindowFocus: false,
-            refetchOnMount: false,
-            refetchOnReconnect: false,
+            refetchOnWindowFocus: true,
+            refetchOnMount: true,
+            refetchOnReconnect: true,
             retry: false,
-            staleTime: 1000 * 60 * 5, // 5 minutes
-            gcTime: 1000 * 60 * 10, // 10 minutes - garbage collect unused data after this time
+            staleTime: 1000 * 30, // 30 seconds - data considered fresh
+            gcTime: 1000 * 60 * 5, // 5 minutes - garbage collect unused data
         },
     },
 });

--- a/frontend/components/cards/RingsClosedFeedCard.tsx
+++ b/frontend/components/cards/RingsClosedFeedCard.tsx
@@ -1,0 +1,286 @@
+import React, { useState, useCallback, useMemo } from "react";
+import { View, StyleSheet, TouchableOpacity, Platform } from "react-native";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useAuth } from "@/hooks/useAuth";
+import CachedImage from "../CachedImage";
+import * as Haptics from "expo-haptics";
+import { HORIZONTAL_PADDING } from "@/constants/spacing";
+import { router } from "expo-router";
+import { Trophy } from "phosphor-react-native";
+import CongratulateModal from "@/components/modals/CongratulateModal";
+
+type RingsClosedFeedCardProps = {
+    id: string;
+    timestamp: string;
+    content: string;
+    user: {
+        _id: string;
+        handle: string;
+        display_name: string;
+        profile_picture: string;
+    };
+};
+
+const RingsClosedFeedCard = React.memo(({
+    id,
+    timestamp,
+    content,
+    user,
+}: RingsClosedFeedCardProps) => {
+    const ThemedColor = useThemeColor();
+    const { user: currentUser } = useAuth();
+    const [showCongratulateModal, setShowCongratulateModal] = useState(false);
+
+    // Calculate time ago
+    const timeAgo = useMemo(() => {
+        const now = new Date();
+        const itemTime = new Date(timestamp);
+        const diffMs = now.getTime() - itemTime.getTime();
+        const diffMinutes = Math.floor(diffMs / (1000 * 60));
+        const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+        const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+        if (diffMinutes < 1) return "now";
+        if (diffMinutes < 60) return `${diffMinutes}m`;
+        if (diffHours < 24) return `${diffHours}h`;
+        if (diffDays < 7) return `${diffDays}d`;
+        const weeks = Math.floor(diffDays / 7);
+        return `${weeks}w`;
+    }, [timestamp]);
+
+    const handleUserPress = useCallback(async () => {
+        try {
+            if (Platform.OS === "ios") {
+                await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            }
+        } catch (error) {
+            // ignored
+        }
+        router.push(`/account/${user._id}`);
+    }, [user._id]);
+
+    const handleCongratulatePress = useCallback(async () => {
+        if (!currentUser?._id) {
+            return;
+        }
+
+        if (currentUser._id === user._id) {
+            return;
+        }
+
+        try {
+            if (Platform.OS === "ios") {
+                await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            }
+        } catch (error) {
+            // ignored
+        }
+
+        setShowCongratulateModal(true);
+    }, [currentUser, user._id]);
+
+    const isOwnItem = currentUser?._id === user._id;
+
+    const styles = useMemo(() => StyleSheet.create({
+        container: {
+            backgroundColor: ThemedColor.background,
+            paddingVertical: 12,
+            borderBottomWidth: 1,
+            borderBottomColor: ThemedColor.tertiary,
+        },
+        content: {
+            paddingVertical: 12,
+        },
+        header: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            paddingHorizontal: HORIZONTAL_PADDING,
+            marginBottom: 18,
+        },
+        userInfo: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 12,
+            flex: 1,
+        },
+        userIcon: {
+            width: 48,
+            height: 48,
+            borderRadius: 24,
+        },
+        userDetails: {
+            flex: 1,
+            gap: 3,
+        },
+        userName: {
+            fontSize: 16,
+            fontWeight: "400",
+            color: ThemedColor.text,
+        },
+        userHandle: {
+            fontSize: 14,
+            fontWeight: "300",
+            color: ThemedColor.caption,
+        },
+        timeText: {
+            fontSize: 12,
+            fontWeight: "400",
+            color: ThemedColor.caption,
+        },
+        categorySection: {
+            paddingHorizontal: HORIZONTAL_PADDING,
+            marginBottom: 18,
+            gap: 12,
+        },
+        taskIndicator: {
+            fontSize: 13,
+            fontWeight: "300",
+            letterSpacing: -0.13,
+            color: ThemedColor.caption,
+        },
+        categoryRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+        },
+        categoryInfo: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 8,
+            flexWrap: "wrap",
+            maxWidth: "60%",
+            flex: 1,
+        },
+        categoryText: {
+            fontSize: 16,
+            fontWeight: "400",
+            letterSpacing: -0.16,
+            color: ThemedColor.text,
+        },
+        dot: {
+            width: 4,
+            height: 4,
+            borderRadius: 2,
+            backgroundColor: ThemedColor.primary,
+        },
+        congratulateButton: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 8,
+        },
+        congratulateText: {
+            fontSize: 14,
+            fontWeight: "400",
+            letterSpacing: -0.14,
+            color: ThemedColor.primary,
+        },
+        contentSection: {
+            paddingHorizontal: HORIZONTAL_PADDING,
+        },
+        taskContent: {
+            fontSize: 16,
+            fontWeight: "400",
+            lineHeight: 20,
+            color: ThemedColor.text,
+        },
+    }), [ThemedColor]);
+
+    return (
+        <View style={styles.container}>
+            <View style={styles.content}>
+                {/* User Header */}
+                <View style={styles.header}>
+                    <TouchableOpacity
+                        style={styles.userInfo}
+                        activeOpacity={0.4}
+                        onPress={handleUserPress}>
+                        <CachedImage
+                            source={{ uri: user.profile_picture }}
+                            style={styles.userIcon}
+                            variant="thumbnail"
+                            cachePolicy="memory-disk"
+                        />
+                        <View style={styles.userDetails}>
+                            <ThemedText style={styles.userName}>
+                                {user.display_name}
+                            </ThemedText>
+                            <ThemedText style={styles.userHandle}>
+                                {user.handle}
+                            </ThemedText>
+                        </View>
+                    </TouchableOpacity>
+                    <ThemedText style={styles.timeText}>
+                        {timeAgo}
+                    </ThemedText>
+                </View>
+
+                {/* Category Section with Congratulate Button */}
+                <View style={styles.categorySection}>
+                    <ThemedText style={styles.taskIndicator}>
+                        closed all their rings
+                    </ThemedText>
+                    <View style={styles.categoryRow}>
+                        <View style={styles.categoryInfo}>
+                            <ThemedText style={styles.categoryText}>
+                                Plan
+                            </ThemedText>
+                            <View style={styles.dot} />
+                            <ThemedText style={styles.categoryText}>
+                                Do
+                            </ThemedText>
+                            <View style={styles.dot} />
+                            <ThemedText style={styles.categoryText}>
+                                Share
+                            </ThemedText>
+                        </View>
+                        {!isOwnItem && (
+                            <TouchableOpacity
+                                style={[
+                                    styles.congratulateButton,
+                                    !currentUser?._id && { opacity: 0.5 },
+                                ]}
+                                onPress={handleCongratulatePress}
+                                disabled={!currentUser?._id}>
+                                <Trophy size={20} color={ThemedColor.primary} weight="regular" />
+                                <ThemedText style={styles.congratulateText}>
+                                    {!currentUser?._id ? "Login" : "Congratulate"}
+                                </ThemedText>
+                            </TouchableOpacity>
+                        )}
+                    </View>
+                </View>
+
+                {/* Content */}
+                <View style={styles.contentSection}>
+                    <ThemedText style={styles.taskContent}>
+                        {content}
+                    </ThemedText>
+                </View>
+
+                {/* Congratulate Modal */}
+                <CongratulateModal
+                    visible={showCongratulateModal}
+                    setVisible={setShowCongratulateModal}
+                    task={{
+                        id: id,
+                        content: "Closed all rings",
+                        value: 0,
+                        priority: 0,
+                        categoryId: "",
+                    }}
+                    congratulationConfig={{
+                        userHandle: user.handle,
+                        receiverId: user._id,
+                        categoryName: "Rings",
+                    }}
+                />
+            </View>
+        </View>
+    );
+});
+
+RingsClosedFeedCard.displayName = "RingsClosedFeedCard";
+
+export default RingsClosedFeedCard;

--- a/frontend/components/inputs/AnimatedTabs.tsx
+++ b/frontend/components/inputs/AnimatedTabs.tsx
@@ -88,15 +88,26 @@ type AnimatedTabContentProps = {
     setActiveTab?: (index: number) => void;
     children: React.ReactNode[];
     flex?: boolean;
+    /** When true, tabs that have never been active render as empty until first visited */
+    lazy?: boolean;
 };
 
 const SWIPE_VELOCITY_THRESHOLD = 500;
 const SWIPE_DISTANCE_FRACTION = 0.3;
 
-export function AnimatedTabContent({ activeTab, setActiveTab, children, flex }: AnimatedTabContentProps) {
+export function AnimatedTabContent({ activeTab, setActiveTab, children, flex, lazy }: AnimatedTabContentProps) {
     const [layoutWidth, setLayoutWidth] = useState(0);
     const translateX = useSharedValue(0);
     const tabCount = React.Children.count(children);
+
+    // Track which tabs have been visited (for lazy rendering)
+    const [visitedTabs, setVisitedTabs] = useState<Set<number>>(() => new Set([activeTab]));
+    useEffect(() => {
+        setVisitedTabs((prev) => {
+            if (prev.has(activeTab)) return prev;
+            return new Set(prev).add(activeTab);
+        });
+    }, [activeTab]);
 
     const activeTabSV = useSharedValue(activeTab);
     const widthSV = useSharedValue(0);
@@ -165,8 +176,10 @@ export function AnimatedTabContent({ activeTab, setActiveTab, children, flex }: 
             <View style={[styles.contentClip, fillStyle]} onLayout={handleLayout}>
                 {layoutWidth > 0 && (
                     <Animated.View style={[styles.contentRow, fillStyle, slidingStyle]}>
-                        {React.Children.map(children, (child) => (
-                            <View style={{ width: layoutWidth }}>{child}</View>
+                        {React.Children.map(children, (child, index) => (
+                            <View style={{ width: layoutWidth }}>
+                                {lazy && !visitedTabs.has(index) ? null : child}
+                            </View>
                         ))}
                     </Animated.View>
                 )}

--- a/frontend/components/modals/EncourageModal.tsx
+++ b/frontend/components/modals/EncourageModal.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useRef, useEffect } from "react";
-import { View, StyleSheet, TouchableOpacity, Image, Dimensions, Modal, Animated } from "react-native";
+import { View, StyleSheet, TouchableOpacity, Image, Dimensions, Modal, Animated, Platform } from "react-native";
+import * as Haptics from "expo-haptics";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import DefaultModal from "./DefaultModal";
@@ -272,6 +273,11 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     encouragements: currentKudosRewards.encouragements + 1
                 }
             });
+
+            // Haptic feedback on successful send
+            if (Platform.OS === "ios") {
+                Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            }
 
             // Close modal first, enable confetti, then trigger it
             setVisible(false);

--- a/frontend/components/modals/RewardRedemptionModal.tsx
+++ b/frontend/components/modals/RewardRedemptionModal.tsx
@@ -57,7 +57,7 @@ const RewardRedemptionModal = (props: Props) => {
     }, [visible]);
 
     return (
-        <DefaultModal visible={visible} setVisible={setVisible} snapPoints={["55%"]}>
+        <DefaultModal visible={visible} setVisible={setVisible} snapPoints={["90%"]}>
             <View style={styles.container}>
                 <View style={styles.header}>
                     <ThemedText type="title" style={{ marginBottom: 16, fontSize: 28 }}>

--- a/frontend/components/modals/RewardUnboxingModal.tsx
+++ b/frontend/components/modals/RewardUnboxingModal.tsx
@@ -5,6 +5,7 @@ import {
     Modal,
     Dimensions,
     Animated,
+    Platform,
 } from "react-native";
 import {
     Microphone,
@@ -17,6 +18,7 @@ import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import PrimaryButton from "@/components/inputs/PrimaryButton";
 import ConfettiCannon from "react-native-confetti-cannon";
+import * as Haptics from "expo-haptics";
 
 const CREDIT_TYPES = [
     { key: "voice", label: "Voice Credits", Icon: Microphone },
@@ -33,11 +35,6 @@ interface RewardUnboxingModalProps {
     rewardAmount: number;
     newTotal?: number;
 }
-
-const SPIN_DURATION = 1500;
-const DECEL_DURATION = 1000;
-const ICON_INTERVAL = 80;
-const TOTAL_SPIN_MS = SPIN_DURATION + DECEL_DURATION;
 
 export default function RewardUnboxingModal({
     visible,
@@ -59,10 +56,16 @@ export default function RewardUnboxingModal({
     const centerScale = useRef(new Animated.Value(1)).current;
     const centerGlow = useRef(new Animated.Value(0)).current;
     const rewardOpacity = useRef(new Animated.Value(0)).current;
+    const rewardScale = useRef(new Animated.Value(0.5)).current;
     const headerOpacity = useRef(new Animated.Value(0)).current;
+    const totalOpacity = useRef(new Animated.Value(0)).current;
 
     const winningIndex = CREDIT_TYPES.findIndex((c) => c.key === rewardType);
     const safeWinningIndex = winningIndex >= 0 ? winningIndex : 0;
+
+    const haptic = (style: Haptics.ImpactFeedbackStyle) => {
+        if (Platform.OS === "ios") Haptics.impactAsync(style);
+    };
 
     useEffect(() => {
         if (!visible) {
@@ -73,7 +76,9 @@ export default function RewardUnboxingModal({
             centerScale.setValue(1);
             centerGlow.setValue(0);
             rewardOpacity.setValue(0);
+            rewardScale.setValue(0.5);
             headerOpacity.setValue(0);
+            totalOpacity.setValue(0);
             return;
         }
 
@@ -84,59 +89,108 @@ export default function RewardUnboxingModal({
             useNativeDriver: true,
         }).start();
 
+        // Decelerating spin — starts fast, slows down
         const len = CREDIT_TYPES.length;
         let tick = 0;
+        let currentInterval = 60; // start fast
+        let spinTimer: ReturnType<typeof setTimeout>;
 
-        const interval = setInterval(() => {
-            tick++;
-            setLeftIndex(tick % len);
-            setCenterIndex((tick + 1) % len);
-            setRightIndex((tick + 2) % len);
-        }, ICON_INTERVAL);
+        const scheduleTick = () => {
+            spinTimer = setTimeout(() => {
+                tick++;
+                if (!leftStopped) setLeftIndex(tick % len);
+                setCenterIndex((tick + 1) % len);
+                if (!rightStopped) setRightIndex((tick + 2) % len);
 
+                // Light haptic on each tick for ratchet feel
+                if (tick % 3 === 0) haptic(Haptics.ImpactFeedbackStyle.Light);
+
+                // Decelerate after 1.5s
+                if (tick > 20) {
+                    currentInterval = Math.min(currentInterval + 8, 250);
+                }
+
+                scheduleTick();
+            }, currentInterval);
+        };
+        scheduleTick();
+
+        // Left stops first at 1.8s
         const leftTimer = setTimeout(() => {
             const leftLand = (safeWinningIndex + len - 1) % len;
             setLeftIndex(leftLand);
             setLeftStopped(true);
-        }, SPIN_DURATION);
+            haptic(Haptics.ImpactFeedbackStyle.Medium);
+        }, 1800);
 
+        // Right stops at 2.5s
         const rightTimer = setTimeout(() => {
             const rightLand = (safeWinningIndex + 1) % len;
             setRightIndex(rightLand);
             setRightStopped(true);
-        }, SPIN_DURATION + 400);
+            haptic(Haptics.ImpactFeedbackStyle.Medium);
+        }, 2500);
 
+        // Center stops last at 3.2s — big reveal
         const centerTimer = setTimeout(() => {
-            clearInterval(interval);
+            clearTimeout(spinTimer);
             setCenterIndex(safeWinningIndex);
             setCenterStopped(true);
 
+            // Heavy haptic for the landing
+            if (Platform.OS === "ios") {
+                Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+            }
+
+            // Dramatic reveal animation
             Animated.parallel([
                 Animated.spring(centerScale, {
-                    toValue: 1.15,
-                    friction: 4,
-                    tension: 100,
+                    toValue: 1.3,
+                    friction: 3,
+                    tension: 120,
                     useNativeDriver: true,
                 }),
                 Animated.timing(centerGlow, {
                     toValue: 1,
+                    duration: 500,
+                    useNativeDriver: true,
+                }),
+            ]).start();
+
+            // Reward text appears after a beat
+            setTimeout(() => {
+                Animated.parallel([
+                    Animated.spring(rewardScale, {
+                        toValue: 1,
+                        friction: 4,
+                        tension: 80,
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(rewardOpacity, {
+                        toValue: 1,
+                        duration: 400,
+                        useNativeDriver: true,
+                    }),
+                ]).start();
+
+                haptic(Haptics.ImpactFeedbackStyle.Light);
+            }, 400);
+
+            // Total text + confetti + done button
+            setTimeout(() => {
+                Animated.timing(totalOpacity, {
+                    toValue: 1,
                     duration: 400,
                     useNativeDriver: true,
-                }),
-                Animated.timing(rewardOpacity, {
-                    toValue: 1,
-                    duration: 500,
-                    delay: 200,
-                    useNativeDriver: true,
-                }),
-            ]).start(() => {
+                }).start();
+
                 setPhase("revealed");
                 confettiRef.current?.start();
-            });
-        }, TOTAL_SPIN_MS);
+            }, 900);
+        }, 3200);
 
         return () => {
-            clearInterval(interval);
+            clearTimeout(spinTimer);
             clearTimeout(leftTimer);
             clearTimeout(rightTimer);
             clearTimeout(centerTimer);
@@ -204,7 +258,7 @@ export default function RewardUnboxingModal({
                                 { opacity: centerGlow },
                             ]}
                         />
-                        <CenterIcon size={32} color="#fff" weight="fill" />
+                        <CenterIcon size={36} color="#fff" weight="fill" />
                     </Animated.View>
 
                     <View
@@ -218,19 +272,30 @@ export default function RewardUnboxingModal({
                     </View>
                 </View>
 
-                <Animated.View style={[styles.rewardSection, { opacity: rewardOpacity }]}>
+                <Animated.View
+                    style={[
+                        styles.rewardSection,
+                        {
+                            opacity: rewardOpacity,
+                            transform: [{ scale: rewardScale }],
+                        },
+                    ]}
+                >
                     <ThemedText style={styles.rewardAmount}>
                         +{rewardAmount}
                     </ThemedText>
-                    <ThemedText style={styles.rewardSubtitle}>
+                    <ThemedText style={styles.rewardLabel}>
                         {winningType.label}
                     </ThemedText>
-                    {newTotal != null && (
-                        <ThemedText type="caption" style={{ color: "#E9D5FF", marginTop: 8 }}>
+                </Animated.View>
+
+                {newTotal != null && (
+                    <Animated.View style={[styles.totalBadge, { opacity: totalOpacity }]}>
+                        <ThemedText style={styles.totalText}>
                             You now have {newTotal} {winningType.label.toLowerCase()}
                         </ThemedText>
-                    )}
-                </Animated.View>
+                    </Animated.View>
+                )}
 
                 {phase === "revealed" && (
                     <View style={styles.buttonContainer}>
@@ -243,13 +308,13 @@ export default function RewardUnboxingModal({
 
                 <ConfettiCannon
                     ref={confettiRef}
-                    count={60}
-                    origin={{ x: screenWidth / 2, y: screenHeight * 0.3 }}
+                    count={120}
+                    origin={{ x: screenWidth / 2, y: -20 }}
                     explosionSpeed={350}
                     fadeOut
                     autoStart={false}
-                    fallSpeed={1200}
-                    colors={["#854DFF", "#A855F7", "#C084FC", "#E9D5FF", "#fff"]}
+                    fallSpeed={2500}
+                    colors={["#854DFF", "#A855F7", "#C084FC", "#E9D5FF", "#FFD700", "#fff"]}
                 />
             </View>
         </Modal>
@@ -290,8 +355,8 @@ const styles = StyleSheet.create({
         opacity: 0.4,
     },
     tileCenter: {
-        width: 72,
-        height: 72,
+        width: 80,
+        height: 80,
         overflow: "hidden",
     },
     centerGlow: {
@@ -302,17 +367,32 @@ const styles = StyleSheet.create({
     },
     rewardSection: {
         alignItems: "center",
-        gap: 4,
+        gap: 2,
     },
     rewardAmount: {
-        fontSize: 24,
-        fontWeight: "700",
+        fontSize: 48,
+        fontWeight: "800",
         color: "#fff",
         fontFamily: "Outfit",
+        letterSpacing: -1,
     },
-    rewardSubtitle: {
-        fontSize: 13,
+    rewardLabel: {
+        fontSize: 18,
         color: "#C084FC",
+        fontWeight: "600",
+        fontFamily: "Outfit",
+    },
+    totalBadge: {
+        backgroundColor: "#854DFF20",
+        paddingHorizontal: 20,
+        paddingVertical: 10,
+        borderRadius: 12,
+        borderWidth: 1,
+        borderColor: "#854DFF40",
+    },
+    totalText: {
+        fontSize: 15,
+        color: "#E9D5FF",
         fontWeight: "500",
         fontFamily: "Outfit",
     },

--- a/frontend/components/profile/FollowRequestsSection.tsx
+++ b/frontend/components/profile/FollowRequestsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback, useImperativeHandle, forwardRef } from "react";
 import { View, Pressable } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import UserInfoFollowRequest from "@/components/UserInfo/UserInfoFollowRequest";
@@ -19,18 +19,23 @@ interface FollowRequestsSectionProps {
     maxVisible?: number; // How many requests to show before "see all"
 }
 
-export const FollowRequestsSection = ({ styles, maxVisible = 3 }: FollowRequestsSectionProps) => {
+export interface FollowRequestsSectionHandle {
+    refresh: () => Promise<void>;
+}
+
+export const FollowRequestsSection = forwardRef<FollowRequestsSectionHandle, FollowRequestsSectionProps>(
+    ({ styles, maxVisible = 3 }, ref) => {
     const [requests, setRequests] = useState<FollowRequestProps[]>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
-    const fetchFollowRequests = async () => {
+    const fetchFollowRequests = useCallback(async () => {
         try {
             setLoading(true);
             setError(null);
-            
+
             const connections = await getConnectionsByReceiverAPI();
-            
+
             // Transform API response to match FollowRequestProps interface
             const transformedRequests: FollowRequestProps[] = connections.map((connection) => ({
                 name: connection.requester.name,
@@ -39,7 +44,7 @@ export const FollowRequestsSection = ({ styles, maxVisible = 3 }: FollowRequests
                 userId: connection.requester._id,
                 connectionID: connection.id,
             }));
-            
+
             setRequests(transformedRequests);
         } catch (err) {
             console.error('Failed to fetch follow requests:', err);
@@ -48,7 +53,11 @@ export const FollowRequestsSection = ({ styles, maxVisible = 3 }: FollowRequests
         } finally {
             setLoading(false);
         }
-    };
+    }, []);
+
+    useImperativeHandle(ref, () => ({
+        refresh: fetchFollowRequests,
+    }), [fetchFollowRequests]);
 
     const removeRequest = (connectionID: string) => {
         setRequests(prev => prev.filter(request => request.connectionID !== connectionID));
@@ -56,11 +65,11 @@ export const FollowRequestsSection = ({ styles, maxVisible = 3 }: FollowRequests
 
     useEffect(() => {
         fetchFollowRequests();
-    }, []);
+    }, [fetchFollowRequests]);
 
     // Don't render anything while loading
     if (loading) return null;
-    
+
     // Don't render if there's an error or no requests
     if (error || requests.length === 0) return null;
 
@@ -88,5 +97,4 @@ export const FollowRequestsSection = ({ styles, maxVisible = 3 }: FollowRequests
             ))}
         </View>
     );
-};
-
+});

--- a/frontend/components/profile/ProfileGallery.tsx
+++ b/frontend/components/profile/ProfileGallery.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useEffect, useState, useRef, useCallback, useImperativeHandle, forwardRef } from "react";
 import { View, StyleSheet, TouchableOpacity, Animated, Image, Dimensions, useColorScheme, ActivityIndicator } from "react-native";
-import { FlatList } from "react-native";
 import { deletePost, getAllPosts, getUserPosts } from "@/api/post";
 import { router } from "expo-router";
 import { useAuth } from "@/hooks/useAuth";
@@ -9,6 +8,11 @@ import CachedImage from "../CachedImage";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
+
+export interface ProfileGalleryHandle {
+    loadMore: () => void;
+    hasMore: boolean;
+}
 
 interface ProfileGalleryProps {
     userId?: string;
@@ -100,7 +104,7 @@ const EmptyGallery = ({ ThemedColor }: { ThemedColor: any }) => {
 
 const GALLERY_PAGE_SIZE = 12;
 
-const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
+const ProfileGalleryComponent = forwardRef<ProfileGalleryHandle, ProfileGalleryProps>(({ userId, images }, ref) => {
     const { user } = useAuth();
     const ThemedColor = useThemeColor();
     const [postImages, setPostImages] = useState<PostImage[]>([]);
@@ -201,6 +205,11 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
             setIsLoadingMore(false);
         }
     }, [hasMore, isLoading, userId, offset]);
+
+    useImperativeHandle(ref, () => ({
+        loadMore: handleLoadMore,
+        hasMore,
+    }), [hasMore, handleLoadMore]);
 
     const handleImagePress = (postId: string) => {
         if (postId.startsWith("legacy-")) {
@@ -309,39 +318,6 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
         showPostOptions(postId, postUserId);
     };
 
-    // Memoize render functions BEFORE any conditional returns
-    const renderItem = React.useCallback(({ item }: { item: PostImage }) => {
-        const isDeleting = deletingPosts.has(item.postId);
-
-        return (
-            <TouchableOpacity
-                style={[styles.galleryItem, isDeleting && styles.deletingItem]}
-                onPress={() => handleImagePress(item.postId)}
-                onLongPress={() => handleImageLongPress(item.postId, item.postUserId)}
-                delayLongPress={500}
-                activeOpacity={isDeleting ? 1 : 0.8}>
-                <CachedImage
-                    style={[styles.galleryImage, isDeleting && styles.deletingImage]}
-                    source={{
-                        uri: item.imageUrl,
-                    }}
-                    variant="thumbnail"
-                    cachePolicy="disk"
-                    transition={100}
-                />
-            </TouchableOpacity>
-        );
-    }, [deletingPosts, handleImagePress, handleImageLongPress]);
-
-    const renderFooter = useCallback(() => {
-        if (!isLoadingMore) return null;
-        return (
-            <View style={{ padding: 16, alignItems: "center" }}>
-                <ActivityIndicator size="small" color={ThemedColor.primary} />
-            </View>
-        );
-    }, [isLoadingMore, ThemedColor.primary]);
-
     // Show skeleton while loading
     if (isLoading) {
         return <GallerySkeleton ThemedColor={ThemedColor} />;
@@ -352,23 +328,51 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
         return <EmptyGallery ThemedColor={ThemedColor} />;
     }
 
+    // Plain grid instead of FlatList — this component is nested inside a
+    // parent ScrollView so FlatList can't virtualize anyway. We paginate
+    // in batches of 12 and lazy-render via the tab, so this is fine.
+    const rows: PostImage[][] = [];
+    for (let i = 0; i < postImages.length; i += 3) {
+        rows.push(postImages.slice(i, i + 3));
+    }
+
     return (
         <>
-            <FlatList
-                numColumns={3}
-                data={postImages}
-                renderItem={renderItem}
-                keyExtractor={(item, index) => `gallery-${item.postId}-${index}`}
-                showsVerticalScrollIndicator={false}
-                contentContainerStyle={styles.galleryContainer}
-                removeClippedSubviews={true}
-                onEndReached={handleLoadMore}
-                onEndReachedThreshold={0.3}
-                ListFooterComponent={renderFooter}
-                initialNumToRender={9}
-                maxToRenderPerBatch={6}
-                windowSize={5}
-            />
+            <View style={styles.galleryContainer}>
+                {rows.map((row, rowIndex) => (
+                    <View key={`row-${rowIndex}`} style={styles.galleryRow}>
+                        {row.map((item, colIndex) => {
+                            const isDeleting = deletingPosts.has(item.postId);
+                            return (
+                                <TouchableOpacity
+                                    key={`gallery-${item.postId}-${rowIndex * 3 + colIndex}`}
+                                    style={[styles.galleryItem, isDeleting && styles.deletingItem]}
+                                    onPress={() => handleImagePress(item.postId)}
+                                    onLongPress={() => handleImageLongPress(item.postId, item.postUserId)}
+                                    delayLongPress={500}
+                                    activeOpacity={isDeleting ? 1 : 0.8}>
+                                    <CachedImage
+                                        style={[styles.galleryImage, isDeleting && styles.deletingImage]}
+                                        source={{ uri: item.imageUrl }}
+                                        variant="thumbnail"
+                                        cachePolicy="disk"
+                                        transition={100}
+                                    />
+                                </TouchableOpacity>
+                            );
+                        })}
+                        {/* Fill empty cells in last row */}
+                        {row.length < 3 && Array.from({ length: 3 - row.length }).map((_, i) => (
+                            <View key={`empty-${i}`} style={styles.galleryItem} />
+                        ))}
+                    </View>
+                ))}
+                {isLoadingMore && (
+                    <View style={styles.loadMoreSpinner}>
+                        <ActivityIndicator size="small" color={ThemedColor.primary} />
+                    </View>
+                )}
+            </View>
             {alertVisible && (
                 <CustomAlert
                     visible={alertVisible}
@@ -380,7 +384,7 @@ const ProfileGalleryComponent = ({ userId, images }: ProfileGalleryProps) => {
             )}
         </>
     );
-}
+});
 
 const styles = StyleSheet.create({
     galleryItem: {
@@ -390,6 +394,9 @@ const styles = StyleSheet.create({
     },
     galleryContainer: {
         padding: 2,
+    },
+    galleryRow: {
+        flexDirection: "row",
     },
     galleryImage: {
         aspectRatio: 1,
@@ -412,8 +419,7 @@ const styles = StyleSheet.create({
         margin: 2,
         borderRadius: 4,
     },
-    // Footer loader
-    footerLoader: {
+    loadMoreSpinner: {
         paddingVertical: 16,
         alignItems: "center",
     },

--- a/frontend/components/profile/ProfileHeader.tsx
+++ b/frontend/components/profile/ProfileHeader.tsx
@@ -37,7 +37,12 @@ export default function ProfileHeader({ displayName, handle, userId, showCameraB
                 </View>
             )}
             <View style={styles.nameContainer}>
-                <ThemedText type="hero" style={styles.displayName}>
+                <ThemedText
+                    type="hero"
+                    style={styles.displayName}
+                    numberOfLines={1}
+                    adjustsFontSizeToFit
+                    minimumFontScale={0.6}>
                     {displayName}
                 </ThemedText>
                 <ThemedText style={[styles.handle, { color: ThemedColor.caption }]}>{handle}</ThemedText>


### PR DESCRIPTION
## Summary
- **Post caption screen**: Added back button and post preview with user avatar using PostCard components (fixes stuck screen on skip)
- **Profile name**: Auto-shrink long display names so they fit on one line
- **Activity page**: Moved "total tasks completed this year" above recurring tasks filter
- **Task detail**: Removed sticky header that was blocking scroll on long notes
- **Kudos claim modal**: Increased height from 55% to 90% so claim buttons are reachable
- **Kudos page**: Removed KudosProgressCard headers (cleanup)
- **Onboarding calendar**: Stronger CTA copy — "complete tasks 3x as often"
- **Feed**: Rings closed cards, chronological merge, notification improvements
- **Other**: Blueprint, profile gallery, reward unboxing, and misc UI refinements

## Test plan
- [ ] Open post flow, tap Skip on camera → verify back button works and post preview shows avatar
- [ ] View profile with long display name → verify text shrinks to fit
- [ ] Open My Activity → verify yearly total appears above recurring tasks
- [ ] Open a task with long notes → verify page scrolls freely
- [ ] Tap Claim on kudos reward → verify modal is tall enough to interact with
- [ ] Open kudos page → verify progress cards are removed
- [ ] Go through onboarding calendar step → verify new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)