### PR TITLE
fix: consolidate task long-press menu and wire up swipe actions

### DIFF
--- a/frontend/components/cards/SwipableTaskCard.tsx
+++ b/frontend/components/cards/SwipableTaskCard.tsx
@@ -1,6 +1,6 @@
 // Wrapper for TaskCard that allows for swiping to delete
 
-import React from "react";
+import React, { useState } from "react";
 
 import TaskCard from "./TaskCard";
 
@@ -12,6 +12,7 @@ import { useThemeColor } from "@/hooks/useThemeColor";
 import { markAsCompletedAPI, activateTaskAPI, setWorkingAPI } from "@/api/task";
 import { ActiveTaskActivityFactory } from "@/widgets/widgetUpdaters";
 import { useTasks } from "@/contexts/tasksContext";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
 import { hideToastable, showToastable } from "react-native-toastable";
 import TaskToast from "../ui/TaskToast";
 import DefaultToast from "../ui/DefaultToast";
@@ -22,6 +23,8 @@ import { AttachStep } from "react-native-spotlight-tour";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
+import DeadlineBottomSheetModal from "../modals/DeadlineBottomSheetModal";
+import ReminderBottomSheetModal from "../modals/ReminderBottomSheetModal";
 
 type Props = {
     redirect?: boolean;
@@ -38,11 +41,28 @@ const SwipableTaskCard = ({
     categoryName,
     highlightContent = false,
 }: Props) => {
-    const { removeFromCategory, addToCategory, setShowConfetti, categories } = useTasks();
+    const { removeFromCategory, addToCategory, setShowConfetti, categories, updateTask } = useTasks();
+    const { loadTaskData } = useTaskCreation();
     const ThemedColor = useThemeColor();
     const { deleteWithUndo, alertElement } = useUndoableDelete();
     const { capture } = useAnalytics();
     const queryClient = useQueryClient();
+    const [showDeadlineModal, setShowDeadlineModal] = useState(false);
+    const [showReminderModal, setShowReminderModal] = useState(false);
+
+    const openDeadline = () => {
+        loadTaskData(task);
+        setShowDeadlineModal(true);
+    };
+
+    const openReminder = () => {
+        loadTaskData(task);
+        setShowReminderModal(true);
+    };
+
+    const handleDeadlineUpdate = (deadline: Date | null) => {
+        updateTask(categoryId, task.id, { deadline: deadline?.toISOString() || "" });
+    };
 
     const finalCategoryName =
         categoryName ||
@@ -198,7 +218,7 @@ const SwipableTaskCard = ({
                         {RightAction(
                             prog,
                             drag,
-                            () => {},
+                            openReminder,
                             3,
                             <Bell size={24} color="white" weight="regular" />,
                             ThemedColor.primary
@@ -206,7 +226,7 @@ const SwipableTaskCard = ({
                         {RightAction(
                             prog,
                             drag,
-                            () => {},
+                            openDeadline,
                             3,
                             <Flag size={24} color="white" weight="regular" />,
                             ThemedColor.primary
@@ -229,6 +249,25 @@ const SwipableTaskCard = ({
                     taskCard
                 )}
             </ReanimatedSwipeable>
+
+            {showDeadlineModal && (
+                <DeadlineBottomSheetModal
+                    visible={showDeadlineModal}
+                    setVisible={setShowDeadlineModal}
+                    taskId={task.id}
+                    categoryId={categoryId}
+                    onDeadlineUpdate={handleDeadlineUpdate}
+                />
+            )}
+
+            {showReminderModal && (
+                <ReminderBottomSheetModal
+                    visible={showReminderModal}
+                    setVisible={setShowReminderModal}
+                    taskId={task.id}
+                    categoryId={categoryId}
+                />
+            )}
 
             {alertElement}
         </>

--- a/frontend/components/cards/TaskCard.tsx
+++ b/frontend/components/cards/TaskCard.tsx
@@ -347,23 +347,7 @@ const TaskCard = ({
         if (task?.isPhantom) return;
         if (!redirect) return;
 
-        setAlertTitle(task?.content || "Task");
-        setAlertMessage("");
-        setAlertButtons([
-            {
-                text: "Start Working",
-                onPress: startWorking,
-            },
-            {
-                text: "Edit Task",
-                onPress: () => setEditing(true),
-            },
-            {
-                text: "Cancel",
-                style: "cancel",
-            },
-        ]);
-        setAlertVisible(true);
+        setEditing(true);
     };
 
     return (
@@ -386,7 +370,15 @@ const TaskCard = ({
                 }
                 onPress={handlePress}
                 onLongPress={handleLongPress}>
-                {editing && <EditPost visible={editing} setVisible={setEditing} id={{ id, category: categoryId }} />}
+                {editing && (
+                    <EditPost
+                        visible={editing}
+                        setVisible={setEditing}
+                        id={{ id, category: categoryId }}
+                        task={task}
+                        onStartWorking={task && !task.isPhantom ? startWorking : undefined}
+                    />
+                )}
 
                 <View style={styles.row}>
                     <View style={styles.contentContainer}>

--- a/frontend/components/inputs/Dropdown.tsx
+++ b/frontend/components/inputs/Dropdown.tsx
@@ -35,9 +35,11 @@ type Props = {
     onSpecial: () => void;
     width?: DimensionValue;
     ghost?: boolean;
+    error?: boolean;
+    placeholder?: string;
 };
 
-const Dropdown = ({ options, footerOptions, selected, setSelected, onSpecial, width, ghost }: Props) => {
+const Dropdown = ({ options, footerOptions, selected, setSelected, onSpecial, width, ghost, error, placeholder }: Props) => {
     const expanded = useSharedValue(false);
     const [expandedState, setExpandedState] = React.useState(false);
     const reducedMotion = useReducedMotion();
@@ -101,7 +103,11 @@ const Dropdown = ({ options, footerOptions, selected, setSelected, onSpecial, wi
                         justifyContent: "space-between",
                     },
                 ]}>
-                <ThemedText type="lightBody">{selected.label || "Select a Category"}</ThemedText>
+                <ThemedText
+                    type="lightBody"
+                    style={error && !selected.label ? { color: ThemedColor.error } : undefined}>
+                    {selected.label || placeholder || "Select a Category"}
+                </ThemedText>
                 <AnimatedArrow
                     name="chevron-up"
                     size={16}

--- a/frontend/components/modals/create/Reminder.tsx
+++ b/frontend/components/modals/create/Reminder.tsx
@@ -11,7 +11,7 @@ import Dropdown from "@/components/inputs/Dropdown";
 import DateTimePicker from "@react-native-community/datetimepicker";
 import ThemedCalendar from "@/components/inputs/ThemedCalendar";
 import { combineDateAndTime } from "@/utils/timeUtils";
-import { add, Duration, sub, addHours, addMinutes } from "date-fns";
+import { add, Duration, sub, addHours, addMinutes, addDays, set } from "date-fns";
 import { HORIZONTAL_PADDING } from "@/constants/spacing";
 
 type Props = {
@@ -231,9 +231,52 @@ const AbsoluteReminderOptions = ({
     );
 };
 
+const buildAbsoluteReminder = (triggerTime: Date) => ({
+    triggerTime,
+    type: "ABSOLUTE",
+    sent: false,
+    afterStart: false,
+    beforeStart: false,
+    beforeDeadline: false,
+    afterDeadline: false,
+    vibration: true,
+});
+
+const formatTime = (d: Date) =>
+    d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+
 const Reminder = ({ goToStandard, onSubmit }: Props) => {
     const ThemedColor = useThemeColor();
     const { startTime, startDate, deadline, setReminders } = useTaskCreation();
+
+    const quickSuggestions = useMemo(() => {
+        const now = new Date();
+        const in15 = addMinutes(now, 15);
+        const in1h = addHours(now, 1);
+        const in3h = addHours(now, 3);
+        const tomorrow9 = set(addDays(now, 1), { hours: 9, minutes: 0, seconds: 0, milliseconds: 0 });
+        const tonight8 = set(now, { hours: 20, minutes: 0, seconds: 0, milliseconds: 0 });
+        const eveningOption = now < tonight8
+            ? { tag: "Tonight 8 PM", caption: formatTime(tonight8), triggerTime: tonight8 }
+            : null;
+        return [
+            { tag: "In 15 min", caption: formatTime(in15), triggerTime: in15 },
+            { tag: "In 1 hour", caption: formatTime(in1h), triggerTime: in1h },
+            { tag: "In 3 hours", caption: formatTime(in3h), triggerTime: in3h },
+            ...(eveningOption ? [eveningOption] : []),
+            { tag: "Tomorrow 9 AM", caption: tomorrow9.toLocaleDateString(), triggerTime: tomorrow9 },
+        ];
+    }, []);
+
+    const handleQuickSuggestion = (triggerTime: Date) => {
+        const reminder = buildAbsoluteReminder(triggerTime);
+        if (onSubmit) {
+            onSubmit([reminder]);
+        } else {
+            setReminders([reminder as any]);
+            goToStandard();
+        }
+    };
 
     // State for reminder configuration
     const [number, setNumber] = useState(1);
@@ -318,6 +361,24 @@ const Reminder = ({ goToStandard, onSubmit }: Props) => {
                     display: "flex",
                     flexDirection: "column",
                 }}>
+                <View style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                    <ThemedText type="defaultSemiBold" style={{ fontSize: 20 }}>
+                        Quick Suggestions
+                    </ThemedText>
+                    <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        contentContainerStyle={{ gap: 8 }}>
+                        {quickSuggestions.map((s) => (
+                            <SuggestedTag
+                                key={s.tag}
+                                tag={s.tag}
+                                caption={s.caption}
+                                onPress={() => handleQuickSuggestion(s.triggerTime)}
+                            />
+                        ))}
+                    </ScrollView>
+                </View>
                 <View style={{ display: "flex", flexDirection: "column", gap: 16 }}>
                     <ThemedText type="defaultSemiBold" style={{ fontSize: 20 }}>
                         Reminder Type

--- a/frontend/components/modals/create/Standard.tsx
+++ b/frontend/components/modals/create/Standard.tsx
@@ -210,37 +210,30 @@ const StandardContent = ({
         }
     }, [screen]);
 
-    // Set the selected category when categoryId is provided (for both edit and create modes)
+    // Set the selected category when categoryId is provided (for both edit and create modes).
+    // Falls back to task.categoryID when the prop is missing/empty so edit flows that
+    // pass `task.categoryID || ""` still resolve to the correct category.
     useEffect(() => {
-        if (categoryId && categories && categories.length > 0) {
-            const timer = setTimeout(() => {
-                const taskCategory = categories.find((cat) => cat.id === categoryId);
+        if (!availableCategories || availableCategories.length === 0) return;
 
-                if (taskCategory) {
-                    setCreateCategory({
-                        label: taskCategory.name,
-                        id: taskCategory.id,
-                        special: false,
-                    });
-                } else {
-                    // As a last resort, set the first available category
-                    if (categories.length > 0) {
-                        const firstCategory = categories[0];
-                        setCreateCategory({
-                            label: firstCategory.name,
-                            id: firstCategory.id,
-                            special: false,
-                        });
-                    }
-                }
-            }, 100);
+        const resolvedId = categoryId || task?.categoryID;
+        if (!resolvedId) return;
 
-            return () => clearTimeout(timer);
+        const taskCategory = availableCategories.find((cat) => cat.id === resolvedId);
+        if (taskCategory) {
+            setCreateCategory({
+                label: taskCategory.name,
+                id: taskCategory.id,
+                special: false,
+            });
+        } else {
+            console.warn("Category not found for edit", { resolvedId });
         }
-    }, [categoryId, categories]);
+    }, [categoryId, availableCategories, task?.categoryID]);
 
     const createPost = async () => {
         if (!availableCategories || availableCategories.length === 0) return;
+        if (!selectedCategory?.id) return;
 
         // Trim trailing newlines and whitespace from task name
         const trimmedTaskName = taskName.replace(/[\n\r]+$/g, "").trim();
@@ -552,10 +545,13 @@ const StandardContent = ({
                                 goTo(Screen.NEW_CATEGORY);
                             }}
                             width="100%"
+                            error={!selectedCategory?.id}
+                            placeholder="No category selected"
                         />
                     </View>
                 </AttachStep>
                 <TouchableOpacity
+                    disabled={!selectedCategory?.id}
                     style={{
                         borderRadius: 12,
                         padding: 12,
@@ -564,6 +560,7 @@ const StandardContent = ({
                         borderWidth: 0,
                         borderColor: ThemedColor.text,
                         zIndex: 1001,
+                        opacity: !selectedCategory?.id ? 0.4 : 1,
                     }}
                     hitSlop={{ top: 15, bottom: 15, left: 15, right: 15 }}
                     activeOpacity={0.7}
@@ -587,6 +584,7 @@ const StandardContent = ({
                     placeHolder="Enter the Task Name"
                     textArea
                     onSubmit={() => {
+                        if (!selectedCategory?.id) return;
                         createPost();
                         hide();
                     }}

--- a/frontend/components/modals/edit/EditPost.tsx
+++ b/frontend/components/modals/edit/EditPost.tsx
@@ -5,6 +5,10 @@ import Modal from "react-native-modal";
 
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useTasks } from "@/contexts/tasksContext";
+import { useCreateModal } from "@/contexts/createModalContext";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
+import { Screen } from "../CreateModal";
+import { Task } from "@/api/types";
 import BottomMenuModal from "../BottomMenuModal";
 import { removeFromCategoryAPI } from "@/api/task";
 type ID = {
@@ -16,15 +20,25 @@ type Props = {
     visible: boolean;
     setVisible: (visible: boolean) => void;
     edit?: boolean;
+    onStartWorking?: () => void;
+    task?: Task;
 };
 
 const EditPost = (props: Props) => {
     let ThemedColor = useThemeColor();
 
     const { categories, removeFromCategory } = useTasks();
+    const { openModal } = useCreateModal();
+    const { loadTaskData } = useTaskCreation();
 
     const editPost = async () => {
-        if (categories.length === 0) return;
+        if (!props.task) return;
+        loadTaskData(props.task);
+        openModal({
+            edit: true,
+            categoryId: props.id.category,
+            screen: Screen.STANDARD,
+        });
     };
     const deletePost = async () => {
         if (categories.length === 0) return;
@@ -34,6 +48,9 @@ const EditPost = (props: Props) => {
     };
 
     const options = [
+        ...(props.onStartWorking
+            ? [{ label: "Start Working", icon: "play", callback: props.onStartWorking }]
+            : []),
         { label: "Edit", icon: "edit", callback: editPost },
         { label: "Delete", icon: "delete", callback: deletePost },
     ];


### PR DESCRIPTION
## Summary

Cleans up two layers of task UI that weren't fully working.

- **Long-press menu**: previously opened a `CustomAlert` with Start Working / Edit Task / Cancel — clicking Edit Task then opened a separate `EditPost` bottom sheet (layered menus). Now long-press opens the bottom sheet directly with **Start Working** as the top option, then **Edit** and **Delete**.
- **Edit option**: was a no-op for a long time. Now actually opens the full edit modal (`useCreateModal` + `loadTaskData`) — same flow the detail-screen pencil icon uses.
- **Swipe-right actions on `SwipableTaskCard`**: the 🔔 Bell and 🚩 Flag buttons were empty callbacks. Now Bell opens `ReminderBottomSheetModal` and Flag opens `DeadlineBottomSheetModal`, with `loadTaskData(task)` called first so the modals see existing values. Deadline updates also patch the local task cache so the card reflects the new deadline immediately.
- **Reminder modal suggestions**: added a "Quick Suggestions" row at the top — **In 15 min / In 1 hour / In 3 hours / Tonight 8 PM / Tomorrow 9 AM** — that's always visible and auto-submits on tap (matching the Deadline modal's UX). The existing relative suggestions (gated on the task's start/deadline) still appear below in the Relative section.
- **Category selection guardrails** in the Standard create/edit screen: dropdown shows an error state when no category is selected, Create is disabled until one is chosen, and the effect falls back to `task.categoryID` when the prop is empty for edit flows.

## Test plan
- [ ] Long-press a task → bottom sheet appears directly with Start Working / Edit / Delete (no layered alert).
- [ ] Tap Start Working → live activity starts, "active" badge appears on the card.
- [ ] Tap Edit → full edit modal opens with task data prefilled.
- [ ] Tap Delete → task is removed.
- [ ] Swipe a task right → tap Bell → reminder bottom sheet opens with task's existing reminders loaded.
- [ ] Tap a quick suggestion ("In 1 hour", etc.) → reminder is created and modal closes.
- [ ] Swipe a task right → tap Flag → deadline bottom sheet opens; tap "Tomorrow" → deadline updates and card label updates.
- [ ] Open Create modal without selecting a category → dropdown shows error styling, Create is disabled.
- [ ] Open Edit modal with `task.categoryID` set but `categoryId` prop empty → category resolves correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)