### PR TITLE
feat: scroll-driven hide for feed top bar, tab bar, and FAB

### DIFF
--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "expo-router";
+import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { feedScrollVisibilityEvents } from "@/utils/feedScrollVisibilityEvents";
 import PostCard from "@/components/cards/PostCard";
 import ReportedPostCard from "@/components/cards/ReportedPostCard";
 import TaskFeedCard from "@/components/cards/TaskFeedCard";
@@ -346,6 +348,16 @@ export default function Feed() {
         fetchPosts(currentFeed.id);
     }, [currentFeed.id]);
 
+    // Restore tab bar / FAB visibility when leaving the feed tab so other
+    // screens don't inherit a hidden state from a mid-scroll navigation.
+    useFocusEffect(
+        useCallback(() => {
+            return () => {
+                feedScrollVisibilityEvents.emit(true);
+            };
+        }, [])
+    );
+
     const handleFeedChange = useCallback((feed: { name: string; id: string }) => {
         setCurrentFeed(feed);
         capture(AnalyticsEvents.FEED_FILTER_CHANGED, {
@@ -388,9 +400,11 @@ export default function Feed() {
             if (isScrollingUp && !showAnimatedHeader) {
                 setShowAnimatedHeader(true);
                 animateHeader(true);
+                feedScrollVisibilityEvents.emit(true);
             } else if ((isScrollingDown || shouldHideHeader) && showAnimatedHeader) {
                 setShowAnimatedHeader(false);
                 animateHeader(false);
+                feedScrollVisibilityEvents.emit(false);
             }
 
             scrollY.setValue(currentScrollY);

--- a/frontend/app/(logged-in)/(tabs)/_layout.tsx
+++ b/frontend/app/(logged-in)/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Tabs, useRouter } from "expo-router";
+import { Tabs, useRouter, useSegments } from "expo-router";
 import React, { useEffect, useRef, useState, useMemo } from "react";
 import { Platform, Animated } from "react-native";
 import { usePathname } from "expo-router";
@@ -15,6 +15,7 @@ import { useTasks } from "@/contexts/tasksContext";
 import { FloatingActionButton } from "@/components/ui/FloatingActionButton";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents, TabNames } from "@/utils/analytics";
+import { feedScrollVisibilityEvents } from "@/utils/feedScrollVisibilityEvents";
 
 // Import Phosphor icons
 import {
@@ -78,12 +79,19 @@ export const unstable_settings = {
 export default function TabLayout() {
     let ThemedColor = useThemeColor();
     const pathname = usePathname();
+    const segments = useSegments();
     const router = useRouter();
     const { isDrawerOpen } = useDrawer();
     const { focusMode } = useFocusMode();
     const { startTodayTasks, dueTodayTasks, windowTasks } = useTasks();
     const currentIndex = useTabIndex();
     const { capture } = useAnalytics();
+    const isOnFeedTab = segments?.some((segment) => segment === "(feed)");
+    const [scrollVisible, setScrollVisible] = useState(true);
+
+    useEffect(() => {
+        return feedScrollVisibilityEvents.subscribe(setScrollVisible);
+    }, []);
     const [modalVisible, setModalVisible] = useState(true);
     const toggleModal = () => {
         setModalVisible(!modalVisible);
@@ -126,7 +134,10 @@ export default function TabLayout() {
     ];
 
     const shouldHideTabBar =
-        hideTabBarScreens.some((screen) => pathname.startsWith(screen)) || isDrawerOpen || focusMode;
+        hideTabBarScreens.some((screen) => pathname.startsWith(screen)) ||
+        isDrawerOpen ||
+        focusMode ||
+        (isOnFeedTab && !scrollVisible);
 
     const shouldHideFAB =
         shouldHideTabBar || hideFABScreens.some((screen) => pathname.startsWith(screen));

--- a/frontend/components/ui/FloatingActionButton.tsx
+++ b/frontend/components/ui/FloatingActionButton.tsx
@@ -36,6 +36,29 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visi
     const { openModal } = useCreateModal();
     const { capture } = useAnalytics();
 
+    // Visibility animation — matches the feed top bar and tab bar tempo
+    // (300ms parallel opacity + translate). The FAB lives at the right edge,
+    // so it slides off horizontally rather than down through the tab bar.
+    // 56 (FAB width) + 16 (right inset) + 16 (buffer) = 88.
+    const FAB_HIDE_X = 88;
+    const visibilityOpacity = useRef(new Animated.Value(visible ? 1 : 0)).current;
+    const visibilityTranslateX = useRef(new Animated.Value(visible ? 0 : FAB_HIDE_X)).current;
+
+    useEffect(() => {
+        Animated.parallel([
+            Animated.timing(visibilityOpacity, {
+                toValue: visible ? 1 : 0,
+                duration: 300,
+                useNativeDriver: true,
+            }),
+            Animated.timing(visibilityTranslateX, {
+                toValue: visible ? 0 : FAB_HIDE_X,
+                duration: 300,
+                useNativeDriver: true,
+            }),
+        ]).start();
+    }, [visible, visibilityOpacity, visibilityTranslateX]);
+
     // State
     const [fabState, setFabState] = useState<FABState>("collapsed");
     const [workspaceModalVisible, setWorkspaceModalVisible] = useState(false);
@@ -291,8 +314,6 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visi
         }
     };
 
-    if (!visible) return null;
-
     const bottomOffset = insets.bottom + TAB_BAR_HEIGHT;
 
     return (
@@ -311,12 +332,12 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visi
             )}
 
             <FABBackdrop
-                visible={fabState !== "collapsed"}
+                visible={visible && fabState !== "collapsed"}
                 opacity={animations.backdropOpacity}
                 onPress={handleBackdropPress}
             />
 
-            {fabState !== "collapsed" && (
+            {visible && fabState !== "collapsed" && (
                 <Animated.View
                     style={[
                         styles.menuContainer,
@@ -424,16 +445,26 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visi
                 </Animated.View>
             )}
 
-            <FABButton
-                isOpen={fabState !== "collapsed"}
-                onPress={handleFABPress}
-                rotation={animations.rotation}
-                scale={animations.fabScale}
-                opacity={animations.fabOpacity}
-                bottomOffset={bottomOffset}
-                isKeyboardVisible={keyboardVisible}
-                isOnFeedTab={isOnFeedTab}
-            />
+            <Animated.View
+                pointerEvents={visible ? "box-none" : "none"}
+                style={[
+                    StyleSheet.absoluteFill,
+                    {
+                        opacity: visibilityOpacity,
+                        transform: [{ translateX: visibilityTranslateX }],
+                    },
+                ]}>
+                <FABButton
+                    isOpen={fabState !== "collapsed"}
+                    onPress={handleFABPress}
+                    rotation={animations.rotation}
+                    scale={animations.fabScale}
+                    opacity={animations.fabOpacity}
+                    bottomOffset={bottomOffset}
+                    isKeyboardVisible={keyboardVisible}
+                    isOnFeedTab={isOnFeedTab}
+                />
+            </Animated.View>
         </>
     );
 };

--- a/frontend/utils/feedScrollVisibilityEvents.ts
+++ b/frontend/utils/feedScrollVisibilityEvents.ts
@@ -1,0 +1,14 @@
+type Listener = (visible: boolean) => void;
+
+const listeners = new Set<Listener>();
+
+export const feedScrollVisibilityEvents = {
+    subscribe(fn: Listener) {
+        listeners.add(fn);
+        return () => { listeners.delete(fn); };
+    },
+
+    emit(visible: boolean) {
+        listeners.forEach((fn) => fn(visible));
+    },
+};


### PR DESCRIPTION
## Summary
- Extends the feed's existing scroll-driven top-bar show/hide so the tab bar and floating action button move in lockstep — one 300ms parallel opacity + translate animation for all three.
- Top bar slides up, tab bar slides down, FAB slides off horizontally (it lives at the right edge, not the bottom).
- Module-level emitter (`feedScrollVisibilityEvents`) carries a boolean from `feed.tsx` to the `(tabs)/_layout.tsx`; gated to the feed tab via `useSegments` so other tabs are unaffected. `useFocusEffect` cleanup re-emits `true` on blur so navigating away mid-scroll doesn't strand chrome hidden.
- `FloatingActionButton` no longer hard-unmounts on `visible=false`; it animates via a transparent `StyleSheet.absoluteFill` wrapper with `pointerEvents="box-none"` / `"none"`.

## Test plan
- [ ] Scroll down in the feed: top bar slides up, tab bar slides down, FAB slides right — all together.
- [ ] Scroll back up: all three return together.
- [ ] At the top of the feed (scrollY < 50): chrome stays visible.
- [ ] Navigate from feed → another tab while chrome is hidden: tab bar/FAB restore.
- [ ] Path-based FAB hide screens (`/daily`, `/review`, `/settings`) still hide the FAB with the same animation rather than the previous hard unmount.
- [ ] FAB menu can still be opened and dismissed normally; opening the menu doesn't fire scroll-hide.
- [ ] Verify FAB taps still register at the same screen location after the wrapper change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)