### PR TITLE
feat: one-way push sync — Kindred tasks → Google Calendar

### DIFF
--- a/backend/internal/handlers/calendar/calendar.go
+++ b/backend/internal/handlers/calendar/calendar.go
@@ -275,7 +275,7 @@ func (h *Handler) SetupWorkspaces(ctx context.Context, input *SetupWorkspacesInp
 		return nil, huma.Error400BadRequest("Invalid user ID format")
 	}
 
-	if err := h.service.SetupWorkspacesForConnection(ctx, connectionID, userObjID, input.Body.CalendarIDs, input.Body.MergeIntoOne, input.Body.MakePublic); err != nil {
+	if err := h.service.SetupWorkspacesForConnection(ctx, connectionID, userObjID, input.Body.CalendarIDs, input.Body.PushEnabledIDs, input.Body.MergeIntoOne, input.Body.MakePublic); err != nil {
 		slog.Error("Failed to set up calendar workspaces", "userId", userID, "connectionId", input.ConnectionID, "calendarIds", input.Body.CalendarIDs, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to set up calendar workspaces. Please try again.", err)
 	}

--- a/backend/internal/handlers/calendar/converter_test.go
+++ b/backend/internal/handlers/calendar/converter_test.go
@@ -557,3 +557,26 @@ func TestConvertEventToTaskParams_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+func TestIsPushOriginEvent(t *testing.T) {
+	pushEv := ProviderEvent{
+		ExtendedProperties: map[string]string{
+			"kindred_origin":  "push",
+			"kindred_task_id": "abc",
+		},
+	}
+	pullEv := ProviderEvent{
+		ExtendedProperties: map[string]string{},
+	}
+	noPropsEv := ProviderEvent{}
+
+	if !IsPushOriginEvent(pushEv) {
+		t.Fatalf("expected push-origin event to be detected")
+	}
+	if IsPushOriginEvent(pullEv) {
+		t.Fatalf("expected pull-origin event to not be detected")
+	}
+	if IsPushOriginEvent(noPropsEv) {
+		t.Fatalf("expected event with no props to not be detected")
+	}
+}

--- a/backend/internal/handlers/calendar/converter_test.go
+++ b/backend/internal/handlers/calendar/converter_test.go
@@ -451,6 +451,28 @@ func TestConvertEventToTaskParams_TimeZones(t *testing.T) {
 	}
 }
 
+func TestProviderEvent_ExtendedPropertiesRoundtrip(t *testing.T) {
+	// A push-origin event should retain its extended properties through conversion.
+	pe := ProviderEvent{
+		ID:         "evt-1",
+		CalendarID: "cal-1",
+		Summary:    "Test",
+		StartTime:  time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:    time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+		ExtendedProperties: map[string]string{
+			"kindred_task_id": "task-123",
+			"kindred_origin":  "push",
+		},
+	}
+
+	if pe.ExtendedProperties["kindred_task_id"] != "task-123" {
+		t.Fatalf("expected task id, got %v", pe.ExtendedProperties)
+	}
+	if pe.ExtendedProperties["kindred_origin"] != "push" {
+		t.Fatalf("expected origin push, got %v", pe.ExtendedProperties)
+	}
+}
+
 func TestConvertEventToTaskParams_EdgeCases(t *testing.T) {
 	userID := primitive.NewObjectID()
 	categoryID := primitive.NewObjectID()

--- a/backend/internal/handlers/calendar/converter_test.go
+++ b/backend/internal/handlers/calendar/converter_test.go
@@ -454,11 +454,6 @@ func TestConvertEventToTaskParams_TimeZones(t *testing.T) {
 func TestProviderEvent_ExtendedPropertiesRoundtrip(t *testing.T) {
 	// A push-origin event should retain its extended properties through conversion.
 	pe := ProviderEvent{
-		ID:         "evt-1",
-		CalendarID: "cal-1",
-		Summary:    "Test",
-		StartTime:  time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
-		EndTime:    time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
 		ExtendedProperties: map[string]string{
 			"kindred_task_id": "task-123",
 			"kindred_origin":  "push",

--- a/backend/internal/handlers/calendar/provider.go
+++ b/backend/internal/handlers/calendar/provider.go
@@ -60,6 +60,11 @@ type ProviderEvent struct {
 	IsAllDay     bool
 	Attendees    []string
 	Status       string // confirmed, tentative, cancelled
+
+	// ExtendedProperties carries provider-specific private metadata that
+	// round-trips through Create/Update/Fetch. Used for push-loop prevention
+	// (kindred_task_id, kindred_origin).
+	ExtendedProperties map[string]string
 }
 
 // WatchResponse represents the response from creating a watch channel

--- a/backend/internal/handlers/calendar/provider.go
+++ b/backend/internal/handlers/calendar/provider.go
@@ -65,6 +65,10 @@ type ProviderEvent struct {
 	// round-trips through Create/Update/Fetch. Used for push-loop prevention
 	// (kindred_task_id, kindred_origin).
 	ExtendedProperties map[string]string
+
+	// Etag is the provider's opaque version identifier for this event, used
+	// later for drift detection. Populated by Create/Update/Fetch; ignored on input.
+	Etag string
 }
 
 // WatchResponse represents the response from creating a watch channel

--- a/backend/internal/handlers/calendar/provider.go
+++ b/backend/internal/handlers/calendar/provider.go
@@ -24,7 +24,7 @@ type Provider interface {
 	FetchEvents(ctx context.Context, token *oauth2.Token, timeMin, timeMax time.Time) ([]ProviderEvent, error)
 	CreateEvent(ctx context.Context, token *oauth2.Token, event ProviderEvent) (ProviderEvent, error)
 	UpdateEvent(ctx context.Context, token *oauth2.Token, eventID string, event ProviderEvent) (ProviderEvent, error)
-	DeleteEvent(ctx context.Context, token *oauth2.Token, eventID string) error
+	DeleteEvent(ctx context.Context, token *oauth2.Token, calendarID string, eventID string) error
 
 	// Watch methods
 	WatchCalendar(ctx context.Context, token *oauth2.Token, calendarID string, channelID string, webhookURL string) (*WatchResponse, error)

--- a/backend/internal/handlers/calendar/provider_google.go
+++ b/backend/internal/handlers/calendar/provider_google.go
@@ -333,6 +333,14 @@ func (p *GoogleProvider) convertGoogleEvent(googleEvent *calendar.Event, calenda
 		}
 	}
 
+	// Surface private extended properties so loop-prevention logic can read them.
+	if googleEvent.ExtendedProperties != nil && googleEvent.ExtendedProperties.Private != nil {
+		event.ExtendedProperties = make(map[string]string, len(googleEvent.ExtendedProperties.Private))
+		for k, v := range googleEvent.ExtendedProperties.Private {
+			event.ExtendedProperties[k] = v
+		}
+	}
+
 	return event
 }
 
@@ -368,6 +376,17 @@ func (p *GoogleProvider) convertToGoogleEvent(event ProviderEvent) *calendar.Eve
 			googleEvent.Attendees = append(googleEvent.Attendees, &calendar.EventAttendee{
 				Email: email,
 			})
+		}
+	}
+
+	// Forward private extended properties (e.g., kindred_task_id for loop prevention).
+	if len(event.ExtendedProperties) > 0 {
+		private := make(map[string]string, len(event.ExtendedProperties))
+		for k, v := range event.ExtendedProperties {
+			private[k] = v
+		}
+		googleEvent.ExtendedProperties = &calendar.EventExtendedProperties{
+			Private: private,
 		}
 	}
 

--- a/backend/internal/handlers/calendar/provider_google.go
+++ b/backend/internal/handlers/calendar/provider_google.go
@@ -2,6 +2,7 @@ package calendar
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -289,6 +291,15 @@ func (p *GoogleProvider) DeleteEvent(ctx context.Context, token *oauth2.Token, c
 
 	err = calendarService.Events.Delete(calendarID, eventID).Do()
 	if err != nil {
+		// "Already gone" is success — common race when the user deletes the event in
+		// Google before Kindred's worker drains the row, or when an aggressive retry
+		// double-fires a delete. We logged it; we don't escalate.
+		var apiErr *googleapi.Error
+		if errors.As(err, &apiErr) && (apiErr.Code == 404 || apiErr.Code == 410) {
+			slog.Info("Google: event already gone, treating delete as success",
+				"calendar_id", calendarID, "event_id", eventID, "code", apiErr.Code)
+			return nil
+		}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		slog.Error("Google: Failed to delete event", "calendar_id", calendarID, "event_id", eventID, "error", err)
@@ -310,6 +321,7 @@ func (p *GoogleProvider) convertGoogleEvent(googleEvent *calendar.Event, calenda
 		Description:  googleEvent.Description,
 		Location:     googleEvent.Location,
 		Status:       googleEvent.Status,
+		Etag:         googleEvent.Etag,
 	}
 
 	// Handle all-day events vs timed events

--- a/backend/internal/handlers/calendar/provider_google.go
+++ b/backend/internal/handlers/calendar/provider_google.go
@@ -268,11 +268,11 @@ func (p *GoogleProvider) UpdateEvent(ctx context.Context, token *oauth2.Token, e
 	return result, nil
 }
 
-func (p *GoogleProvider) DeleteEvent(ctx context.Context, token *oauth2.Token, eventID string) error {
+func (p *GoogleProvider) DeleteEvent(ctx context.Context, token *oauth2.Token, calendarID string, eventID string) error {
 	ctx, span := otel.Tracer("kindred").Start(ctx, "calendar.DeleteEvent")
 	defer span.End()
 
-	slog.Info("Google: Deleting calendar event", "event_id", eventID)
+	slog.Info("Google: Deleting calendar event", "calendar_id", calendarID, "event_id", eventID)
 
 	client := p.config.Client(ctx, token)
 	calendarService, err := calendar.NewService(ctx, option.WithHTTPClient(client))
@@ -283,15 +283,19 @@ func (p *GoogleProvider) DeleteEvent(ctx context.Context, token *oauth2.Token, e
 		return err
 	}
 
-	err = calendarService.Events.Delete("primary", eventID).Do()
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+
+	err = calendarService.Events.Delete(calendarID, eventID).Do()
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		slog.Error("Google: Failed to delete event", "event_id", eventID, "error", err)
+		slog.Error("Google: Failed to delete event", "calendar_id", calendarID, "event_id", eventID, "error", err)
 		return err
 	}
 
-	slog.Info("Google: Event deleted successfully", "event_id", eventID)
+	slog.Info("Google: Event deleted successfully", "calendar_id", calendarID, "event_id", eventID)
 	return nil
 }
 

--- a/backend/internal/handlers/calendar/push_converter.go
+++ b/backend/internal/handlers/calendar/push_converter.go
@@ -70,3 +70,12 @@ func BuildProviderEventFromTask(task *types.TaskDocument, calendarID string) (Pr
 
 	return ev, nil
 }
+
+// IsPushOriginEvent returns true if the event carries the kindred_origin=push marker,
+// meaning Kindred wrote it. The pull-side sync uses this to skip its own writes.
+func IsPushOriginEvent(ev ProviderEvent) bool {
+	if ev.ExtendedProperties == nil {
+		return false
+	}
+	return ev.ExtendedProperties["kindred_origin"] == "push"
+}

--- a/backend/internal/handlers/calendar/push_converter.go
+++ b/backend/internal/handlers/calendar/push_converter.go
@@ -1,0 +1,72 @@
+package calendar
+
+import (
+	"errors"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+)
+
+// ErrTaskNotPushable is returned when a task has no date and therefore can't
+// be expressed as a calendar event.
+var ErrTaskNotPushable = errors.New("task has no date and cannot be pushed to calendar")
+
+// BuildProviderEventFromTask converts a task to a ProviderEvent destined for `calendarID`.
+// Mapping rules:
+//   - Timed (StartTime + Deadline set): timed event, [StartTime, Deadline]
+//   - All-day (StartDate set, no StartTime): all-day event, [StartDate, Deadline or StartDate]
+//   - Deadline-only (Deadline set, no StartTime/StartDate): all-day on deadline date, "Due: " prefix
+//   - Completed (Active == false): same shape as above, "✓ " prefix on summary
+//   - No date: returns ErrTaskNotPushable
+func BuildProviderEventFromTask(task *types.TaskDocument, calendarID string) (ProviderEvent, error) {
+	if task.StartTime == nil && task.StartDate == nil && task.Deadline == nil {
+		return ProviderEvent{}, ErrTaskNotPushable
+	}
+
+	summary := task.Content
+	deadlineOnly := task.StartTime == nil && task.StartDate == nil && task.Deadline != nil
+	if deadlineOnly {
+		summary = "Due: " + summary
+	}
+
+	completed := !task.Active
+	if completed {
+		summary = "✓ " + summary
+	}
+
+	ev := ProviderEvent{
+		CalendarID: calendarID,
+		Summary:    summary,
+		ExtendedProperties: map[string]string{
+			"kindred_task_id": task.ID.Hex(),
+			"kindred_origin":  "push",
+		},
+	}
+
+	switch {
+	case task.StartTime != nil:
+		ev.IsAllDay = false
+		ev.StartTime = *task.StartTime
+		if task.Deadline != nil {
+			ev.EndTime = *task.Deadline
+		} else {
+			// Default to 30-minute block if a timed task has no deadline.
+			ev.EndTime = task.StartTime.Add(30 * time.Minute)
+		}
+	case task.StartDate != nil:
+		ev.IsAllDay = true
+		ev.StartTime = *task.StartDate
+		if task.Deadline != nil {
+			ev.EndTime = *task.Deadline
+		} else {
+			ev.EndTime = *task.StartDate
+		}
+	default:
+		// Deadline-only: all-day event on the deadline date.
+		ev.IsAllDay = true
+		ev.StartTime = *task.Deadline
+		ev.EndTime = *task.Deadline
+	}
+
+	return ev, nil
+}

--- a/backend/internal/handlers/calendar/push_converter_test.go
+++ b/backend/internal/handlers/calendar/push_converter_test.go
@@ -111,3 +111,25 @@ func TestBuildProviderEventFromTask_NoDate(t *testing.T) {
 		t.Fatalf("expected error for undated task")
 	}
 }
+
+func TestParseCategoryIntegration(t *testing.T) {
+	connID := primitive.NewObjectID()
+	in := "gcal:" + connID.Hex() + ":primary"
+	gotConn, gotCal, ok := parseCategoryIntegration(in)
+	if !ok {
+		t.Fatalf("expected ok")
+	}
+	if gotConn != connID {
+		t.Fatalf("conn mismatch")
+	}
+	if gotCal != "primary" {
+		t.Fatalf("cal mismatch: %q", gotCal)
+	}
+
+	if _, _, ok := parseCategoryIntegration("notgcal:foo:bar"); ok {
+		t.Fatalf("expected !ok for non-gcal prefix")
+	}
+	if _, _, ok := parseCategoryIntegration("gcal:notahex:cal"); ok {
+		t.Fatalf("expected !ok for invalid connection id")
+	}
+}

--- a/backend/internal/handlers/calendar/push_converter_test.go
+++ b/backend/internal/handlers/calendar/push_converter_test.go
@@ -1,0 +1,113 @@
+package calendar
+
+import (
+	"testing"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func ptrTime(t time.Time) *time.Time { return &t }
+
+func TestBuildProviderEventFromTask_TimedTask(t *testing.T) {
+	task := &types.TaskDocument{
+		ID:        primitive.NewObjectID(),
+		Content:   "Standup",
+		StartTime: ptrTime(time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)),
+		Deadline:  ptrTime(time.Date(2026, 6, 1, 10, 30, 0, 0, time.UTC)),
+		Active:    true,
+	}
+
+	ev, err := BuildProviderEventFromTask(task, "cal-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Summary != "Standup" {
+		t.Fatalf("summary: got %q want %q", ev.Summary, "Standup")
+	}
+	if ev.IsAllDay {
+		t.Fatalf("timed task should not be all-day")
+	}
+	if !ev.StartTime.Equal(*task.StartTime) {
+		t.Fatalf("start mismatch")
+	}
+	if !ev.EndTime.Equal(*task.Deadline) {
+		t.Fatalf("end mismatch")
+	}
+	if ev.ExtendedProperties["kindred_task_id"] != task.ID.Hex() {
+		t.Fatalf("missing kindred_task_id tag")
+	}
+	if ev.ExtendedProperties["kindred_origin"] != "push" {
+		t.Fatalf("missing kindred_origin tag")
+	}
+	if ev.CalendarID != "cal-1" {
+		t.Fatalf("calendar id not propagated")
+	}
+}
+
+func TestBuildProviderEventFromTask_AllDay(t *testing.T) {
+	// StartDate set, StartTime nil → all-day
+	task := &types.TaskDocument{
+		ID:        primitive.NewObjectID(),
+		Content:   "Conference",
+		StartDate: ptrTime(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)),
+		Deadline:  ptrTime(time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC)),
+		Active:    true,
+	}
+	ev, err := BuildProviderEventFromTask(task, "cal-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ev.IsAllDay {
+		t.Fatalf("expected all-day")
+	}
+}
+
+func TestBuildProviderEventFromTask_DeadlineOnly(t *testing.T) {
+	// Deadline set, no StartTime, no StartDate → all-day event on deadline date with "Due: " prefix.
+	task := &types.TaskDocument{
+		ID:       primitive.NewObjectID(),
+		Content:  "File taxes",
+		Deadline: ptrTime(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)),
+		Active:   true,
+	}
+	ev, err := BuildProviderEventFromTask(task, "cal-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ev.IsAllDay {
+		t.Fatalf("deadline-only should be all-day")
+	}
+	if ev.Summary != "Due: File taxes" {
+		t.Fatalf("summary: got %q", ev.Summary)
+	}
+}
+
+func TestBuildProviderEventFromTask_Completed(t *testing.T) {
+	task := &types.TaskDocument{
+		ID:        primitive.NewObjectID(),
+		Content:   "Standup",
+		StartTime: ptrTime(time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC)),
+		Deadline:  ptrTime(time.Date(2026, 6, 1, 10, 30, 0, 0, time.UTC)),
+		Active:    false,
+	}
+	ev, err := BuildProviderEventFromTask(task, "cal-1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev.Summary != "✓ Standup" {
+		t.Fatalf("expected check prefix, got %q", ev.Summary)
+	}
+}
+
+func TestBuildProviderEventFromTask_NoDate(t *testing.T) {
+	task := &types.TaskDocument{
+		ID:      primitive.NewObjectID(),
+		Content: "Sometime soon",
+	}
+	_, err := BuildProviderEventFromTask(task, "cal-1")
+	if err == nil {
+		t.Fatalf("expected error for undated task")
+	}
+}

--- a/backend/internal/handlers/calendar/push_outbox.go
+++ b/backend/internal/handlers/calendar/push_outbox.go
@@ -1,0 +1,178 @@
+package calendar
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// PushOp is the kind of push action queued for the worker.
+type PushOp string
+
+const (
+	PushOpUpsert PushOp = "upsert"
+	PushOpDelete PushOp = "delete"
+)
+
+// PushOutboxRow is a queued push action.
+type PushOutboxRow struct {
+	ID         primitive.ObjectID `bson:"_id,omitempty"`
+	TaskID     primitive.ObjectID `bson:"task_id"`
+	CategoryID primitive.ObjectID `bson:"category_id"`
+	UserID     primitive.ObjectID `bson:"user_id"`
+	Op         PushOp             `bson:"op"`
+
+	// Snapshot fields (set only for delete ops).
+	TargetEventID      string             `bson:"target_event_id,omitempty"`
+	TargetCalendarID   string             `bson:"target_calendar_id,omitempty"`
+	TargetConnectionID primitive.ObjectID `bson:"target_connection_id,omitempty"`
+
+	EnqueuedAt    time.Time `bson:"enqueued_at"`
+	AttemptCount  int       `bson:"attempt_count"`
+	NextAttemptAt time.Time `bson:"next_attempt_at"`
+	LastError     string    `bson:"last_error,omitempty"`
+	Status        string    `bson:"status"` // "pending" | "failed_permanent"
+}
+
+const (
+	pushStatusPending         = "pending"
+	pushStatusFailedPermanent = "failed_permanent"
+	pushMaxAttempts           = 10
+)
+
+// PushOutbox handles enqueue, coalescing, and drain queries.
+type PushOutbox struct {
+	col *mongo.Collection
+}
+
+func NewPushOutbox(col *mongo.Collection) *PushOutbox {
+	return &PushOutbox{col: col}
+}
+
+// EnqueueUpsert inserts an upsert row unless one is already pending for this task.
+// If a pending delete exists for the same task, the upsert is still inserted —
+// the worker processes them in order (this is the "moved between calendars" case).
+func (o *PushOutbox) EnqueueUpsert(ctx context.Context, taskID, categoryID, userID primitive.ObjectID) error {
+	// Check for an existing pending upsert for this task.
+	count, err := o.col.CountDocuments(ctx, bson.M{
+		"task_id": taskID,
+		"op":      PushOpUpsert,
+		"status":  pushStatusPending,
+	})
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		slog.Debug("Push outbox: upsert already pending, coalescing", "task_id", taskID)
+		return nil
+	}
+
+	now := time.Now()
+	_, err = o.col.InsertOne(ctx, PushOutboxRow{
+		TaskID:        taskID,
+		CategoryID:    categoryID,
+		UserID:        userID,
+		Op:            PushOpUpsert,
+		EnqueuedAt:    now,
+		NextAttemptAt: now,
+		Status:        pushStatusPending,
+	})
+	return err
+}
+
+// EnqueueDelete inserts a delete row carrying the snapshot of what to delete.
+// Removes any pending upsert for the same task (delete supersedes upsert).
+func (o *PushOutbox) EnqueueDelete(ctx context.Context, taskID, categoryID, userID, connectionID primitive.ObjectID, eventID, calendarID string) error {
+	// Drop any pending upsert for this task.
+	_, err := o.col.DeleteMany(ctx, bson.M{
+		"task_id": taskID,
+		"op":      PushOpUpsert,
+		"status":  pushStatusPending,
+	})
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	_, err = o.col.InsertOne(ctx, PushOutboxRow{
+		TaskID:             taskID,
+		CategoryID:         categoryID,
+		UserID:             userID,
+		Op:                 PushOpDelete,
+		TargetEventID:      eventID,
+		TargetCalendarID:   calendarID,
+		TargetConnectionID: connectionID,
+		EnqueuedAt:         now,
+		NextAttemptAt:      now,
+		Status:             pushStatusPending,
+	})
+	return err
+}
+
+// ClaimBatch fetches up to `limit` pending rows whose next_attempt_at <= now.
+// Caller is responsible for re-queuing or marking permanent.
+func (o *PushOutbox) ClaimBatch(ctx context.Context, limit int) ([]PushOutboxRow, error) {
+	cursor, err := o.col.Find(ctx, bson.M{
+		"status":          pushStatusPending,
+		"next_attempt_at": bson.M{"$lte": time.Now()},
+	}, options.Find().SetLimit(int64(limit)).SetSort(bson.D{{Key: "next_attempt_at", Value: 1}}))
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var rows []PushOutboxRow
+	if err := cursor.All(ctx, &rows); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// MarkSuccess deletes the row after a successful drain.
+func (o *PushOutbox) MarkSuccess(ctx context.Context, id primitive.ObjectID) error {
+	_, err := o.col.DeleteOne(ctx, bson.M{"_id": id})
+	return err
+}
+
+// MarkFailure increments attempt_count, sets next_attempt_at with backoff,
+// stores last_error, and flips to failed_permanent after pushMaxAttempts.
+func (o *PushOutbox) MarkFailure(ctx context.Context, id primitive.ObjectID, attempt int, errMsg string) error {
+	backoff := backoffFor(attempt)
+	status := pushStatusPending
+	if attempt+1 >= pushMaxAttempts {
+		status = pushStatusFailedPermanent
+	}
+	_, err := o.col.UpdateOne(ctx, bson.M{"_id": id}, bson.M{
+		"$set": bson.M{
+			"attempt_count":   attempt + 1,
+			"next_attempt_at": time.Now().Add(backoff),
+			"last_error":      errMsg,
+			"status":          status,
+		},
+	})
+	return err
+}
+
+// backoffFor returns the wait before retrying attempt n (0-indexed).
+// 10s, 30s, 1m, 5m, 15m, 1h, then 1h repeating.
+func backoffFor(attempt int) time.Duration {
+	schedule := []time.Duration{
+		10 * time.Second,
+		30 * time.Second,
+		1 * time.Minute,
+		5 * time.Minute,
+		15 * time.Minute,
+		1 * time.Hour,
+	}
+	if attempt < 0 {
+		attempt = 0
+	}
+	if attempt >= len(schedule) {
+		return schedule[len(schedule)-1]
+	}
+	return schedule[attempt]
+}

--- a/backend/internal/handlers/calendar/push_outbox.go
+++ b/backend/internal/handlers/calendar/push_outbox.go
@@ -2,7 +2,6 @@ package calendar
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson"
@@ -55,34 +54,40 @@ func NewPushOutbox(col *mongo.Collection) *PushOutbox {
 }
 
 // EnqueueUpsert inserts an upsert row unless one is already pending for this task.
+// Uses an upsert on (task_id, op, status) so two concurrent calls collapse to one row.
 // If a pending delete exists for the same task, the upsert is still inserted —
 // the worker processes them in order (this is the "moved between calendars" case).
+//
+// NOTE: A unique partial index on (task_id, op, status) where status == "pending"
+// would make this airtight against the narrow window where two concurrent upserts
+// could both pass the filter check before either inserts. Recommended as a
+// deployment-time follow-up; not added here.
 func (o *PushOutbox) EnqueueUpsert(ctx context.Context, taskID, categoryID, userID primitive.ObjectID) error {
-	// Check for an existing pending upsert for this task.
-	count, err := o.col.CountDocuments(ctx, bson.M{
-		"task_id": taskID,
-		"op":      PushOpUpsert,
-		"status":  pushStatusPending,
-	})
+	now := time.Now()
+	_, err := o.col.UpdateOne(ctx,
+		bson.M{
+			"task_id": taskID,
+			"op":      PushOpUpsert,
+			"status":  pushStatusPending,
+		},
+		bson.M{
+			"$setOnInsert": bson.M{
+				"task_id":         taskID,
+				"category_id":     categoryID,
+				"user_id":         userID,
+				"op":              PushOpUpsert,
+				"enqueued_at":     now,
+				"next_attempt_at": now,
+				"attempt_count":   0,
+				"status":          pushStatusPending,
+			},
+		},
+		options.Update().SetUpsert(true),
+	)
 	if err != nil {
 		return err
 	}
-	if count > 0 {
-		slog.Debug("Push outbox: upsert already pending, coalescing", "task_id", taskID)
-		return nil
-	}
-
-	now := time.Now()
-	_, err = o.col.InsertOne(ctx, PushOutboxRow{
-		TaskID:        taskID,
-		CategoryID:    categoryID,
-		UserID:        userID,
-		Op:            PushOpUpsert,
-		EnqueuedAt:    now,
-		NextAttemptAt: now,
-		Status:        pushStatusPending,
-	})
-	return err
+	return nil
 }
 
 // EnqueueDelete inserts a delete row carrying the snapshot of what to delete.
@@ -114,19 +119,59 @@ func (o *PushOutbox) EnqueueDelete(ctx context.Context, taskID, categoryID, user
 	return err
 }
 
-// ClaimBatch fetches up to `limit` pending rows whose next_attempt_at <= now.
-// Caller is responsible for re-queuing or marking permanent.
+// ClaimBatch atomically claims up to `limit` pending rows whose next_attempt_at
+// has come due. Each claimed row's next_attempt_at is pushed forward by the
+// claim TTL so a concurrent worker (re-entrant tick or sibling replica) skips
+// it. On success/failure the worker still deletes (MarkSuccess) or resets
+// next_attempt_at via backoff (MarkFailure). If the worker crashes mid-process,
+// the row reappears after the TTL and another worker can pick it up.
 func (o *PushOutbox) ClaimBatch(ctx context.Context, limit int) ([]PushOutboxRow, error) {
+	const claimTTL = 5 * time.Minute
+	now := time.Now()
+
+	// Step 1: find up to `limit` due rows.
 	cursor, err := o.col.Find(ctx, bson.M{
 		"status":          pushStatusPending,
-		"next_attempt_at": bson.M{"$lte": time.Now()},
-	}, options.Find().SetLimit(int64(limit)).SetSort(bson.D{{Key: "next_attempt_at", Value: 1}}))
+		"next_attempt_at": bson.M{"$lte": now},
+	}, options.Find().SetLimit(int64(limit)).SetSort(bson.D{{Key: "next_attempt_at", Value: 1}}).SetProjection(bson.M{"_id": 1}))
 	if err != nil {
 		return nil, err
 	}
-	defer cursor.Close(ctx)
+	var ids []primitive.ObjectID
+	{
+		var idDocs []struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}
+		if err := cursor.All(ctx, &idDocs); err != nil {
+			return nil, err
+		}
+		for _, d := range idDocs {
+			ids = append(ids, d.ID)
+		}
+	}
+	if len(ids) == 0 {
+		return nil, nil
+	}
+
+	// Step 2: claim them by pushing next_attempt_at forward by the TTL.
+	// Workers that crash before MarkSuccess/MarkFailure will see these rows again
+	// after the TTL elapses.
+	_, err = o.col.UpdateMany(ctx,
+		bson.M{"_id": bson.M{"$in": ids}, "status": pushStatusPending},
+		bson.M{"$set": bson.M{"next_attempt_at": now.Add(claimTTL)}},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 3: re-fetch the rows we successfully claimed (they have the new next_attempt_at).
+	cursor2, err := o.col.Find(ctx, bson.M{"_id": bson.M{"$in": ids}})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor2.Close(ctx)
 	var rows []PushOutboxRow
-	if err := cursor.All(ctx, &rows); err != nil {
+	if err := cursor2.All(ctx, &rows); err != nil {
 		return nil, err
 	}
 	return rows, nil

--- a/backend/internal/handlers/calendar/push_service.go
+++ b/backend/internal/handlers/calendar/push_service.go
@@ -10,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.opentelemetry.io/otel"
 )
 
@@ -143,7 +144,7 @@ func (s *Service) processPushUpsert(ctx context.Context, row PushOutboxRow) erro
 			"$set": bson.M{
 				"tasks.$.pushed_event_id":    written.ID,
 				"tasks.$.pushed_calendar_id": written.CalendarID,
-				"tasks.$.pushed_event_etag":  written.ExtendedProperties["etag"],
+				"tasks.$.pushed_event_etag":  written.Etag,
 			},
 		},
 	)
@@ -218,23 +219,27 @@ func (s *Service) loadTaskWithCategory(ctx context.Context, taskID, categoryID p
 		PushEnabled bool                 `bson:"push_enabled"`
 		Tasks       []types.TaskDocument `bson:"tasks"`
 	}
+	projection := bson.M{
+		"_id":          1,
+		"integration":  1,
+		"push_enabled": 1,
+		"tasks":        bson.M{"$elemMatch": bson.M{"_id": taskID}},
+	}
 	err := s.categories.FindOne(ctx, bson.M{
 		"_id":       categoryID,
 		"tasks._id": taskID,
-	}).Decode(&doc)
+	}, options.FindOne().SetProjection(projection)).Decode(&doc)
 	if err != nil {
 		return nil, nil, err
 	}
-	for i := range doc.Tasks {
-		if doc.Tasks[i].ID == taskID {
-			return &doc.Tasks[i], &categoryRow{
-				ID:          doc.ID,
-				Integration: doc.Integration,
-				PushEnabled: doc.PushEnabled,
-			}, nil
-		}
+	if len(doc.Tasks) == 0 {
+		return nil, nil, mongo.ErrNoDocuments
 	}
-	return nil, nil, mongo.ErrNoDocuments
+	return &doc.Tasks[0], &categoryRow{
+		ID:          doc.ID,
+		Integration: doc.Integration,
+		PushEnabled: doc.PushEnabled,
+	}, nil
 }
 
 // parseCategoryIntegration extracts (connectionID, calendarID) from "gcal:<connID>:<calID>".

--- a/backend/internal/handlers/calendar/push_service.go
+++ b/backend/internal/handlers/calendar/push_service.go
@@ -1,0 +1,264 @@
+package calendar
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.opentelemetry.io/otel"
+)
+
+// ProcessPushRow handles one outbox row end-to-end. Returns nil on success,
+// an error otherwise; the worker translates that into a backoff via MarkFailure.
+func (s *Service) ProcessPushRow(ctx context.Context, row PushOutboxRow) error {
+	ctx, span := otel.Tracer("kindred").Start(ctx, "calendar.push.process")
+	defer span.End()
+	slog.Info("Push: processing outbox row",
+		"row_id", row.ID,
+		"task_id", row.TaskID,
+		"op", row.Op,
+		"attempt", row.AttemptCount)
+
+	switch row.Op {
+	case PushOpDelete:
+		return s.processPushDelete(ctx, row)
+	case PushOpUpsert:
+		return s.processPushUpsert(ctx, row)
+	default:
+		return fmt.Errorf("unknown push op: %s", row.Op)
+	}
+}
+
+func (s *Service) processPushDelete(ctx context.Context, row PushOutboxRow) error {
+	if row.TargetEventID == "" || row.TargetCalendarID == "" || row.TargetConnectionID.IsZero() {
+		slog.Warn("Push delete missing target snapshot; nothing to do", "row_id", row.ID)
+		return nil
+	}
+	conn, err := s.connectionByID(ctx, row.TargetConnectionID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			slog.Info("Push delete: connection gone, treating as success", "connection_id", row.TargetConnectionID)
+			return nil
+		}
+		return fmt.Errorf("load connection: %w", err)
+	}
+	provider, ok := s.providers[conn.Provider]
+	if !ok {
+		return fmt.Errorf("unsupported provider %s", conn.Provider)
+	}
+	token, err := s.getValidToken(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("refresh token: %w", err)
+	}
+	if err := provider.DeleteEvent(ctx, token, row.TargetCalendarID, row.TargetEventID); err != nil {
+		return fmt.Errorf("provider delete: %w", err)
+	}
+
+	// Clear pushed_* fields on the task if they still point at this event.
+	_, _ = s.categories.UpdateOne(ctx,
+		bson.M{
+			"_id":                   row.CategoryID,
+			"tasks._id":             row.TaskID,
+			"tasks.pushed_event_id": row.TargetEventID,
+		},
+		bson.M{
+			"$unset": bson.M{
+				"tasks.$.pushed_event_id":    "",
+				"tasks.$.pushed_calendar_id": "",
+				"tasks.$.pushed_event_etag":  "",
+			},
+		},
+	)
+	return nil
+}
+
+func (s *Service) processPushUpsert(ctx context.Context, row PushOutboxRow) error {
+	task, category, err := s.loadTaskWithCategory(ctx, row.TaskID, row.CategoryID)
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			slog.Info("Push upsert: task or category gone, dropping", "task_id", row.TaskID)
+			return nil
+		}
+		return fmt.Errorf("load task: %w", err)
+	}
+	if !category.PushEnabled {
+		slog.Info("Push upsert: category push disabled, dropping", "category_id", row.CategoryID)
+		return nil
+	}
+	connID, calendarID, ok := parseCategoryIntegration(category.Integration)
+	if !ok {
+		slog.Info("Push upsert: category integration not a Google calendar, dropping", "integration", category.Integration)
+		return nil
+	}
+
+	ev, err := BuildProviderEventFromTask(task, calendarID)
+	if err != nil {
+		if errors.Is(err, ErrTaskNotPushable) {
+			// Task lost its date. If we previously pushed an event, delete it now —
+			// otherwise the calendar would carry a stale event indefinitely.
+			if task.PushedEventID != "" {
+				slog.Info("Push upsert: task no longer pushable, deleting prior event", "task_id", task.ID, "event_id", task.PushedEventID)
+				return s.deleteEventForTask(ctx, task, row.CategoryID)
+			}
+			slog.Info("Push upsert: task not pushable and never was pushed, dropping", "task_id", task.ID)
+			return nil
+		}
+		return fmt.Errorf("build event: %w", err)
+	}
+
+	conn, err := s.connectionByID(ctx, connID)
+	if err != nil {
+		return fmt.Errorf("load connection: %w", err)
+	}
+	provider, ok2 := s.providers[conn.Provider]
+	if !ok2 {
+		return fmt.Errorf("unsupported provider %s", conn.Provider)
+	}
+	token, err := s.getValidToken(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("refresh token: %w", err)
+	}
+
+	var written ProviderEvent
+	if task.PushedEventID == "" {
+		written, err = provider.CreateEvent(ctx, token, ev)
+		if err != nil {
+			return fmt.Errorf("provider create: %w", err)
+		}
+	} else {
+		written, err = provider.UpdateEvent(ctx, token, task.PushedEventID, ev)
+		if err != nil {
+			return fmt.Errorf("provider update: %w", err)
+		}
+	}
+
+	_, err = s.categories.UpdateOne(ctx,
+		bson.M{"_id": row.CategoryID, "tasks._id": row.TaskID},
+		bson.M{
+			"$set": bson.M{
+				"tasks.$.pushed_event_id":    written.ID,
+				"tasks.$.pushed_calendar_id": written.CalendarID,
+				"tasks.$.pushed_event_etag":  written.ExtendedProperties["etag"],
+			},
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("persist pushed_event_id: %w", err)
+	}
+	return nil
+}
+
+// deleteEventForTask deletes the task's previously-pushed event using the
+// connection inferred from its category's integration field. Also clears the
+// task's pushed_* fields.
+func (s *Service) deleteEventForTask(ctx context.Context, task *types.TaskDocument, categoryID primitive.ObjectID) error {
+	var cat struct {
+		Integration string `bson:"integration"`
+	}
+	if err := s.categories.FindOne(ctx, bson.M{"_id": categoryID}).Decode(&cat); err != nil {
+		return fmt.Errorf("load category for delete: %w", err)
+	}
+	connID, _, ok := parseCategoryIntegration(cat.Integration)
+	if !ok {
+		return nil
+	}
+	conn, err := s.connectionByID(ctx, connID)
+	if err != nil {
+		return fmt.Errorf("load connection for delete: %w", err)
+	}
+	provider, ok := s.providers[conn.Provider]
+	if !ok {
+		return fmt.Errorf("unsupported provider %s", conn.Provider)
+	}
+	token, err := s.getValidToken(ctx, conn)
+	if err != nil {
+		return fmt.Errorf("refresh token: %w", err)
+	}
+	if err := provider.DeleteEvent(ctx, token, task.PushedCalendarID, task.PushedEventID); err != nil {
+		return fmt.Errorf("provider delete: %w", err)
+	}
+	_, _ = s.categories.UpdateOne(ctx,
+		bson.M{"_id": categoryID, "tasks._id": task.ID},
+		bson.M{"$unset": bson.M{
+			"tasks.$.pushed_event_id":    "",
+			"tasks.$.pushed_calendar_id": "",
+			"tasks.$.pushed_event_etag":  "",
+		}},
+	)
+	return nil
+}
+
+// connectionByID is a thin helper around the connections collection.
+func (s *Service) connectionByID(ctx context.Context, id primitive.ObjectID) (*CalendarConnection, error) {
+	var conn CalendarConnection
+	err := s.connections.FindOne(ctx, bson.M{"_id": id}).Decode(&conn)
+	if err != nil {
+		return nil, err
+	}
+	return &conn, nil
+}
+
+// categoryRow is a partial category projection — only what the push worker needs.
+type categoryRow struct {
+	ID          primitive.ObjectID `bson:"_id"`
+	Integration string             `bson:"integration"`
+	PushEnabled bool               `bson:"push_enabled"`
+}
+
+// loadTaskWithCategory finds the embedded task in its category.
+func (s *Service) loadTaskWithCategory(ctx context.Context, taskID, categoryID primitive.ObjectID) (*types.TaskDocument, *categoryRow, error) {
+	var doc struct {
+		ID          primitive.ObjectID   `bson:"_id"`
+		Integration string               `bson:"integration"`
+		PushEnabled bool                 `bson:"push_enabled"`
+		Tasks       []types.TaskDocument `bson:"tasks"`
+	}
+	err := s.categories.FindOne(ctx, bson.M{
+		"_id":       categoryID,
+		"tasks._id": taskID,
+	}).Decode(&doc)
+	if err != nil {
+		return nil, nil, err
+	}
+	for i := range doc.Tasks {
+		if doc.Tasks[i].ID == taskID {
+			return &doc.Tasks[i], &categoryRow{
+				ID:          doc.ID,
+				Integration: doc.Integration,
+				PushEnabled: doc.PushEnabled,
+			}, nil
+		}
+	}
+	return nil, nil, mongo.ErrNoDocuments
+}
+
+// parseCategoryIntegration extracts (connectionID, calendarID) from "gcal:<connID>:<calID>".
+// Returns ok=false if the format does not match.
+func parseCategoryIntegration(integration string) (primitive.ObjectID, string, bool) {
+	const prefix = "gcal:"
+	if len(integration) < len(prefix) || integration[:len(prefix)] != prefix {
+		return primitive.NilObjectID, "", false
+	}
+	rest := integration[len(prefix):]
+	// Find the second colon; everything before is the connection id (24 hex chars).
+	colonIdx := -1
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == ':' {
+			colonIdx = i
+			break
+		}
+	}
+	if colonIdx <= 0 || colonIdx >= len(rest)-1 {
+		return primitive.NilObjectID, "", false
+	}
+	connID, err := primitive.ObjectIDFromHex(rest[:colonIdx])
+	if err != nil {
+		return primitive.NilObjectID, "", false
+	}
+	return connID, rest[colonIdx+1:], true
+}

--- a/backend/internal/handlers/calendar/routes.go
+++ b/backend/internal/handlers/calendar/routes.go
@@ -8,7 +8,7 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
-func Routes(api huma.API, collections map[string]*mongo.Collection, cfg config.Config) {
+func Routes(api huma.API, collections map[string]*mongo.Collection, cfg config.Config) *Service {
 	slog.Info("Registering calendar routes")
 
 	// Get or create calendar_connections collection
@@ -29,7 +29,7 @@ func Routes(api huma.API, collections map[string]*mongo.Collection, cfg config.C
 	categories := collections["categories"]
 	if categories == nil {
 		slog.Error("categories collection not found")
-		return
+		return nil
 	}
 
 	service := NewService(calendarConnections, categories, cfg)
@@ -57,4 +57,5 @@ func Routes(api huma.API, collections map[string]*mongo.Collection, cfg config.C
 	RegisterWebhookOperation(api, handler)
 
 	slog.Info("Calendar routes registered successfully")
+	return service
 }

--- a/backend/internal/handlers/calendar/service.go
+++ b/backend/internal/handlers/calendar/service.go
@@ -326,8 +326,8 @@ func (s *Service) ListCalendarsForConnection(ctx context.Context, connectionID, 
 }
 
 // SetupWorkspacesForConnection creates workspaces and categories for selected calendars
-func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID, userID primitive.ObjectID, calendarIDs []string, mergeIntoOne bool, makePublic bool) error {
-	slog.Info("Setting up workspaces for connection", "connection_id", connectionID, "user_id", userID, "calendar_count", len(calendarIDs), "merge_into_one", mergeIntoOne)
+func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID, userID primitive.ObjectID, calendarIDs []string, pushEnabledCalendarIDs []string, mergeIntoOne bool, makePublic bool) error {
+	slog.Info("Setting up workspaces for connection", "connection_id", connectionID, "user_id", userID, "calendar_count", len(calendarIDs), "push_enabled_count", len(pushEnabledCalendarIDs), "merge_into_one", mergeIntoOne)
 
 	var connection CalendarConnection
 	err := s.connections.FindOne(ctx, bson.M{
@@ -363,6 +363,11 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 		selectedSet[id] = true
 	}
 
+	pushEnabledSet := make(map[string]bool, len(pushEnabledCalendarIDs))
+	for _, id := range pushEnabledCalendarIDs {
+		pushEnabledSet[id] = true
+	}
+
 	now := time.Now()
 
 	for _, cal := range allCalendars {
@@ -388,7 +393,14 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 		}).Decode(&existing)
 
 		if err == nil {
-			slog.Info("Category already exists, skipping", "calendar_id", cal.ID, "category_id", existing.ID)
+			// Update push_enabled on existing category if it differs.
+			_, updErr := s.categories.UpdateOne(ctx, bson.M{"_id": existing.ID}, bson.M{
+				"$set": bson.M{"push_enabled": pushEnabledSet[cal.ID]},
+			})
+			if updErr != nil {
+				slog.Warn("Failed to update push_enabled on existing category", "category_id", existing.ID, "error", updErr)
+			}
+			slog.Info("Category already exists, updated push flag", "calendar_id", cal.ID, "category_id", existing.ID, "push_enabled", pushEnabledSet[cal.ID])
 			continue
 		} else if err != mongo.ErrNoDocuments {
 			return fmt.Errorf("failed to check existing category for %s: %w", cal.Name, err)
@@ -402,6 +414,7 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 			"tasks":         []bson.M{},
 			"user":          userID,
 			"integration":   integrationKey,
+			"push_enabled":  pushEnabledSet[cal.ID],
 		}
 
 		_, err = s.categories.InsertOne(ctx, category)

--- a/backend/internal/handlers/calendar/service.go
+++ b/backend/internal/handlers/calendar/service.go
@@ -707,6 +707,12 @@ func (s *Service) SyncEventsToTasks(ctx context.Context, connectionID, userID pr
 		tasksSkipped := 0
 
 		for _, event := range calEvents {
+			// Loop prevention: skip events Kindred itself wrote.
+			if IsPushOriginEvent(event) {
+				slog.Debug("Sync: skipping push-origin event", "event_id", event.ID, "task_id_hint", event.ExtendedProperties["kindred_task_id"])
+				tasksSkipped++
+				continue
+			}
 			// Convert event to task params
 			taskParams := ConvertEventToTaskParams(event, userID, category.ID, connection.MakePublic)
 

--- a/backend/internal/handlers/calendar/service.go
+++ b/backend/internal/handlers/calendar/service.go
@@ -20,8 +20,14 @@ type Service struct {
 	connections     *mongo.Collection
 	categories      *mongo.Collection
 	processedEvents *mongo.Collection
+	pushOutbox      *PushOutbox
 	providers       map[CalendarProvider]Provider
 	config          config.Config
+}
+
+// PushOutbox returns the push outbox helper (used by jobs and the task package).
+func (s *Service) PushOutbox() *PushOutbox {
+	return s.pushOutbox
 }
 
 // GetConnectionForUser fetches a calendar connection that belongs to the given user
@@ -45,11 +51,13 @@ func NewService(connections *mongo.Collection, categories *mongo.Collection, cfg
 
 	// Get processed events collection from the same database
 	processedEvents := connections.Database().Collection("calendar_processed_events")
+	pushOutboxCol := connections.Database().Collection("calendar_push_outbox")
 
 	return &Service{
 		connections:     connections,
 		categories:      categories,
 		processedEvents: processedEvents,
+		pushOutbox:      NewPushOutbox(pushOutboxCol),
 		providers:       providers,
 		config:          cfg,
 	}

--- a/backend/internal/handlers/calendar/types.go
+++ b/backend/internal/handlers/calendar/types.go
@@ -82,9 +82,10 @@ type ListCalendarsOutput struct {
 type SetupWorkspacesInput struct {
 	ConnectionID string `path:"connectionId" required:"true"`
 	Body         struct {
-		CalendarIDs  []string `json:"calendar_ids"`
-		MergeIntoOne bool     `json:"merge_into_one"`
-		MakePublic   bool     `json:"make_public"`
+		CalendarIDs    []string `json:"calendar_ids"`
+		PushEnabledIDs []string `json:"push_enabled_calendar_ids,omitempty" doc:"Calendar IDs (subset of calendar_ids) that should also receive Kindred tasks pushed back to Google. Default empty (push disabled)."`
+		MergeIntoOne   bool     `json:"merge_into_one"`
+		MakePublic     bool     `json:"make_public"`
 	}
 }
 

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -9,7 +9,7 @@ import (
 /*
 Router maps endpoints to handlers
 */
-func Routes(api huma.API, collections map[string]*mongo.Collection, geminiService any, ringService *rings.RingService) {
+func Routes(api huma.API, collections map[string]*mongo.Collection, geminiService any, ringService *rings.RingService) *Service {
 	service := newService(collections, ringService)
 	handler := Handler{
 		service:       service,
@@ -17,6 +17,7 @@ func Routes(api huma.API, collections map[string]*mongo.Collection, geminiServic
 	}
 
 	RegisterTaskOperations(api, &handler)
+	return service
 }
 
 // RegisterTaskOperations registers all task operations with Huma

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -1036,7 +1036,6 @@ func (s *Service) BulkDeleteTask(userId primitive.ObjectID, tasks []BulkDeleteTa
 }
 
 func (s *Service) IncrementTaskCompletedAndDelete(userId primitive.ObjectID, categoryId primitive.ObjectID, id primitive.ObjectID) error {
-	s.snapshotPushTargetForDelete(context.Background(), id, categoryId, userId)
 	ctx := context.Background()
 
 	// TODO: find a way better way to do this
@@ -1126,7 +1125,6 @@ func (s *Service) DeleteTaskByID(id primitive.ObjectID) error {
 	}
 
 	for _, result := range results {
-		s.snapshotPushTargetForDelete(ctx, id, result.ID, primitive.NilObjectID)
 		err = s.DeleteTask(result.ID, id)
 		if err != nil {
 			return err

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -216,6 +216,74 @@ func (s *Service) enqueuePushUpsertIfEnabled(ctx context.Context, taskID, catego
 	}
 }
 
+// snapshotPushTargetForDelete reads the task's pushed_event_id / pushed_calendar_id
+// (if any) along with the category's connection_id (parsed from `integration`) and
+// enqueues a delete. Called BEFORE the task is removed.
+func (s *Service) snapshotPushTargetForDelete(ctx context.Context, taskID, categoryID, userID primitive.ObjectID) {
+	if s.PushEnqueuer == nil {
+		return
+	}
+	var cat struct {
+		Integration string `bson:"integration"`
+		PushEnabled bool   `bson:"push_enabled"`
+		Tasks       []struct {
+			ID               primitive.ObjectID `bson:"_id"`
+			PushedEventID    string             `bson:"pushed_event_id,omitempty"`
+			PushedCalendarID string             `bson:"pushed_calendar_id,omitempty"`
+		} `bson:"tasks"`
+	}
+	err := s.Tasks.FindOne(ctx, bson.M{
+		"_id":       categoryID,
+		"tasks._id": taskID,
+	}, options.FindOne().SetProjection(bson.M{
+		"integration":              1,
+		"push_enabled":             1,
+		"tasks._id":                1,
+		"tasks.pushed_event_id":    1,
+		"tasks.pushed_calendar_id": 1,
+	})).Decode(&cat)
+	if err != nil {
+		return
+	}
+	if !cat.PushEnabled {
+		return
+	}
+	var eventID, calendarID string
+	for _, t := range cat.Tasks {
+		if t.ID == taskID {
+			eventID = t.PushedEventID
+			calendarID = t.PushedCalendarID
+			break
+		}
+	}
+	if eventID == "" {
+		return
+	}
+	// Parse connectionID from integration "gcal:<connID>:<calID>".
+	const prefix = "gcal:"
+	if len(cat.Integration) <= len(prefix) || cat.Integration[:len(prefix)] != prefix {
+		return
+	}
+	rest := cat.Integration[len(prefix):]
+	colonIdx := -1
+	for i := 0; i < len(rest); i++ {
+		if rest[i] == ':' {
+			colonIdx = i
+			break
+		}
+	}
+	if colonIdx <= 0 {
+		return
+	}
+	connID, err := primitive.ObjectIDFromHex(rest[:colonIdx])
+	if err != nil {
+		return
+	}
+	if err := s.PushEnqueuer.EnqueueDelete(ctx, taskID, categoryID, userID, connID, eventID, calendarID); err != nil {
+		slog.Warn("Push hook: enqueue delete failed", "task_id", taskID, "error", err)
+	}
+}
+
 // UpdatePartialTask updates only specified fields of a Task document by ObjectID.
 func (s *Service) UpdatePartialTask(
 	id primitive.ObjectID,
@@ -968,6 +1036,7 @@ func (s *Service) BulkDeleteTask(userId primitive.ObjectID, tasks []BulkDeleteTa
 }
 
 func (s *Service) IncrementTaskCompletedAndDelete(userId primitive.ObjectID, categoryId primitive.ObjectID, id primitive.ObjectID) error {
+	s.snapshotPushTargetForDelete(context.Background(), id, categoryId, userId)
 	ctx := context.Background()
 
 	// TODO: find a way better way to do this
@@ -1015,6 +1084,7 @@ func (s *Service) IncrementTaskCompletedAndDelete(userId primitive.ObjectID, cat
 
 // DeleteCategory removes a Category document by ObjectID.
 func (s *Service) DeleteTask(categoryId primitive.ObjectID, id primitive.ObjectID) error {
+	s.snapshotPushTargetForDelete(context.Background(), id, categoryId, primitive.NilObjectID)
 	ctx := context.Background()
 	result, err := s.Tasks.UpdateOne(
 		ctx, bson.M{
@@ -1056,6 +1126,7 @@ func (s *Service) DeleteTaskByID(id primitive.ObjectID) error {
 	}
 
 	for _, result := range results {
+		s.snapshotPushTargetForDelete(ctx, id, result.ID, primitive.NilObjectID)
 		err = s.DeleteTask(result.ID, id)
 		if err != nil {
 			return err

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -189,7 +189,31 @@ func (s *Service) CreateTask(categoryId primitive.ObjectID, r *TaskDocument) (*T
 	// Cast the inserted ID to ObjectID
 	slog.LogAttrs(ctx, slog.LevelInfo, "Task inserted")
 
+	s.enqueuePushUpsertIfEnabled(context.Background(), r.ID, categoryId, r.UserID)
+
 	return r, nil
+}
+
+// enqueuePushUpsertIfEnabled checks whether the task's category has push_enabled,
+// and if so, queues an upsert. Failures are logged but never block the task mutation.
+func (s *Service) enqueuePushUpsertIfEnabled(ctx context.Context, taskID, categoryID, userID primitive.ObjectID) {
+	if s.PushEnqueuer == nil {
+		return
+	}
+	var cat struct {
+		PushEnabled bool `bson:"push_enabled"`
+	}
+	err := s.Tasks.FindOne(ctx, bson.M{"_id": categoryID}, options.FindOne().SetProjection(bson.M{"push_enabled": 1})).Decode(&cat)
+	if err != nil {
+		slog.Warn("Push hook: category lookup failed", "category_id", categoryID, "error", err)
+		return
+	}
+	if !cat.PushEnabled {
+		return
+	}
+	if err := s.PushEnqueuer.EnqueueUpsert(ctx, taskID, categoryID, userID); err != nil {
+		slog.Warn("Push hook: enqueue upsert failed", "task_id", taskID, "error", err)
+	}
 }
 
 // UpdatePartialTask updates only specified fields of a Task document by ObjectID.

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -292,6 +292,14 @@ func (s *Service) UpdatePartialTask(
 
 	ctx := context.Background()
 
+	// Resolve the category owner up-front so the push hook can attribute the
+	// outbox row to the right user. Done before the `options` shadow below.
+	var ownerDoc struct {
+		User primitive.ObjectID `bson:"user"`
+	}
+	_ = s.Tasks.FindOne(ctx, bson.M{"_id": categoryId}, options.FindOne().SetProjection(bson.M{"user": 1})).Decode(&ownerDoc)
+	ownerUserID := ownerDoc.User
+
 	options := options.UpdateOptions{
 		ArrayFilters: &options.ArrayFilters{
 			Filters: bson.A{
@@ -365,7 +373,7 @@ func (s *Service) UpdatePartialTask(
 		return nil, err
 	}
 
-	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, primitive.NilObjectID)
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, ownerUserID)
 
 	return nil, err
 }
@@ -719,6 +727,10 @@ func (s *Service) BulkCompleteTask(userId primitive.ObjectID, tasks []BulkComple
 			slog.Warn("Failed to move task to completed-tasks", "taskID", taskID.Hex(), "error", err)
 			continue
 		}
+
+		// Mirror the single-task CompleteTask push hook: enqueue an upsert
+		// after the task has been successfully marked completed.
+		s.enqueuePushUpsertIfEnabled(context.Background(), taskID, mapping.categoryID, userId)
 	}
 
 	// Create a set of failed task IDs for efficient lookup
@@ -978,6 +990,16 @@ func (s *Service) BulkDeleteTask(userId primitive.ObjectID, tasks []BulkDeleteTa
 		return output, nil
 	}
 
+	// Snapshot push targets BEFORE the bulk $pull removes the tasks from
+	// their categories. Mirrors how the single-task DeleteTask calls
+	// snapshotPushTargetForDelete at the top of the function — once the
+	// tasks are pulled, pushed_event_id is unreachable.
+	for categoryID, taskIDsInCategory := range tasksByCategory {
+		for _, taskID := range taskIDsInCategory {
+			s.snapshotPushTargetForDelete(context.Background(), taskID, categoryID, userId)
+		}
+	}
+
 	// Bulk delete tasks from categories using $pull with $in
 	for categoryID, taskIDsInCategory := range tasksByCategory {
 		// Use $pullAll to remove multiple tasks at once
@@ -1087,8 +1109,12 @@ func (s *Service) IncrementTaskCompletedAndDelete(userId primitive.ObjectID, cat
 
 // DeleteCategory removes a Category document by ObjectID.
 func (s *Service) DeleteTask(categoryId primitive.ObjectID, id primitive.ObjectID) error {
-	s.snapshotPushTargetForDelete(context.Background(), id, categoryId, primitive.NilObjectID)
 	ctx := context.Background()
+	var ownerDoc struct {
+		User primitive.ObjectID `bson:"user"`
+	}
+	_ = s.Tasks.FindOne(ctx, bson.M{"_id": categoryId}, options.FindOne().SetProjection(bson.M{"user": 1})).Decode(&ownerDoc)
+	s.snapshotPushTargetForDelete(context.Background(), id, categoryId, ownerDoc.User)
 	result, err := s.Tasks.UpdateOne(
 		ctx, bson.M{
 			"_id": categoryId,

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -487,6 +487,8 @@ func (s *Service) CompleteTask(
 		}()
 	}
 
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, userId)
+
 	return &TaskCompletionResult{
 		StreakChanged: streakChanged,
 		CurrentStreak: userAfter.Streak,
@@ -1098,6 +1100,9 @@ func (s *Service) ActivateTask(userId primitive.ObjectID, categoryId primitive.O
 
 	resultDecoded := *result
 	fmt.Println(resultDecoded)
+
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, userId)
+
 	return err
 
 }

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -297,6 +297,8 @@ func (s *Service) UpdatePartialTask(
 		return nil, err
 	}
 
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, primitive.NilObjectID)
+
 	return nil, err
 }
 
@@ -1252,6 +1254,8 @@ func (s *Service) UpdateTaskDeadline(id primitive.ObjectID, categoryID primitive
 		return handleMongoError(ctx, "update task deadline", err)
 	}
 
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryID, userID)
+
 	// Recalculate FOLLOW_UP reminder
 	return s.recalculateFollowUp(ctx, id, categoryID, update.Deadline)
 }
@@ -1283,8 +1287,13 @@ func (s *Service) UpdateTaskStart(id primitive.ObjectID, categoryID primitive.Ob
 		bson.M{"$set": updateFields},
 		getTaskArrayFilterOptions(id),
 	)
+	if err != nil {
+		return handleMongoError(ctx, "update task start date/time", err)
+	}
 
-	return handleMongoError(ctx, "update task start date/time", err)
+	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryID, userID)
+
+	return nil
 }
 
 // UpdateTaskReminders updates the reminders field of a task

--- a/backend/internal/handlers/task/types.go
+++ b/backend/internal/handlers/task/types.go
@@ -1,6 +1,7 @@
 package task
 
 import (
+	"context"
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
@@ -9,6 +10,13 @@ import (
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// PushEnqueuer is satisfied by *calendar.PushOutbox; injected via a setter
+// so the task package doesn't depend on the calendar package directly.
+type PushEnqueuer interface {
+	EnqueueUpsert(ctx context.Context, taskID, categoryID, userID primitive.ObjectID) error
+	EnqueueDelete(ctx context.Context, taskID, categoryID, userID, connectionID primitive.ObjectID, eventID, calendarID string) error
+}
 
 type CreateTaskParams struct {
 	Priority  int     `validate:"required,min=1,max=3" bson:"priority" json:"priority"`
@@ -140,6 +148,7 @@ type Service struct {
 	TemplateTasks       *mongo.Collection
 	EncouragementHelper EncouragementServiceInterface
 	RingService         *rings.RingService
+	PushEnqueuer        PushEnqueuer // optional; nil disables push hooks
 }
 
 // EncouragementServiceInterface defines the methods we need from the encouragement service

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -70,6 +70,10 @@ type TaskDocument struct {
 	BlueprintID *primitive.ObjectID `bson:"blueprintId,omitempty" json:"blueprintId,omitempty"`
 	Integration string              `bson:"integration,omitempty" json:"integration,omitempty"`
 
+	PushedEventID    string `bson:"pushed_event_id,omitempty" json:"pushed_event_id,omitempty"`       // Google event ID for tasks pushed to a calendar
+	PushedCalendarID string `bson:"pushed_calendar_id,omitempty" json:"pushed_calendar_id,omitempty"` // Calendar the event lives on
+	PushedEventEtag  string `bson:"pushed_event_etag,omitempty" json:"pushed_event_etag,omitempty"`   // ETag at last write (for future drift detection)
+
 	FlexInfo *FlexInstanceInfo `bson:"flexInfo,omitempty" json:"flexInfo,omitempty"`
 
 	// Working state — set when user starts working, cleared on complete/stop

--- a/backend/internal/jobs/calendar_push_worker.go
+++ b/backend/internal/jobs/calendar_push_worker.go
@@ -1,0 +1,83 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"runtime/debug"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/config"
+	"github.com/abhikaboy/Kindred/internal/handlers/calendar"
+	"github.com/getsentry/sentry-go"
+	"github.com/robfig/cron/v3"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// CalendarPushWorker drains the calendar_push_outbox and pushes tasks to Google Calendar.
+type CalendarPushWorker struct {
+	service *calendar.Service
+}
+
+// NewCalendarPushWorker constructs the worker reusing the calendar service.
+func NewCalendarPushWorker(connections, categories *mongo.Collection, cfg config.Config) *CalendarPushWorker {
+	service := calendar.NewService(connections, categories, cfg)
+	return &CalendarPushWorker{service: service}
+}
+
+// StartCron registers the drain on the given cron scheduler. Runs every 30 seconds.
+// (The outbox table also stores next_attempt_at, so backed-off rows don't run early.)
+func (w *CalendarPushWorker) StartCron(c *cron.Cron) {
+	_, err := c.AddFunc("@every 30s", func() {
+		defer func() {
+			if r := recover(); r != nil {
+				stack := string(debug.Stack())
+				slog.Error("Panic in calendar push worker", "panic", r, "stack", stack)
+				sentry.CurrentHub().Recover(r)
+				sentry.Flush(2 * time.Second)
+			}
+		}()
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := w.Run(ctx); err != nil {
+			slog.Error("Calendar push worker failed", "error", err)
+			sentry.CaptureException(fmt.Errorf("calendar push worker failed: %w", err))
+		}
+	})
+	if err != nil {
+		slog.Error("Error registering calendar push worker cron", "error", err)
+	} else {
+		slog.Info("Calendar push worker registered (every 30s)")
+	}
+}
+
+// Run drains up to 50 rows in one tick.
+func (w *CalendarPushWorker) Run(ctx context.Context) error {
+	outbox := w.service.PushOutbox()
+	rows, err := outbox.ClaimBatch(ctx, 50)
+	if err != nil {
+		return fmt.Errorf("claim batch: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	slog.Info("Calendar push worker draining", "count", len(rows))
+
+	var processed, failed int
+	for _, row := range rows {
+		if err := w.service.ProcessPushRow(ctx, row); err != nil {
+			slog.Error("Push row failed", "row_id", row.ID, "task_id", row.TaskID, "op", row.Op, "attempt", row.AttemptCount, "error", err)
+			if markErr := outbox.MarkFailure(ctx, row.ID, row.AttemptCount, err.Error()); markErr != nil {
+				slog.Error("Failed to mark push row failure", "row_id", row.ID, "error", markErr)
+			}
+			failed++
+			continue
+		}
+		if err := outbox.MarkSuccess(ctx, row.ID); err != nil {
+			slog.Error("Failed to delete successful push row", "row_id", row.ID, "error", err)
+		}
+		processed++
+	}
+	slog.Info("Calendar push worker tick complete", "processed", processed, "failed", failed)
+	return nil
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -207,7 +207,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 		heartbeatJob := jobs.NewCalendarHeartbeatJob(calendarConns, collections["categories"], cfg)
 		heartbeatJob.StartCron(cronScheduler)
 
-		// Push notification worker (drains queued channel notifications)
+		// Calendar push worker (drains the calendar_push_outbox, mirroring Kindred task changes to Google Calendar)
 		pushWorker := jobs.NewCalendarPushWorker(calendarConns, collections["categories"], cfg)
 		pushWorker.StartCron(cronScheduler)
 	} else {

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -141,7 +141,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	category.Routes(api, collections)
 	activity.Routes(api, collections)
 	profile.Routes(api, collections, ringService)
-	task.Routes(api, collections, geminiService, ringService)
+	taskService := task.Routes(api, collections, geminiService, ringService)
 
 	// SSE streaming routes for NLP flows (raw Fiber, bypass Huma)
 	taskStreamHandler := task.NewStreamHandler(collections, geminiService, ringService)
@@ -182,7 +182,12 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	report.Routes(api, collections)
 
 	// Register calendar routes
-	calendar.Routes(api, collections, cfg)
+	calendarService := calendar.Routes(api, collections, cfg)
+
+	// Wire the calendar push outbox into the task service so task mutations enqueue pushes.
+	if calendarService != nil && taskService != nil {
+		taskService.PushEnqueuer = calendarService.PushOutbox()
+	}
 
 	// Register subscription webhook routes
 	subscription.Routes(api, collections, cfg)

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -201,6 +201,10 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 		// Connection heartbeat (every 1h)
 		heartbeatJob := jobs.NewCalendarHeartbeatJob(calendarConns, collections["categories"], cfg)
 		heartbeatJob.StartCron(cronScheduler)
+
+		// Push notification worker (drains queued channel notifications)
+		pushWorker := jobs.NewCalendarPushWorker(calendarConns, collections["categories"], cfg)
+		pushWorker.StartCron(cronScheduler)
 	} else {
 		slog.Warn("Calendar jobs disabled: calendar_connections collection not available")
 	}


### PR DESCRIPTION
## Summary

Adds one-way push sync so qualifying Kindred tasks (timed, all-day, deadline-only, completed) automatically mirror to a Google Calendar of the user's choice. Reuses the existing `Provider.CreateEvent`/`UpdateEvent`/`DeleteEvent` plumbing — those methods were declared but had no callers before this PR. Pull sync is unchanged.

**Design:** [`docs/superpowers/specs/2026-05-27-calendar-push-sync-design.md`](docs/superpowers/specs/2026-05-27-calendar-push-sync-design.md)
**Plan:** [`docs/superpowers/plans/2026-05-27-calendar-push-sync.md`](docs/superpowers/plans/2026-05-27-calendar-push-sync.md)

## Architecture

- **Per-category opt-in:** Categories gain a `push_enabled` bool; the setup endpoint (`POST /v1/user/calendar/connections/{id}/setup`) takes a `push_enabled_calendar_ids` list (subset of `calendar_ids`).
- **Outbox pattern:** Task mutations don't call Google synchronously. They enqueue rows into a new `calendar_push_outbox` MongoDB collection; a cron worker (every 30s, alongside existing heartbeat/watch-renewal jobs) drains them.
- **Loop prevention:** Every event Kindred writes carries `extendedProperties.private.kindred_task_id` and `extendedProperties.private.kindred_origin = "push"`. The inbound `SyncEventsToTasks` path skips any event with `kindred_origin = "push"` so we never create phantom tasks from our own writes.
- **Atomic claim:** `ClaimBatch` pushes `next_attempt_at` forward by a 5-minute TTL before processing, so re-entrant cron ticks or sibling replicas don't double-process rows.
- **Exponential backoff** (10s → 30s → 1m → 5m → 15m → 1h) with permanent failure after 10 attempts.
- **Title prefixes** map task state to event titles: deadline-only tasks get `Due: ` prefix; completed tasks get `✓ ` prefix (event is **not** deleted on completion).

## Lifecycle hooks (every mutation that affects the Google view)

- `CreateTask`, `UpdatePartialTask`, `UpdateTaskDeadline`, `UpdateTaskStart` → enqueue upsert
- `CompleteTask`, `ActivateTask`, `BulkCompleteTask` → enqueue upsert (title prefix toggles)
- `DeleteTask`, `BulkDeleteTask` → enqueue delete (snapshot of event ID + calendar ID taken BEFORE the row disappears)

## Key files

| File | Purpose |
|---|---|
| `backend/internal/handlers/calendar/push_converter.go` | `BuildProviderEventFromTask` + `IsPushOriginEvent` |
| `backend/internal/handlers/calendar/push_outbox.go` | Outbox model, enqueue/coalesce/claim helpers |
| `backend/internal/handlers/calendar/push_service.go` | `ProcessPushRow` — fetches task + category, calls provider, persists `pushed_event_id` |
| `backend/internal/jobs/calendar_push_worker.go` | Cron worker draining the outbox every 30s |
| `backend/internal/handlers/task/task_service.go` | `PushEnqueuer` interface, hook helpers (`enqueuePushUpsertIfEnabled`, `snapshotPushTargetForDelete`), call sites on every relevant mutation |
| `backend/internal/server/server.go` | Wires `taskService.PushEnqueuer = calendarService.PushOutbox()` |

## Test plan

- [x] All `internal/handlers/calendar/`, `internal/handlers/task/...`, `internal/jobs/` tests pass (`go test`)
- [x] Pre-commit hooks (gofmt, go vet, full Go test suite) clean on every commit
- [ ] **Manual E2E with a real Google account:**
  - [ ] Connect Google Calendar; run setup with one calendar in `push_enabled_calendar_ids`
  - [ ] Create a timed task in the corresponding category → event appears on Google within ~1 min with matching title/time
  - [ ] Edit task title → Google event updates
  - [ ] Complete task → Google event title gets `✓ ` prefix, event stays
  - [ ] Delete task → Google event removed
  - [ ] Confirm webhook delivery after each push logs `Sync: skipping push-origin event` and creates no phantom task

## Out of scope (deferred, documented in spec/review)

- Frontend setup UI for the push toggle (backend accepts `push_enabled_calendar_ids`; UI work is a separate plan)
- Recurring tasks
- Bulk catch-up when push is enabled on a category with existing tasks
- Drift detection / conflict resolution when the user manually edits a Kindred-written event in Google
- Task moved between categories (no `MoveTask` exists in the task service today)

## Migration notes

- Existing categories without `push_enabled` decode as `false` — no migration needed, push is opt-in
- The `Provider.DeleteEvent` interface signature changed (added `calendarID` parameter); Google is the only implementation, fixed in this PR
- Two new MongoDB collections used: `calendar_push_outbox` (created on first enqueue) — no schema migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)