### PR TITLE
calendar: round-trip test for kindred_origin loop prevention (KIN-276)

### DIFF
--- a/backend/internal/handlers/calendar/converter_test.go
+++ b/backend/internal/handlers/calendar/converter_test.go
@@ -468,6 +468,55 @@ func TestProviderEvent_ExtendedPropertiesRoundtrip(t *testing.T) {
 	}
 }
 
+func TestProviderEvent_ConversionRoundtrip_PreservesKindredOrigin(t *testing.T) {
+	// Loop-prevention contract: a push-originated event must keep
+	// kindred_origin=push (and kindred_task_id) after a full round-trip
+	// through convertToGoogleEvent -> *calendar.Event -> convertGoogleEvent.
+	// If either conversion drops the property, webhook ingestion will treat
+	// the push-originated event as a user edit and re-ingest it as a new
+	// task, breaking the loop-prevention check (see IsPushOriginEvent).
+	taskID := primitive.NewObjectID().Hex()
+
+	original := ProviderEvent{
+		ID:           "evt-roundtrip-1",
+		CalendarID:   "cal-roundtrip",
+		CalendarName: "Primary",
+		Summary:      "Pushed task",
+		StartTime:    time.Date(2026, 6, 1, 10, 0, 0, 0, time.UTC),
+		EndTime:      time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+		IsAllDay:     false,
+		Status:       "confirmed",
+		ExtendedProperties: map[string]string{
+			"kindred_origin":  "push",
+			"kindred_task_id": taskID,
+		},
+	}
+
+	// convertToGoogleEvent and convertGoogleEvent are methods on
+	// *GoogleProvider but never dereference the receiver, so a nil
+	// receiver is sufficient for a hermetic test.
+	var p *GoogleProvider
+
+	googleEvent := p.convertToGoogleEvent(original)
+	roundtripped := p.convertGoogleEvent(googleEvent, original.CalendarID, original.CalendarName)
+
+	if roundtripped.ExtendedProperties == nil {
+		t.Fatalf("expected ExtendedProperties to survive round-trip, got nil")
+	}
+	if got := roundtripped.ExtendedProperties["kindred_origin"]; got != "push" {
+		t.Fatalf("expected kindred_origin=push after round-trip, got %q (props=%v)", got, roundtripped.ExtendedProperties)
+	}
+	if got := roundtripped.ExtendedProperties["kindred_task_id"]; got != taskID {
+		t.Fatalf("expected kindred_task_id=%q after round-trip, got %q (props=%v)", taskID, got, roundtripped.ExtendedProperties)
+	}
+
+	// Belt-and-suspenders: the production loop-prevention helper must
+	// still recognize the round-tripped event as push-originated.
+	if !IsPushOriginEvent(roundtripped) {
+		t.Fatalf("expected round-tripped event to be detected as push-origin, props=%v", roundtripped.ExtendedProperties)
+	}
+}
+
 func TestConvertEventToTaskParams_EdgeCases(t *testing.T) {
 	userID := primitive.NewObjectID()
 	categoryID := primitive.NewObjectID()


### PR DESCRIPTION
## Summary

Adds `TestProviderEvent_ConversionRoundtrip_PreservesKindredOrigin` next to the existing `TestProviderEvent_ExtendedPropertiesRoundtrip`.

The existing test only exercises struct-literal access to extended properties — it does not actually call `convertToGoogleEvent` or `convertGoogleEvent`, so a regression in either conversion function would slip past it.

The new test runs a `ProviderEvent` with `kindred_origin=push` (plus a hex ObjectID `kindred_task_id`) through `convertToGoogleEvent` → `*calendar.Event` → `convertGoogleEvent` → `ProviderEvent`, and asserts both extended properties survive. Also asserts `IsPushOriginEvent` recognizes the round-tripped event, since that's the actual hook the loop-prevention path depends on.

Linear: [KIN-276](https://linear.app/kindredtdl/issue/KIN-276).

## Test plan

- [x] New test passes: `go test -run TestProviderEvent_ConversionRoundtrip_PreservesKindredOrigin ./internal/handlers/calendar/ -v`
- [x] Existing roundtrip test untouched
- [x] Hermetic — no network, no fixtures, nil receiver

## Notes

No production code changes. If this test ever starts failing on `main`, the loop-prevention contract is broken and push-originated events will be re-ingested as new tasks (phantom tasks) — treat as a release blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)