### PR TITLE
fix: deep-link push and DB notifications to the entity they reference

### DIFF
--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -152,7 +152,7 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 	slog.LogAttrs(ctx, slog.LevelInfo, "Congratulation inserted", slog.String("id", id.Hex()))
 
 	// Send push notification to receiver
-	err = s.sendCongratulationNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type)
+	err = s.sendCongratulationNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.PostID)
 	if err != nil {
 		// Log error but don't fail the operation since congratulation was already created
 		slog.Error("Failed to send congratulation notification", "error", err, "receiver_id", r.Receiver)
@@ -175,7 +175,15 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 		}
 	}
 
-	err = s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeCongratulation, id, thumbnail)
+	// ReferenceID points to the post the congratulation is on (if any) so tapping the notification
+	// opens that post. Congratulations without a post (no current backend path produces this,
+	// but the field is optional) get a zero referenceID and the frontend will fall back.
+	var referenceID primitive.ObjectID
+	if r.PostID != nil && !r.PostID.IsZero() {
+		referenceID = *r.PostID
+	}
+	_ = id // congratulation document ID; not used as referenceID — see comment above
+	err = s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeCongratulation, referenceID, thumbnail)
 	if err != nil {
 		// Log error but don't fail the operation since congratulation was already created
 		slog.Error("Failed to create congratulation notification in database", "error", err, "receiver_id", r.Receiver)
@@ -318,8 +326,9 @@ func (s *Service) GetSenderInfo(senderID primitive.ObjectID) (*CongratulationSen
 	}, nil
 }
 
-// sendCongratulationNotification sends a push notification when a congratulation is created
-func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, senderName, taskName, congratulationText, congratulationType string) error {
+// sendCongratulationNotification sends a push notification when a congratulation is created.
+// postID may be nil — congratulations created outside the post flow (e.g. beak onboarding) won't carry one.
+func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, senderName, taskName, congratulationText, congratulationType string, postID *primitive.ObjectID) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
@@ -338,6 +347,16 @@ func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, 
 		return nil // Not an error, just no notification sent
 	}
 
+	data := map[string]string{
+		"type":         "congratulation",
+		"sender_name":  senderName,
+		"task_name":    taskName,
+		"message_text": congratulationText,
+	}
+	if postID != nil && !postID.IsZero() {
+		data["post_id"] = postID.Hex()
+	}
+
 	var message string
 	var notification xutils.Notification
 
@@ -349,12 +368,7 @@ func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, 
 			Title:    "You're killing it!",
 			Message:  message,
 			ImageURL: congratulationText, // The message field contains the image URL for type="image"
-			Data: map[string]string{
-				"type":         "congratulation",
-				"sender_name":  senderName,
-				"task_name":    taskName,
-				"message_text": congratulationText,
-			},
+			Data:     data,
 		}
 	} else {
 		message = fmt.Sprintf("%s on \"%s\": \"%s\"", senderName, taskName, congratulationText)
@@ -363,12 +377,7 @@ func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, 
 			Title:   "You're killing it!",
 			Message: message,
 			// No ImageURL for text congratulations
-			Data: map[string]string{
-				"type":         "congratulation",
-				"sender_name":  senderName,
-				"task_name":    taskName,
-				"message_text": congratulationText,
-			},
+			Data: data,
 		}
 	}
 
@@ -410,7 +419,7 @@ func (s *Service) SendBeakCongratulation(receiverID primitive.ObjectID, message,
 	}
 
 	// Send push notification
-	err = s.sendCongratulationNotification(receiverID, beakName, taskName, message, "message")
+	err = s.sendCongratulationNotification(receiverID, beakName, taskName, message, "message", nil)
 	if err != nil {
 		slog.Error("Failed to send beak congratulation notification", "error", err, "receiver_id", receiverID)
 	}

--- a/backend/internal/handlers/encouragement/service.go
+++ b/backend/internal/handlers/encouragement/service.go
@@ -182,20 +182,26 @@ func (s *Service) CreateEncouragement(r *EncouragementDocumentInternal) (*Encour
 	slog.LogAttrs(ctx, slog.LevelInfo, "Encouragement inserted", slog.String("id", id.Hex()))
 
 	// Send push notification to receiver
-	err = s.sendEncouragementNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.Scope)
+	err = s.sendEncouragementNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.Scope, r.TaskID)
 	if err != nil {
 		// Log error but don't fail the operation since encouragement was already created
 		slog.Error("Failed to send encouragement notification", "error", err, "receiver_id", r.Receiver)
 	}
 
-	// Create notification in the database
+	// Create notification in the database.
+	// ReferenceID points to the entity the user should land on when they tap the notification:
+	//   - task scope → the task being encouraged
+	//   - profile scope → no entity, leave zero (frontend will fall back)
 	var notificationContent string
+	var referenceID primitive.ObjectID
 	if r.Scope == "profile" {
 		notificationContent = fmt.Sprintf("%s says: \"%s\"", r.Sender.Name, r.Message)
 	} else {
 		notificationContent = fmt.Sprintf("%s on \"%s\": \"%s\"", r.Sender.Name, r.TaskName, r.Message)
+		referenceID = r.TaskID
 	}
-	err = s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeEncouragement, id)
+	_ = id // encouragement document ID; not used as referenceID — see comment above
+	err = s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeEncouragement, referenceID)
 	if err != nil {
 		// Log error but don't fail the operation since encouragement was already created
 		slog.Error("Failed to create encouragement notification in database", "error", err, "receiver_id", r.Receiver)
@@ -339,7 +345,7 @@ func (s *Service) GetSenderInfo(senderID primitive.ObjectID) (*EncouragementSend
 }
 
 // sendEncouragementNotification sends a push notification when an encouragement is created
-func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, senderName, taskName, encouragementText, encouragementType, scope string) error {
+func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, senderName, taskName, encouragementText, encouragementType, scope string, taskID primitive.ObjectID) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
@@ -363,6 +369,12 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 
 	// Handle profile-level encouragements
 	if scope == "profile" {
+		data := map[string]string{
+			"type":         "encouragement",
+			"scope":        "profile",
+			"sender_name":  senderName,
+			"message_text": encouragementText,
+		}
 		if encouragementType == "image" {
 			message = fmt.Sprintf("%s is rooting for you!", senderName)
 			notification = xutils.Notification{
@@ -370,12 +382,7 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 				Title:    "You've got a fan!",
 				Message:  message,
 				ImageURL: encouragementText, // The message field contains the image URL for type="image"
-				Data: map[string]string{
-					"type":         "encouragement",
-					"scope":        "profile",
-					"sender_name":  senderName,
-					"message_text": encouragementText,
-				},
+				Data:     data,
 			}
 		} else {
 			message = fmt.Sprintf("%s says: \"%s\"", senderName, encouragementText)
@@ -383,16 +390,21 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 				Token:   receiver.PushToken,
 				Title:   "You've got a fan!",
 				Message: message,
-				Data: map[string]string{
-					"type":         "encouragement",
-					"scope":        "profile",
-					"sender_name":  senderName,
-					"message_text": encouragementText,
-				},
+				Data:    data,
 			}
 		}
 	} else {
 		// Task-level encouragements
+		data := map[string]string{
+			"type":         "encouragement",
+			"scope":        "task",
+			"sender_name":  senderName,
+			"task_name":    taskName,
+			"message_text": encouragementText,
+		}
+		if !taskID.IsZero() {
+			data["task_id"] = taskID.Hex()
+		}
 		if encouragementType == "image" {
 			message = fmt.Sprintf("%s is cheering you on for \"%s\"!", senderName, taskName)
 			notification = xutils.Notification{
@@ -400,13 +412,7 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 				Title:    "Someone believes in you!",
 				Message:  message,
 				ImageURL: encouragementText, // The message field contains the image URL for type="image"
-				Data: map[string]string{
-					"type":         "encouragement",
-					"scope":        "task",
-					"sender_name":  senderName,
-					"task_name":    taskName,
-					"message_text": encouragementText,
-				},
+				Data:     data,
 			}
 		} else {
 			message = fmt.Sprintf("%s on \"%s\": \"%s\"", senderName, taskName, encouragementText)
@@ -415,13 +421,7 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 				Title:   "Someone believes in you!",
 				Message: message,
 				// No ImageURL for text encouragements
-				Data: map[string]string{
-					"type":         "encouragement",
-					"scope":        "task",
-					"sender_name":  senderName,
-					"task_name":    taskName,
-					"message_text": encouragementText,
-				},
+				Data: data,
 			}
 		}
 	}

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -819,7 +819,7 @@ func (s *Service) AddComment(postID primitive.ObjectID, comment types.CommentDoc
 	// Send notification to post owner (only if commenter is not the post owner)
 	if comment.User != nil && comment.User.ID != post.User.ID {
 		// Send push notification
-		err = s.sendCommentNotification(post.User.ID, comment.User.DisplayName, comment.Content)
+		err = s.sendCommentNotification(post.User.ID, post.ID, comment.User.DisplayName, comment.Content)
 		if err != nil {
 			// Log error but don't fail the operation since comment was already created
 			slog.Error("Failed to send comment notification", "error", err, "post_owner_id", post.User.ID)
@@ -857,7 +857,7 @@ func (s *Service) AddComment(postID primitive.ObjectID, comment types.CommentDoc
 		}
 
 		// Send push notification
-		err = s.sendCommentNotification(mention.ID, comment.User.DisplayName, comment.Content)
+		err = s.sendCommentNotification(mention.ID, post.ID, comment.User.DisplayName, comment.Content)
 		if err != nil {
 			slog.Error("Failed to send mention push notification", "error", err, "mentioned_user_id", mention.ID)
 		}
@@ -965,7 +965,7 @@ func (s *Service) DeleteComment(postID primitive.ObjectID, commentID primitive.O
 }
 
 // sendCommentNotification sends a push notification when a comment is added to a post
-func (s *Service) sendCommentNotification(postOwnerID primitive.ObjectID, commenterName, commentText string) error {
+func (s *Service) sendCommentNotification(postOwnerID, postID primitive.ObjectID, commenterName, commentText string) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
@@ -986,15 +986,20 @@ func (s *Service) sendCommentNotification(postOwnerID primitive.ObjectID, commen
 
 	message := fmt.Sprintf("%s commented: \"%s\"", commenterName, commentText)
 
+	data := map[string]string{
+		"type":           "comment",
+		"commenter_name": commenterName,
+		"comment_text":   commentText,
+	}
+	if !postID.IsZero() {
+		data["post_id"] = postID.Hex()
+	}
+
 	notification := xutils.Notification{
 		Token:   postOwner.PushToken,
 		Title:   "New comment on your post",
 		Message: message,
-		Data: map[string]string{
-			"type":           "comment",
-			"commenter_name": commenterName,
-			"comment_text":   commentText,
-		},
+		Data:    data,
 	}
 
 	return xutils.SendNotification(notification)

--- a/docs/push-notification-audit.md
+++ b/docs/push-notification-audit.md
@@ -1,0 +1,90 @@
+# Push Notification Audit
+
+Tracks: [KIN-291](https://linear.app/kindredtdl/issue/KIN-291)
+
+Goal: confirm every push notification the backend sends has a working frontend deep-link route.
+
+## How routing works
+
+**Backend** (`backend/xutils/notifications.go`) sends pushes via the Expo Push API. Every push carries a `data` map; convention is to include a `type` field, and optionally a `url` field for fully-qualified deep-links.
+
+**Frontend** (`frontend/app/(logged-in)/_layout.tsx:82`) resolves a notification to a route via `getNotificationRoute(data)`:
+
+1. If `data.url` is set, navigate to it directly (override path).
+2. Else, switch on `data.type` and map to a route.
+3. Default returns `null` — **silent navigation failure**.
+
+Tap handler at line 320; foreground listener at 287. `live_activity` has special handling at 291–335 (skips the generic route resolver).
+
+## Audit matrix
+
+Legend:
+- ✅ — handled, payload fully used
+- ⚠️ — handled, but payload data ignored (suboptimal — lands on a list/tab instead of the specific entity)
+- ❌ — not handled (would silently fail)
+
+| # | Type | Trigger | Backend payload | Frontend route | Status |
+|---|---|---|---|---|---|
+| 1 | `friend_request` | Friend request sent | `requester_name`, `requester_id` | `/(activity)` | ⚠️ `requester_id` not used |
+| 2 | `friend_request_accepted` | Friend request accepted | `accepter_name`, `accepter_id` | `/account/{accepter_id}` (fallback to activity) | ✅ |
+| 3 | `encouragement` (profile) | Encouragement sent on profile | `sender_name`, `message_text`, `imageUrl?` | `/kudos?tab=encouragements` | ✅ |
+| 4 | `encouragement` (task) | Encouragement sent on task | `sender_name`, `message_text`, `task_name`, `imageUrl?` | `/kudos?tab=encouragements` | ⚠️ no `task_id` sent — can't deep-link to task |
+| 5 | `task_completion` | Task owner completed a task encourager backed | `task_owner_id`, `task_owner`, `task_name`, `task_id` | `/kudos?tab=congratulations` | ⚠️ `task_id` sent but ignored |
+| 6 | `comment` | Comment on user's post | `commenter_name`, `comment_text` | `/(feed)/feed` | ⚠️ no `post_id` sent — can't deep-link to post |
+| 7 | `new_post` | Friend created a post (~30% chance) | `post_id`, `poster_name`, `poster_id` | `/(feed)/feed` | ⚠️ `post_id` sent but ignored |
+| 8 | `live_activity` (activeTask) | Task start time hit (2-min window) | `liveActivityType`, `taskId`, `categoryId`, `taskName`, `workspaceName`, `startTime`, `endTime` | `/(task)/task/{taskId}?categoryId=...&name=...` | ✅ |
+| 9 | `live_activity` (deadlineCountdown) | Task deadline ≈1h away | `liveActivityType`, `taskId`, `categoryId`, `taskName`, `workspaceName`, `deadline`, `priority` | `/(task)/task/{taskId}?categoryId=...&name=...` | ✅ |
+| 10 | `congratulation` | Congratulation sent on task | `sender_name`, `task_name`, `message_text`, `imageUrl?` | `/kudos?tab=congratulations` | ⚠️ no `task_id` / `post_id` sent |
+| 11 | `congratulation` (onboarding beak) | Onboarding tutorial message | Same as 10 | `/kudos?tab=congratulations` | ✅ (intentional) |
+| 12 | `checkin` | Daily check-in at user-local 17:01 | `time`, `timestamp`, `scheduled_today`, `deadline_today`, `open_tasks`, **`url`** = `/(task)/review` | Uses `data.url` override → `/(task)/review` | ✅ |
+| 13 | `FOLLOW_UP` (reminder) | Task follow-up reminder | `taskId`, `type` | `/(task)` | ⚠️ `taskId` ignored — should open the task |
+| 14 | `ABSOLUTE` (reminder) | Absolute-time task reminder | `taskId`, `type` | `/(task)` | ⚠️ `taskId` ignored |
+| 15 | `RELATIVE` (reminder) | Relative-time task reminder | `taskId`, `type` | `/(task)` | ⚠️ `taskId` ignored |
+| 16 | `TASK_MISSED` | Recurring task occurrence missed | `taskId`, `type`, **`url`** = `/(task)/undo-missed/{templateTaskId}` | Uses `data.url` override → specific undo screen | ✅ |
+| 17 | `TASK_REGENERATED` | Recurring task rolled over | `taskId`, `type` | `/(task)` | ⚠️ `taskId` ignored — could open template task |
+| 18 | `rings_closed` (user) | User closed all rings (delayed 2 min) | `type` only | `/profile` (fallback) | ✅ (no entity to link to) |
+| 19 | `rings_closed` (friend) | Friend closed all rings | `type`, `user_id` | `/account/{user_id}` | ✅ |
+
+## Summary
+
+**No type is unhandled** — every push the backend sends results in *some* navigation. However:
+
+- **8 of 19 pushes (~42%) under-use their payload** — they land on a tab or list when they could deep-link to the specific task/post/profile. Tapping a comment notification dumps you in the feed, not at your post; tapping a task reminder lands you on the task tab, not the task. This is the kind of "broken-feeling" UX the audit was designed to catch.
+- **Silent failure mode**: `getNotificationRoute` returns `null` for unknown `type` values. Adding a new backend notification type without updating the frontend switch is invisible — no error, no log, no toast. **High risk for regressions.**
+- **Two notification types use the `url` override** (`checkin`, `TASK_MISSED`). This pattern is the cleanest — backend owns the route, frontend just navigates. Worth considering as the default convention going forward, instead of relying on type→route switch staying in sync.
+
+## Implementation (this PR)
+
+Both audit-surfaced issues are now fixed for both push notifications **and** the in-app (DB) notification list.
+
+### Backend — push payloads now carry the right IDs
+- `comment` push — `post_id` added (`backend/internal/handlers/post/service.go` `sendCommentNotification`)
+- `encouragement` push (task scope) — `task_id` added (`backend/internal/handlers/encouragement/service.go` `sendEncouragementNotification`)
+- `congratulation` push — `post_id` added when the congratulation references a post (`backend/internal/handlers/congratulation/service.go` `sendCongratulationNotification`); Beak/onboarding congratulations correctly pass `nil` (no post)
+
+### Backend — DB notifications now use entity IDs as `reference_id`
+Previously the `reference_id` field for encouragement and congratulation DB notifications stored the encouragement/congratulation **document** ID, which had no working frontend route. Both now store the entity the user should land on when tapping:
+- Encouragement DB notification (task scope) → `reference_id` = task ID; profile scope → zero (frontend falls back)
+- Congratulation DB notification → `reference_id` = post ID when present; else zero
+
+### Frontend — `getNotificationRoute` now uses payload IDs
+`frontend/app/(logged-in)/_layout.tsx` `getNotificationRoute`:
+- `encouragement` (task scope) → `/(task)/task/{task_id}`
+- `congratulation` (post present) → `/posting/{post_id}`
+- `task_completion` → `/(task)/task/{task_id}`
+- `new_post` → `/posting/{post_id}`
+- `comment` → `/posting/{post_id}`
+- `FOLLOW_UP` / `ABSOLUTE` / `RELATIVE` / `TASK_REGENERATED` reminders → `/(task)/task/{taskId}`
+- Each falls back to the previous list/tab destination when the ID is missing.
+
+### Frontend — DB notification tap handlers deep-link too
+- `frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx` `handleNotificationPress` — encouragement now opens the task, congratulation now opens the post (matches push behavior).
+- `frontend/components/UserInfo/UserInfoEncouragementNotification.tsx` — fixed a real bug: route was `/post/${id}` (a path that does not exist) — now correctly routes to `/posting/{id}` for congratulations and `/(task)/task/{id}` for encouragements.
+
+### Frontend — unknown `data.type` no longer silently fails
+`getNotificationRoute` returning `null` now `logger.warn`s with the type and full data payload. The user already saw the OS notification banner; this is an engineering signal so new backend notification types added without frontend wiring don't go invisible.
+
+## Known gaps (out of scope for KIN-291)
+
+- **POST and RINGS_CLOSED DB notifications don't render in the in-app notifications list.** `Notifications.tsx` `processNotification` casts type to a union missing those, and the render switch returns `null` for unhandled types. Backend creates these DB notifications but the user never sees them.
+- **No analytics event** for unknown-type push notifications — only console warn. PostHog wiring is a small follow-up if we want production visibility.

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -262,10 +262,20 @@ const Notifications = () => {
 
         switch (notification.type) {
             case "encouragement":
-                router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=encouragements");
+                // referenceId is the task ID (task-scope) or empty (profile-scope).
+                if (notification.referenceId) {
+                    router.push(`/(logged-in)/(tabs)/(task)/task/${notification.referenceId}` as any);
+                } else {
+                    router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=encouragements");
+                }
                 break;
             case "congratulation":
-                router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=congratulations");
+                // referenceId is the post the congratulation is on.
+                if (notification.referenceId) {
+                    router.push(`/(logged-in)/posting/${notification.referenceId}`);
+                } else {
+                    router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=congratulations");
+                }
                 break;
             case "friend_request":
             case "friend_request_accepted":

--- a/frontend/app/(logged-in)/_layout.tsx
+++ b/frontend/app/(logged-in)/_layout.tsx
@@ -37,6 +37,7 @@ import { tryStartActiveTaskActivity, tryStartDeadlineActivity } from '@/utils/li
 import { useLiveActivityScheduler } from '@/hooks/useLiveActivityScheduler';
 import { useBackgroundTaskSync, registerBackgroundFetch } from '@/tasks/backgroundTaskSync';
 import { useTasks } from '@/contexts/tasksContext';
+import { logger } from '@/utils/logger';
 
 export const unstable_settings = {
     initialRouteName: "index",
@@ -64,11 +65,15 @@ interface NotificationData {
     url?: string;
     // Social
     accepter_id?: string;
+    requester_id?: string;
     user_id?: string;
     // Task
     taskId?: string;
+    task_id?: string;
     categoryId?: string;
     taskName?: string;
+    // Post
+    post_id?: string;
     // Live Activity
     liveActivityType?: 'activeTask' | 'deadlineCountdown';
     workspaceName?: string;
@@ -86,10 +91,21 @@ function getNotificationRoute(data: NotificationData | undefined): string | null
 
     switch (data.type) {
         case "encouragement":
+            // Task-scope encouragements deep-link to the task; profile-scope go to the kudos tab.
+            if (data.task_id) {
+                return `/(logged-in)/(tabs)/(task)/task/${data.task_id}`;
+            }
             return "/(logged-in)/(tabs)/(task)/kudos?tab=encouragements";
         case "congratulation":
+            // If the congratulation references a post, open it; otherwise show the kudos tab.
+            if (data.post_id) {
+                return `/(logged-in)/posting/${data.post_id}`;
+            }
             return "/(logged-in)/(tabs)/(task)/kudos?tab=congratulations";
         case "task_completion":
+            if (data.task_id) {
+                return `/(logged-in)/(tabs)/(task)/task/${data.task_id}`;
+            }
             return "/(logged-in)/(tabs)/(task)/kudos?tab=congratulations";
         case "friend_request":
             return "/(logged-in)/(tabs)/(activity)";
@@ -99,8 +115,14 @@ function getNotificationRoute(data: NotificationData | undefined): string | null
             }
             return "/(logged-in)/(tabs)/(activity)";
         case "new_post":
+            if (data.post_id) {
+                return `/(logged-in)/posting/${data.post_id}`;
+            }
             return "/(logged-in)/(tabs)/(feed)/feed";
         case "comment":
+            if (data.post_id) {
+                return `/(logged-in)/posting/${data.post_id}`;
+            }
             return "/(logged-in)/(tabs)/(feed)/feed";
         case "rings_closed":
             if (data.user_id) {
@@ -112,6 +134,9 @@ function getNotificationRoute(data: NotificationData | undefined): string | null
         case "ABSOLUTE":
         case "RELATIVE":
         case "FOLLOW_UP":
+            if (data.taskId) {
+                return `/(logged-in)/(tabs)/(task)/task/${data.taskId}`;
+            }
             return "/(logged-in)/(tabs)/(task)";
         default:
             return null;
@@ -339,6 +364,11 @@ const layout = ({ children }: { children: React.ReactNode }) => {
             const route = getNotificationRoute(data);
             if (route) {
                 router.navigate(route);
+            } else {
+                // No route for this notification type — log it so we catch new backend types that
+                // weren't wired up on the frontend. The user already saw the system notification banner,
+                // so this is mostly an engineering signal.
+                logger.warn("Push notification has no matching route", { type: data?.type, data });
             }
         });
 

--- a/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
@@ -13,8 +13,10 @@ type Props = {
     taskName: string;
     icon: string;
     time: number;
-    referenceId: string; // Post ID to navigate to
-    type?: "encouragement" | "congratulation"; // Type of notification
+    // For encouragements this is the task ID; for congratulations this is the post ID.
+    // Empty string if the notification has no entity to deep-link to (e.g. profile-scope encouragement).
+    referenceId: string;
+    type?: "encouragement" | "congratulation";
 };
 
 const UserInfoEncouragementNotification = ({ name, userId, taskName, icon, time, referenceId, type = "encouragement" }: Props) => {
@@ -72,8 +74,18 @@ const UserInfoEncouragementNotification = ({ name, userId, taskName, icon, time,
     const timeLabel = getTimeLabel(time);
     
     const handleNotificationPress = () => {
-        // Navigate to the post that was encouraged
-        router.push(`/post/${referenceId}`);
+        // Congratulations reference a post; encouragements reference a task.
+        // Fall back to the kudos tab if no referenceId (e.g. profile-scope encouragement).
+        if (!referenceId) {
+            const tab = type === "congratulation" ? "congratulations" : "encouragements";
+            router.push(`/(logged-in)/(tabs)/(task)/kudos?tab=${tab}` as any);
+            return;
+        }
+        if (type === "congratulation") {
+            router.push(`/(logged-in)/posting/${referenceId}`);
+        } else {
+            router.push(`/(logged-in)/(tabs)/(task)/task/${referenceId}` as any);
+        }
     };
 
     // Animation for sparkle icon


### PR DESCRIPTION
## Summary
- Push notifications, in-app DB notifications, and the in-app notifications list now deep-link to the specific post/task instead of a tab/list. Tap a comment push, land at the post — not the feed.
- Unknown push notification types no longer silently fail; the frontend logs them so missing wiring is visible.
- Fixes a real bug in `UserInfoEncouragementNotification` that routed to `/post/{id}` — a path that does not exist.

## What's in the diff

**Backend — push payloads carry entity IDs**
- `comment` push includes `post_id` (`post/service.go`)
- `encouragement` push (task scope) includes `task_id` (`encouragement/service.go`)
- `congratulation` push includes `post_id` when the congratulation is on a post (`congratulation/service.go`); Beak/onboarding congratulations correctly pass `nil`

**Backend — DB notification `reference_id` is now the entity, not the doc**
- Encouragement DB notification: `reference_id` is the task ID (task scope) or zero (profile scope)
- Congratulation DB notification: `reference_id` is the post ID, when present
- Previously these stored the encouragement/congratulation document IDs, which had no working frontend route

**Frontend — `getNotificationRoute` uses payload IDs**
- `frontend/app/(logged-in)/_layout.tsx`: encouragement (task scope) → task; congratulation (post) → post; `task_completion`, `new_post`, `comment`, reminders, `TASK_REGENERATED` all now deep-link via the IDs the backend sends. Each falls back to the old list/tab destination when the ID is missing.
- Unknown `data.type` now `logger.warn`s — was silently returning null

**Frontend — DB notification tap handlers match push behavior**
- `Notifications.tsx handleNotificationPress`: encouragement → task, congratulation → post (both with fallbacks)
- `UserInfoEncouragementNotification`: route fix — was `/post/{id}` (does not exist) → now `/posting/{id}` for congratulations, `/(task)/task/{id}` for encouragements

## Audit
Full backend↔frontend audit and notification-type matrix in [`docs/push-notification-audit.md`](docs/push-notification-audit.md). Covers all 19 backend push types and the DB notification flow.

## Known gaps (out of scope)
- POST and RINGS_CLOSED DB notifications never render in `Notifications.tsx` — the type union and render switch don't include them. Backend creates them but users don't see them. Separate fix.
- No PostHog event on unknown-type pushes — only console warn. Small follow-up if we want production visibility.

Refs KIN-291.

## Test plan
- [ ] Send a comment push to a real device → tap → lands on the post (not the feed)
- [ ] Send a task-scope encouragement push → tap → lands on the task
- [ ] Send a congratulation push that references a post → tap → lands on the post
- [ ] Send a `new_post` push → tap → lands on the specific post
- [ ] Send a task reminder push (`FOLLOW_UP`/`ABSOLUTE`/`RELATIVE`/`TASK_REGENERATED`) → tap → lands on the specific task
- [ ] In-app: tap an encouragement DB notification → lands on the task
- [ ] In-app: tap a congratulation DB notification → lands on the post (was a 404 path before this PR)
- [ ] In-app: tap a comment DB notification → lands on the post (regression check)
- [ ] Send a push with an unknown `data.type` → app doesn't crash, warning appears in logs
- [ ] Beak/onboarding congratulation still works (no post_id in payload, lands on kudos tab fallback)
- [ ] `checkin` and `TASK_MISSED` pushes still work (use the `data.url` override path)
- [ ] `live_activity` pushes still start the live activity AND navigate to the task

🤖 Generated with [Claude Code](https://claude.com/claude-code)