### PR TITLE
feat: calendar push toggles in setup + workspace settings

### DIFF
--- a/backend/internal/handlers/category/category.go
+++ b/backend/internal/handlers/category/category.go
@@ -265,6 +265,34 @@ func (h *Handler) UpdateWorkspace(ctx context.Context, input *UpdateWorkspaceInp
 	return resp, nil
 }
 
+func (h *Handler) SetWorkspacePushEnabled(ctx context.Context, input *SetWorkspacePushEnabledInput) (*SetWorkspacePushEnabledOutput, error) {
+	workspaceName, err := url.QueryUnescape(input.Name)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid workspace name encoding", err)
+	}
+
+	user_id_str, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+
+	user_id, err := primitive.ObjectIDFromHex(user_id_str)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid ID format for UserId", err)
+	}
+
+	modified, err := h.service.SetWorkspacePushEnabled(workspaceName, user_id, input.Body.PushEnabled)
+	if err != nil {
+		slog.Error("unable to set workspace push_enabled", "userId", user_id_str, "workspace", workspaceName, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to update push setting. Please try again.", err)
+	}
+
+	resp := &SetWorkspacePushEnabledOutput{}
+	resp.Body.Message = "Workspace push setting updated"
+	resp.Body.Modified = modified
+	return resp, nil
+}
+
 func (h *Handler) SetupDefaultWorkspace(ctx context.Context, input *SetupDefaultWorkspaceInput) (*SetupDefaultWorkspaceOutput, error) {
 	// Extract user_id from context (set by auth middleware)
 	user_id, err := auth.RequireAuth(ctx)

--- a/backend/internal/handlers/category/operations.go
+++ b/backend/internal/handlers/category/operations.go
@@ -238,6 +238,33 @@ func RegisterSetupDefaultWorkspaceOperation(api huma.API, handler *Handler) {
 	}, handler.SetupDefaultWorkspace)
 }
 
+// Set Workspace Push Enabled
+type SetWorkspacePushEnabledInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Name          string `path:"name"`
+	Body          struct {
+		PushEnabled bool `json:"push_enabled"`
+	}
+}
+
+type SetWorkspacePushEnabledOutput struct {
+	Body struct {
+		Message  string `json:"message" example:"Workspace push setting updated"`
+		Modified int64  `json:"modified" example:"2"`
+	}
+}
+
+func RegisterSetWorkspacePushEnabledOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "set-workspace-push-enabled",
+		Method:      http.MethodPatch,
+		Path:        "/v1/user/workspaces/{name}/push-enabled",
+		Summary:     "Set push-to-calendar for a workspace",
+		Description: "Flips push_enabled on every calendar-integrated category in the workspace.",
+		Tags:        []string{"categories", "workspaces", "calendar"},
+	}, handler.SetWorkspacePushEnabled)
+}
+
 func RegisterUpdateWorkspaceOperation(api huma.API, handler *Handler) {
 	huma.Register(api, huma.Operation{
 		OperationID: "update-workspace",

--- a/backend/internal/handlers/category/routes.go
+++ b/backend/internal/handlers/category/routes.go
@@ -35,4 +35,5 @@ func RegisterCategoryOperations(api huma.API, handler *Handler) {
 	RegisterRenameWorkspaceOperation(api, handler)
 	RegisterSetupDefaultWorkspaceOperation(api, handler)
 	RegisterUpdateWorkspaceOperation(api, handler)
+	RegisterSetWorkspacePushEnabledOperation(api, handler)
 }

--- a/backend/internal/handlers/category/service.go
+++ b/backend/internal/handlers/category/service.go
@@ -420,6 +420,41 @@ func (s *Service) GetCategoryNamesSummary(userID primitive.ObjectID) (string, er
 	return b.String(), nil
 }
 
+// SetWorkspacePushEnabled sets push_enabled on every calendar-integrated
+// category in the given workspace owned by the user. Categories without a
+// "gcal:" integration are not touched, since they have no destination calendar.
+func (s *Service) SetWorkspacePushEnabled(workspaceName string, user primitive.ObjectID, enabled bool) (int64, error) {
+	ctx := context.Background()
+
+	filter := bson.M{
+		"workspaceName": workspaceName,
+		"user":          user,
+		"integration":   bson.M{"$regex": "^gcal:"},
+	}
+	update := bson.D{{Key: "$set", Value: bson.D{
+		{Key: "push_enabled", Value: enabled},
+		{Key: "lastEdited", Value: xutils.NowUTC()},
+	}}}
+
+	result, err := s.Categories.UpdateMany(ctx, filter, update)
+	if err != nil {
+		slog.LogAttrs(ctx, slog.LevelError, "Failed to set workspace push_enabled",
+			slog.String("workspace", workspaceName),
+			slog.String("userID", user.Hex()),
+			slog.Bool("enabled", enabled),
+			slog.String("error", err.Error()))
+		return 0, err
+	}
+
+	slog.LogAttrs(ctx, slog.LevelInfo, "Workspace push_enabled updated",
+		slog.String("workspace", workspaceName),
+		slog.Bool("enabled", enabled),
+		slog.Int64("matched", result.MatchedCount),
+		slog.Int64("modified", result.ModifiedCount))
+
+	return result.ModifiedCount, nil
+}
+
 // UpdateWorkspaceMeta updates only the provided icon/color fields on a workspace document
 func (s *Service) UpdateWorkspaceMeta(name string, user primitive.ObjectID, icon *string, color *string) error {
 	if s.Workspaces == nil {

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	testpkg "github.com/abhikaboy/Kindred/internal/testing"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -454,6 +455,133 @@ func (s *CategoryServiceTestSuite) TestGetCategoryNamesSummary_NoCategories() {
 // ========================================
 // RenameWorkspace Tests
 // ========================================
+
+// ========================================
+// SetWorkspacePushEnabled Tests
+// ========================================
+
+func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_OnlyAffectsCalendarCategoriesInWorkspace() {
+	user := s.GetUser(0)
+
+	cal1 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Work calendar",
+		User:          user.ID,
+		WorkspaceName: "📅 Cal",
+		Integration:   "gcal:conn1:cal-a",
+		Tasks:         []types.TaskDocument{},
+	}
+	cal2 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Personal calendar",
+		User:          user.ID,
+		WorkspaceName: "📅 Cal",
+		Integration:   "gcal:conn1:cal-b",
+		Tasks:         []types.TaskDocument{},
+	}
+	plain := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Plain",
+		User:          user.ID,
+		WorkspaceName: "📅 Cal",
+		Tasks:         []types.TaskDocument{},
+	}
+	other := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Other workspace cal",
+		User:          user.ID,
+		WorkspaceName: "Other",
+		Integration:   "gcal:conn2:cal-x",
+		Tasks:         []types.TaskDocument{},
+	}
+
+	for _, c := range []*CategoryDocument{cal1, cal2, plain, other} {
+		_, err := s.service.CreateCategory(c)
+		s.NoError(err)
+	}
+
+	modified, err := s.service.SetWorkspacePushEnabled("📅 Cal", user.ID, true)
+	s.NoError(err)
+	s.Equal(int64(2), modified)
+
+	cases := []struct {
+		id          primitive.ObjectID
+		wantEnabled bool
+	}{
+		{cal1.ID, true},
+		{cal2.ID, true},
+		{plain.ID, false},
+		{other.ID, false},
+	}
+	for _, tc := range cases {
+		var got struct {
+			PushEnabled bool `bson:"push_enabled"`
+		}
+		err := s.Collections["categories"].FindOne(s.Ctx, bson.M{"_id": tc.id}).Decode(&got)
+		s.NoError(err)
+		s.Equal(tc.wantEnabled, got.PushEnabled, "category %s", tc.id.Hex())
+	}
+}
+
+func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_WrongUserNoOp() {
+	user1 := s.GetUser(0)
+	user2 := s.GetUser(1)
+
+	cal := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Work",
+		User:          user1.ID,
+		WorkspaceName: "WS",
+		Integration:   "gcal:conn1:cal-a",
+		Tasks:         []types.TaskDocument{},
+	}
+	_, err := s.service.CreateCategory(cal)
+	s.NoError(err)
+
+	modified, err := s.service.SetWorkspacePushEnabled("WS", user2.ID, true)
+	s.NoError(err)
+	s.Equal(int64(0), modified)
+}
+
+func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_DisablesAllInWorkspace() {
+	user := s.GetUser(0)
+
+	cal1 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Cal A",
+		User:          user.ID,
+		WorkspaceName: "WS",
+		Integration:   "gcal:conn1:cal-a",
+		PushEnabled:   true,
+		Tasks:         []types.TaskDocument{},
+	}
+	cal2 := &CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Cal B",
+		User:          user.ID,
+		WorkspaceName: "WS",
+		Integration:   "gcal:conn1:cal-b",
+		PushEnabled:   true,
+		Tasks:         []types.TaskDocument{},
+	}
+	for _, c := range []*CategoryDocument{cal1, cal2} {
+		_, err := s.service.CreateCategory(c)
+		s.NoError(err)
+	}
+
+	modified, err := s.service.SetWorkspacePushEnabled("WS", user.ID, false)
+	s.NoError(err)
+	s.Equal(int64(2), modified)
+
+	for _, id := range []primitive.ObjectID{cal1.ID, cal2.ID} {
+		var got struct {
+			PushEnabled bool `bson:"push_enabled"`
+		}
+		err := s.Collections["categories"].FindOne(s.Ctx, bson.M{"_id": id}).Decode(&got)
+		s.NoError(err)
+		s.False(got.PushEnabled, "category %s should be disabled", id.Hex())
+	}
+}
 
 func (s *CategoryServiceTestSuite) TestRenameWorkspace_Success() {
 	user := s.GetUser(0)

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -24,6 +24,7 @@ type CategoryDocument struct {
 	IsBlueprint   bool                `bson:"isBlueprint,omitempty" json:"isBlueprint,omitempty"`
 	BlueprintID   *primitive.ObjectID `bson:"blueprintId,omitempty" json:"blueprintId,omitempty"`
 	Integration   string              `bson:"integration,omitempty" json:"integration,omitempty"` // Format: "gcal:{connection_id}:{calendar_id}"
+	PushEnabled   bool                `bson:"push_enabled,omitempty" json:"push_enabled,omitempty"`
 }
 
 type WorkspaceDocument struct {

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -2533,7 +2533,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/CongratulationDocument'
+                                $ref: '#/components/schemas/CreateCongratulationOutputBody'
                 default:
                     description: Error
                     content:
@@ -3399,7 +3399,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/EncouragementDocument'
+                                $ref: '#/components/schemas/CreateEncouragementOutputBody'
                 default:
                     description: Error
                     content:
@@ -4153,7 +4153,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/PostDocumentAPI'
+                                $ref: '#/components/schemas/CreatePostOutputBody'
                 default:
                     description: Error
                     content:
@@ -5154,7 +5154,7 @@ paths:
                     content:
                         application/json:
                             schema:
-                                $ref: '#/components/schemas/TaskDocument'
+                                $ref: '#/components/schemas/CreateTaskOutputBody'
                 default:
                     description: Error
                     content:
@@ -6374,6 +6374,45 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/workspaces/{name}/push-enabled:
+        patch:
+            tags:
+                - categories
+                - workspaces
+                - calendar
+            summary: Set push-to-calendar for a workspace
+            description: Flips push_enabled on every calendar-integrated category in the workspace.
+            operationId: set-workspace-push-enabled
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: name
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/SetWorkspacePushEnabledInputBody'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/SetWorkspacePushEnabledOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/waitlist:
         post:
             tags:
@@ -7252,6 +7291,8 @@ components:
                     format: date-time
                 name:
                     type: string
+                push_enabled:
+                    type: boolean
                 tasks:
                     type: array
                     items:
@@ -7427,6 +7468,9 @@ components:
                 nextFlexTask:
                     description: If this was a flex task and more instances remain, the next task instance
                     $ref: '#/components/schemas/NextFlexTaskDTO'
+                ringDelta:
+                    description: Describes the Do ring increment triggered by this completion so the client can render feedback
+                    $ref: '#/components/schemas/RingDelta'
                 streakChanged:
                     type: boolean
                     description: Indicates if the user's streak increased
@@ -7764,6 +7808,74 @@ components:
             required:
                 - name
                 - workspaceName
+        CreateCongratulationOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/CreateCongratulationOutputBody.json
+                    readOnly: true
+                categoryName:
+                    type: string
+                    description: Category name
+                    examples:
+                        - Work
+                id:
+                    type: string
+                    description: Unique identifier for the congratulation
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                message:
+                    type: string
+                    description: Congratulation message
+                    examples:
+                        - Congratulations on completing your task!
+                read:
+                    type: boolean
+                    description: Whether the congratulation has been read
+                    examples:
+                        - false
+                receiver:
+                    type: string
+                    description: Receiver user ID
+                    examples:
+                        - 507f1f77bcf86cd799439012
+                ringDelta:
+                    description: Describes the Share ring increment triggered by this congratulation so the client can render feedback
+                    $ref: '#/components/schemas/RingDelta'
+                sender:
+                    description: Sender information
+                    $ref: '#/components/schemas/CongratulationSender'
+                taskName:
+                    type: string
+                    description: Task name
+                    examples:
+                        - Complete project proposal
+                timestamp:
+                    type: string
+                    description: Creation timestamp
+                    format: date-time
+                    examples:
+                        - "2023-01-01T00:00:00Z"
+                type:
+                    type: string
+                    description: Type of congratulation (message or image)
+                    examples:
+                        - message
+            required:
+                - id
+                - sender
+                - receiver
+                - message
+                - timestamp
+                - categoryName
+                - taskName
+                - read
+                - type
         CreateCongratulationParams:
             type: object
             additionalProperties: false
@@ -7829,6 +7941,83 @@ components:
                         - 507f1f77bcf86cd799439012
             required:
                 - receiver_id
+        CreateEncouragementOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/CreateEncouragementOutputBody.json
+                    readOnly: true
+                categoryName:
+                    type: string
+                    description: Category name
+                    examples:
+                        - Work
+                id:
+                    type: string
+                    description: Unique identifier for the encouragement
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                message:
+                    type: string
+                    description: Encouragement message
+                    examples:
+                        - Great job on completing your task!
+                read:
+                    type: boolean
+                    description: Whether the encouragement has been read
+                    examples:
+                        - false
+                receiver:
+                    type: string
+                    description: Receiver user ID
+                    examples:
+                        - 507f1f77bcf86cd799439012
+                ringDelta:
+                    description: Describes the Share ring increment triggered by this encouragement so the client can render feedback
+                    $ref: '#/components/schemas/RingDelta'
+                scope:
+                    type: string
+                    description: Scope of encouragement (task or profile)
+                    examples:
+                        - task
+                sender:
+                    description: Sender information
+                    $ref: '#/components/schemas/EncouragementSender'
+                taskId:
+                    type: string
+                    description: Task ID being encouraged
+                    examples:
+                        - 507f1f77bcf86cd799439013
+                taskName:
+                    type: string
+                    description: Task name
+                    examples:
+                        - Complete project proposal
+                timestamp:
+                    type: string
+                    description: Creation timestamp
+                    format: date-time
+                    examples:
+                        - "2023-01-01T00:00:00Z"
+                type:
+                    type: string
+                    description: Type of encouragement (message or image)
+                    examples:
+                        - message
+            required:
+                - id
+                - sender
+                - receiver
+                - message
+                - timestamp
+                - scope
+                - read
+                - type
         CreateEncouragementParams:
             type: object
             additionalProperties: false
@@ -7899,6 +8088,64 @@ components:
                     type: string
             required:
                 - name
+        CreatePostOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/CreatePostOutputBody.json
+                    readOnly: true
+                _id:
+                    type: string
+                blueprint:
+                    $ref: '#/components/schemas/EnhancedBlueprintReference'
+                caption:
+                    type: string
+                category:
+                    $ref: '#/components/schemas/CategoryExtendedReference'
+                comments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/CommentDocumentAPI'
+                dual:
+                    type: string
+                groups:
+                    type: array
+                    items:
+                        type: string
+                images:
+                    type: array
+                    items:
+                        type: string
+                metadata:
+                    $ref: '#/components/schemas/PostMetadata'
+                reactions:
+                    type: object
+                    additionalProperties:
+                        type: array
+                        items:
+                            type: string
+                ringDelta:
+                    description: Describes the Share ring increment triggered by this post so the client can render feedback
+                    $ref: '#/components/schemas/RingDelta'
+                size:
+                    $ref: '#/components/schemas/ImageSize'
+                task:
+                    $ref: '#/components/schemas/PostTaskExtendedReference'
+                user:
+                    $ref: '#/components/schemas/UserExtendedReference'
+            required:
+                - _id
+                - user
+                - images
+                - caption
+                - reactions
+                - comments
+                - metadata
         CreatePostOutputUserStats:
             type: object
             additionalProperties: false
@@ -8013,6 +8260,107 @@ components:
                 - tasksCreated
                 - tasks
                 - message
+        CreateTaskOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/CreateTaskOutputBody.json
+                    readOnly: true
+                active:
+                    type: boolean
+                blueprintId:
+                    type: string
+                categoryID:
+                    type: string
+                checklist:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ChecklistItem'
+                content:
+                    type: string
+                deadline:
+                    type: string
+                    format: date-time
+                flexInfo:
+                    $ref: '#/components/schemas/FlexInstanceInfo'
+                id:
+                    type: string
+                integration:
+                    type: string
+                lastEdited:
+                    type: string
+                    format: date-time
+                notes:
+                    type: string
+                posted:
+                    type: boolean
+                priority:
+                    type: integer
+                    format: int64
+                public:
+                    type: boolean
+                pushed_calendar_id:
+                    type: string
+                pushed_event_etag:
+                    type: string
+                pushed_event_id:
+                    type: string
+                recurDetails:
+                    $ref: '#/components/schemas/RecurDetails'
+                recurFrequency:
+                    type: string
+                recurType:
+                    type: string
+                recurring:
+                    type: boolean
+                reminders:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/Reminder'
+                ringDelta:
+                    description: Describes the Plan ring increment triggered by this creation so the client can render feedback
+                    $ref: '#/components/schemas/RingDelta'
+                startDate:
+                    type: string
+                    format: date-time
+                startTime:
+                    type: string
+                    format: date-time
+                templateID:
+                    type: string
+                timeCompleted:
+                    type: string
+                    format: date-time
+                timeTaken:
+                    type: string
+                timestamp:
+                    type: string
+                    format: date-time
+                userID:
+                    type: string
+                value:
+                    type: number
+                    format: double
+                workingOnSince:
+                    type: string
+                    format: date-time
+            required:
+                - id
+                - priority
+                - content
+                - value
+                - recurring
+                - public
+                - active
+                - timestamp
+                - lastEdited
+                - startDate
+                - posted
         CreateTaskParams:
             type: object
             additionalProperties: false
@@ -10822,6 +11170,35 @@ components:
                 - price_in_purchased_currency
                 - currency
                 - original_transaction_id
+        RingDelta:
+            type: object
+            additionalProperties: false
+            properties:
+                all_closed:
+                    type: boolean
+                current:
+                    type: integer
+                    format: int64
+                just_closed:
+                    type: boolean
+                just_closed_all:
+                    type: boolean
+                previous:
+                    type: integer
+                    format: int64
+                ring:
+                    type: string
+                target:
+                    type: integer
+                    format: int64
+            required:
+                - ring
+                - previous
+                - current
+                - target
+                - just_closed
+                - all_closed
+                - just_closed_all
         RingProgress:
             type: object
             additionalProperties: false
@@ -11056,6 +11433,44 @@ components:
                     type: string
             required:
                 - phone_number
+        SetWorkspacePushEnabledInputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/SetWorkspacePushEnabledInputBody.json
+                    readOnly: true
+                push_enabled:
+                    type: boolean
+            required:
+                - push_enabled
+        SetWorkspacePushEnabledOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/SetWorkspacePushEnabledOutputBody.json
+                    readOnly: true
+                message:
+                    type: string
+                    examples:
+                        - Workspace push setting updated
+                modified:
+                    type: integer
+                    format: int64
+                    examples:
+                        - 2
+            required:
+                - message
+                - modified
         SetupWorkspacesInputBody:
             type: object
             additionalProperties: false
@@ -11075,6 +11490,11 @@ components:
                     type: boolean
                 merge_into_one:
                     type: boolean
+                push_enabled_calendar_ids:
+                    type: array
+                    description: Calendar IDs (subset of calendar_ids) that should also receive Kindred tasks pushed back to Google. Default empty (push disabled).
+                    items:
+                        type: string
             required:
                 - calendar_ids
                 - merge_into_one
@@ -11255,6 +11675,12 @@ components:
                     format: int64
                 public:
                     type: boolean
+                pushed_calendar_id:
+                    type: string
+                pushed_event_etag:
+                    type: string
+                pushed_event_id:
+                    type: string
                 recurDetails:
                     $ref: '#/components/schemas/RecurDetails'
                 recurFrequency:

--- a/frontend/api/calendar.ts
+++ b/frontend/api/calendar.ts
@@ -159,6 +159,7 @@ export async function getConnectionCalendars(connectionId: string): Promise<Cale
 export async function setupCalendarWorkspaces(
     connectionId: string,
     calendarIds: string[],
+    pushEnabledCalendarIds: string[],
     mergeIntoOne: boolean,
     makePublic: boolean
 ): Promise<{ success: boolean; message: string }> {
@@ -168,6 +169,7 @@ export async function setupCalendarWorkspaces(
         },
         body: {
             calendar_ids: calendarIds,
+            push_enabled_calendar_ids: pushEnabledCalendarIds,
             merge_into_one: mergeIntoOne,
             make_public: makePublic,
         },

--- a/frontend/api/category.ts
+++ b/frontend/api/category.ts
@@ -176,6 +176,27 @@ export const updateWorkspaceMeta = async (
 };
 
 /**
+ * Toggle push-to-calendar for all calendar-linked categories in a workspace.
+ * Non-calendar categories are not affected.
+ */
+export const setWorkspacePushEnabled = async (
+    workspaceName: string,
+    pushEnabled: boolean
+): Promise<void> => {
+    const { error } = await (client.PATCH as any)(
+        `/v1/user/workspaces/${encodeURIComponent(workspaceName)}/push-enabled`,
+        {
+            params: withAuthHeaders({}),
+            body: { push_enabled: pushEnabled },
+        }
+    );
+
+    if (error) {
+        throw new Error(`Failed to set workspace push: ${JSON.stringify(error)}`);
+    }
+};
+
+/**
  * Setup default workspace with starter tasks
  * Creates the "🌺 Kindred Guide" workspace with onboarding tasks for new users
  */

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -3088,6 +3088,26 @@ export interface paths {
         patch: operations["update-workspace"];
         trace?: never;
     };
+    "/v1/user/workspaces/{name}/push-enabled": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set push-to-calendar for a workspace
+         * @description Flips push_enabled on every calendar-integrated category in the workspace.
+         */
+        patch: operations["set-workspace-push-enabled"];
+        trace?: never;
+    };
     "/v1/waitlist": {
         parameters: {
             query?: never;
@@ -3646,6 +3666,7 @@ export interface components {
             /** Format: date-time */
             lastEdited: string;
             name: string;
+            push_enabled?: boolean;
             tasks: components["schemas"]["TaskDocument"][];
             user: string;
             workspaceName: string;
@@ -3728,6 +3749,8 @@ export interface components {
             message: string;
             /** @description If this was a flex task and more instances remain, the next task instance */
             nextFlexTask?: components["schemas"]["NextFlexTaskDTO"];
+            /** @description Describes the Do ring increment triggered by this completion so the client can render feedback */
+            ringDelta?: components["schemas"]["RingDelta"];
             /**
              * @description Indicates if the user's streak increased
              * @example true
@@ -3969,6 +3992,59 @@ export interface components {
             name: string;
             workspaceName: string;
         };
+        CreateCongratulationOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/CreateCongratulationOutputBody.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Category name
+             * @example Work
+             */
+            categoryName: string;
+            /**
+             * @description Unique identifier for the congratulation
+             * @example 507f1f77bcf86cd799439011
+             */
+            id: string;
+            /**
+             * @description Congratulation message
+             * @example Congratulations on completing your task!
+             */
+            message: string;
+            /**
+             * @description Whether the congratulation has been read
+             * @example false
+             */
+            read: boolean;
+            /**
+             * @description Receiver user ID
+             * @example 507f1f77bcf86cd799439012
+             */
+            receiver: string;
+            /** @description Describes the Share ring increment triggered by this congratulation so the client can render feedback */
+            ringDelta?: components["schemas"]["RingDelta"];
+            /** @description Sender information */
+            sender: components["schemas"]["CongratulationSender"];
+            /**
+             * @description Task name
+             * @example Complete project proposal
+             */
+            taskName: string;
+            /**
+             * Format: date-time
+             * @description Creation timestamp
+             * @example 2023-01-01T00:00:00Z
+             */
+            timestamp: string;
+            /**
+             * @description Type of congratulation (message or image)
+             * @example message
+             */
+            type: string;
+        };
         CreateCongratulationParams: {
             /**
              * Format: uri
@@ -4019,6 +4095,69 @@ export interface components {
              * @example 507f1f77bcf86cd799439012
              */
             receiver_id: string;
+        };
+        CreateEncouragementOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/CreateEncouragementOutputBody.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Category name
+             * @example Work
+             */
+            categoryName?: string;
+            /**
+             * @description Unique identifier for the encouragement
+             * @example 507f1f77bcf86cd799439011
+             */
+            id: string;
+            /**
+             * @description Encouragement message
+             * @example Great job on completing your task!
+             */
+            message: string;
+            /**
+             * @description Whether the encouragement has been read
+             * @example false
+             */
+            read: boolean;
+            /**
+             * @description Receiver user ID
+             * @example 507f1f77bcf86cd799439012
+             */
+            receiver: string;
+            /** @description Describes the Share ring increment triggered by this encouragement so the client can render feedback */
+            ringDelta?: components["schemas"]["RingDelta"];
+            /**
+             * @description Scope of encouragement (task or profile)
+             * @example task
+             */
+            scope: string;
+            /** @description Sender information */
+            sender: components["schemas"]["EncouragementSender"];
+            /**
+             * @description Task ID being encouraged
+             * @example 507f1f77bcf86cd799439013
+             */
+            taskId?: string;
+            /**
+             * @description Task name
+             * @example Complete project proposal
+             */
+            taskName?: string;
+            /**
+             * Format: date-time
+             * @description Creation timestamp
+             * @example 2023-01-01T00:00:00Z
+             */
+            timestamp: string;
+            /**
+             * @description Type of encouragement (message or image)
+             * @example message
+             */
+            type: string;
         };
         CreateEncouragementParams: {
             /**
@@ -4072,6 +4211,31 @@ export interface components {
             readonly $schema?: string;
             members?: string[];
             name: string;
+        };
+        CreatePostOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/CreatePostOutputBody.json
+             */
+            readonly $schema?: string;
+            _id: string;
+            blueprint?: components["schemas"]["EnhancedBlueprintReference"];
+            caption: string;
+            category?: components["schemas"]["CategoryExtendedReference"];
+            comments: components["schemas"]["CommentDocumentAPI"][];
+            dual?: string;
+            groups?: string[];
+            images: string[];
+            metadata: components["schemas"]["PostMetadata"];
+            reactions: {
+                [key: string]: string[];
+            };
+            /** @description Describes the Share ring increment triggered by this post so the client can render feedback */
+            ringDelta?: components["schemas"]["RingDelta"];
+            size?: components["schemas"]["ImageSize"];
+            task?: components["schemas"]["PostTaskExtendedReference"];
+            user: components["schemas"]["UserExtendedReference"];
         };
         CreatePostOutputUserStats: {
             /** Format: int64 */
@@ -4137,6 +4301,56 @@ export interface components {
              * @description Total number of tasks created
              */
             tasksCreated: number;
+        };
+        CreateTaskOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/CreateTaskOutputBody.json
+             */
+            readonly $schema?: string;
+            active: boolean;
+            blueprintId?: string;
+            categoryID?: string;
+            checklist?: components["schemas"]["ChecklistItem"][];
+            content: string;
+            /** Format: date-time */
+            deadline?: string;
+            flexInfo?: components["schemas"]["FlexInstanceInfo"];
+            id: string;
+            integration?: string;
+            /** Format: date-time */
+            lastEdited: string;
+            notes?: string;
+            posted: boolean;
+            /** Format: int64 */
+            priority: number;
+            public: boolean;
+            pushed_calendar_id?: string;
+            pushed_event_etag?: string;
+            pushed_event_id?: string;
+            recurDetails?: components["schemas"]["RecurDetails"];
+            recurFrequency?: string;
+            recurType?: string;
+            recurring: boolean;
+            reminders?: components["schemas"]["Reminder"][];
+            /** @description Describes the Plan ring increment triggered by this creation so the client can render feedback */
+            ringDelta?: components["schemas"]["RingDelta"];
+            /** Format: date-time */
+            startDate: string;
+            /** Format: date-time */
+            startTime?: string;
+            templateID?: string;
+            /** Format: date-time */
+            timeCompleted?: string;
+            timeTaken?: string;
+            /** Format: date-time */
+            timestamp: string;
+            userID?: string;
+            /** Format: double */
+            value: number;
+            /** Format: date-time */
+            workingOnSince?: string;
         };
         CreateTaskParams: {
             /**
@@ -5696,6 +5910,18 @@ export interface components {
             store: string;
             type: string;
         };
+        RingDelta: {
+            all_closed: boolean;
+            /** Format: int64 */
+            current: number;
+            just_closed: boolean;
+            just_closed_all: boolean;
+            /** Format: int64 */
+            previous: number;
+            ring: string;
+            /** Format: int64 */
+            target: number;
+        };
         RingProgress: {
             closed: boolean;
             /** Format: int64 */
@@ -5816,6 +6042,30 @@ export interface components {
             readonly $schema?: string;
             phone_number: string;
         };
+        SetWorkspacePushEnabledInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/SetWorkspacePushEnabledInputBody.json
+             */
+            readonly $schema?: string;
+            push_enabled: boolean;
+        };
+        SetWorkspacePushEnabledOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/SetWorkspacePushEnabledOutputBody.json
+             */
+            readonly $schema?: string;
+            /** @example Workspace push setting updated */
+            message: string;
+            /**
+             * Format: int64
+             * @example 2
+             */
+            modified: number;
+        };
         SetupWorkspacesInputBody: {
             /**
              * Format: uri
@@ -5826,6 +6076,8 @@ export interface components {
             calendar_ids: string[];
             make_public: boolean;
             merge_into_one: boolean;
+            /** @description Calendar IDs (subset of calendar_ids) that should also receive Kindred tasks pushed back to Google. Default empty (push disabled). */
+            push_enabled_calendar_ids?: string[];
         };
         SetupWorkspacesOutputBody: {
             /**
@@ -5924,6 +6176,9 @@ export interface components {
             /** Format: int64 */
             priority: number;
             public: boolean;
+            pushed_calendar_id?: string;
+            pushed_event_etag?: string;
+            pushed_event_id?: string;
             recurDetails?: components["schemas"]["RecurDetails"];
             recurFrequency?: string;
             recurType?: string;
@@ -9420,7 +9675,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["CongratulationDocument"];
+                    "application/json": components["schemas"]["CreateCongratulationOutputBody"];
                 };
             };
             /** @description Error */
@@ -10198,7 +10453,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["EncouragementDocument"];
+                    "application/json": components["schemas"]["CreateEncouragementOutputBody"];
                 };
             };
             /** @description Error */
@@ -10894,7 +11149,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PostDocumentAPI"];
+                    "application/json": components["schemas"]["CreatePostOutputBody"];
                 };
             };
             /** @description Error */
@@ -11902,7 +12157,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TaskDocument"];
+                    "application/json": components["schemas"]["CreateTaskOutputBody"];
                 };
             };
             /** @description Error */
@@ -13056,6 +13311,43 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UpdateWorkspaceOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "set-workspace-push-enabled": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path: {
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SetWorkspacePushEnabledInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetWorkspacePushEnabledOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/components/modals/CalendarSetupBottomSheet.tsx
+++ b/frontend/components/modals/CalendarSetupBottomSheet.tsx
@@ -29,6 +29,7 @@ export default function CalendarSetupBottomSheet({
     const { height: windowHeight } = useWindowDimensions();
     const [calendars, setCalendars] = useState<CalendarInfo[]>([]);
     const [selectedIds, setSelectedIds] = useState<string[]>([]);
+    const [pushEnabledIds, setPushEnabledIds] = useState<string[]>([]);
     const [mergeIntoOne, setMergeIntoOne] = useState(false);
     const [makePublic, setMakePublic] = useState(false);
     const [fetching, setFetching] = useState(false);
@@ -53,7 +54,17 @@ export default function CalendarSetupBottomSheet({
     }, [visible, connectionId]);
 
     const toggleCalendar = (id: string) => {
-        setSelectedIds((prev) =>
+        setSelectedIds((prev) => {
+            const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+            if (!next.includes(id)) {
+                setPushEnabledIds((p) => p.filter((x) => x !== id));
+            }
+            return next;
+        });
+    };
+
+    const togglePushEnabled = (id: string) => {
+        setPushEnabledIds((prev) =>
             prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
         );
     };
@@ -62,7 +73,7 @@ export default function CalendarSetupBottomSheet({
         if (selectedIds.length === 0 || creating) return;
         setCreating(true);
         try {
-            await setupCalendarWorkspaces(connectionId, selectedIds, mergeIntoOne, makePublic);
+            await setupCalendarWorkspaces(connectionId, selectedIds, pushEnabledIds, mergeIntoOne, makePublic);
             onComplete();
         } catch (err) {
             console.error("Failed to set up workspaces:", err);
@@ -101,16 +112,34 @@ export default function CalendarSetupBottomSheet({
                             </ThemedText>
                         )}
                     </View>
-                    <View
-                        style={[
-                            styles.checkbox,
-                            {
-                                backgroundColor: isSelected ? ThemedColor.primary : "transparent",
-                                borderColor: isSelected ? "transparent" : ThemedColor.text,
-                                borderWidth: isSelected ? 0 : 1.5,
-                            },
-                        ]}>
-                        {isSelected && <Ionicons name="checkmark" size={18} color="#FFFFFF" />}
+                    <View style={styles.calendarRowControls}>
+                        {isSelected && (
+                            <View
+                                style={styles.pushSwitchWrap}
+                                onStartShouldSetResponder={() => true}>
+                                <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                                    Push
+                                </ThemedText>
+                                <Switch
+                                    value={pushEnabledIds.includes(itemId)}
+                                    onValueChange={() => togglePushEnabled(itemId)}
+                                    trackColor={{ false: ThemedColor.tertiary, true: ThemedColor.primary }}
+                                    thumbColor="#ffffff"
+                                    ios_backgroundColor={ThemedColor.tertiary}
+                                />
+                            </View>
+                        )}
+                        <View
+                            style={[
+                                styles.checkbox,
+                                {
+                                    backgroundColor: isSelected ? ThemedColor.primary : "transparent",
+                                    borderColor: isSelected ? "transparent" : ThemedColor.text,
+                                    borderWidth: isSelected ? 0 : 1.5,
+                                },
+                            ]}>
+                            {isSelected && <Ionicons name="checkmark" size={18} color="#FFFFFF" />}
+                        </View>
                     </View>
                 </View>
             </TouchableOpacity>
@@ -262,6 +291,16 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
         marginLeft: 12,
+    },
+    calendarRowControls: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    pushSwitchWrap: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 6,
+        marginRight: 4,
     },
     toggleRow: {
         flexDirection: "row",

--- a/frontend/components/modals/edit/EditWorkspace.tsx
+++ b/frontend/components/modals/edit/EditWorkspace.tsx
@@ -4,7 +4,7 @@ import BottomMenuModal from "../BottomMenuModal";
 import DeleteWorkspaceConfirmationModal from "../DeleteWorkspaceConfirmationModal";
 import EditWorkspaceModal from "./EditWorkspaceModal";
 import { useTasks } from "@/contexts/tasksContext";
-import { deleteWorkspace } from "@/api/category";
+import { deleteWorkspace, setWorkspacePushEnabled } from "@/api/category";
 import { showToastable } from "react-native-toastable";
 import DefaultToast from "@/components/ui/DefaultToast";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -44,7 +44,7 @@ type Props = {
 
 const EditWorkspace = (props: Props) => {
     const { editing, setEditing, id, actionRequest = null, onActionHandled, skipMenu = false } = props;
-    const { removeWorkspace, getWorkspace, restoreWorkspace, workspaces } = useTasks();
+    const { removeWorkspace, getWorkspace, restoreWorkspace, workspaces, setWorkSpaces } = useTasks();
     const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
     const [showEditModal, setShowEditModal] = useState(false);
     const [showReorderModal, setShowReorderModal] = useState(false);
@@ -58,6 +58,16 @@ const EditWorkspace = (props: Props) => {
     // Get the categories for the current workspace
     const currentWorkspace = workspaces.find((ws) => ws.name === id);
     const workspaceCategories = currentWorkspace?.categories || [];
+
+    // Calendar-linked categories (those that have a gcal:* integration string).
+    // The "Push to Calendar" workspace toggle only surfaces when at least one exists,
+    // and the display state reflects whether all of them are currently push-enabled.
+    const calendarCategories = workspaceCategories.filter(
+        (c: any) => typeof c.integration === "string" && c.integration.startsWith("gcal:")
+    );
+    const hasCalendarCategories = calendarCategories.length > 0;
+    const pushOn =
+        hasCalendarCategories && calendarCategories.every((c: any) => Boolean(c.push_enabled));
 
     // Reference to the bottom sheet modals
     const editWorkspaceSheetRef = useRef<BottomSheetModal>(null);
@@ -197,6 +207,36 @@ const EditWorkspace = (props: Props) => {
             workspaceStateEvents.emit(id);
         } catch (error) {
             console.error("Error saving workspace visibility:", error);
+        }
+    };
+
+    const handlePushToggleClick = async () => {
+        if (!hasCalendarCategories) return;
+        const next = !pushOn;
+        try {
+            await setWorkspacePushEnabled(id, next);
+            const wsCopy = [...workspaces];
+            const idx = wsCopy.findIndex((w) => w.name === id);
+            if (idx !== -1) {
+                wsCopy[idx] = {
+                    ...wsCopy[idx],
+                    categories: wsCopy[idx].categories.map((c: any) =>
+                        typeof c.integration === "string" && c.integration.startsWith("gcal:")
+                            ? { ...c, push_enabled: next }
+                            : c
+                    ),
+                };
+                setWorkSpaces(wsCopy);
+            }
+        } catch (error) {
+            console.error("Error toggling workspace push:", error);
+            showToastable({
+                title: "Error",
+                status: "danger",
+                position: "top",
+                message: "Failed to update push setting",
+                renderContent: (props) => <DefaultToast {...props} />,
+            });
         }
     };
 
@@ -349,6 +389,16 @@ const EditWorkspace = (props: Props) => {
             icon: isPublic ? "eye" : "eye-off",
             callback: handleVisibilityClick,
         },
+        ...(hasCalendarCategories
+            ? [
+                  {
+                      label: `Push to Calendar • ${pushOn ? "On" : "Off"}`,
+                      icon: "upload-cloud",
+                      callback: handlePushToggleClick,
+                      labelHighlight: pushOn ? "On" : undefined,
+                  },
+              ]
+            : []),
         { label: "Delete", icon: "trash-2", callback: handleDeleteClick },
     ];
 


### PR DESCRIPTION
Closes #373, closes #376.

## Summary

- **#373 — Setup flow:** Per-row push switch in `CalendarSetupBottomSheet`, only visible once a calendar is selected. Selection is passed as `push_enabled_calendar_ids` to the existing setup endpoint (which already accepted the field but had no UI surface).
- **#376 — Workspace settings:** Single "Push to Calendar • On/Off" row in `EditWorkspace`, surfaced only when the workspace contains gcal-linked categories. Toggle fans out to every gcal-integrated category in the workspace via a new `PATCH /v1/user/workspaces/{name}/push-enabled` endpoint — non-calendar categories are untouched.
- **Schema fix:** `CategoryDocument.PushEnabled` was already stored in Mongo (since #372) but missing from the canonical Go struct, so the frontend never received it. Added.

## Architecture notes

`push_enabled` stays the source of truth on each category, so existing push paths (`task_service.enqueuePushUpsertIfEnabled`, `push_service`) keep working unchanged. The workspace-level toggle is a pure UI/API abstraction: it reflects "are all calendar-linked categories in this workspace push-enabled?" and writes the same value to all of them.

## Test plan

- [x] Backend: `go test ./internal/handlers/category/...` (3 new tests: gcal-only scope, wrong-user no-op, disable-all)
- [x] Backend build + vet clean
- [x] Frontend: `bun tsc --noEmit` — no new errors in touched files
- [ ] Manual: connect a Google Calendar, run setup, flip push toggles per row, confirm only toggled calendars get `push_enabled=true` server-side
- [ ] Manual: open workspace settings on a calendar-linked workspace, flip "Push to Calendar", verify all gcal categories flip and that non-calendar workspaces don't show the row
- [ ] Manual: create/update a task in a push-enabled category and confirm it pushes to Google Calendar

🤖 Generated with [Claude Code](https://claude.com/claude-code)