### PR TITLE
fix: stop silently disconnecting calendars on setup-sheet close

### DIFF
--- a/backend/internal/handlers/calendar/calendar.go
+++ b/backend/internal/handlers/calendar/calendar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
@@ -43,67 +44,34 @@ func (h *Handler) ConnectGoogle(ctx context.Context, input *ConnectGoogleInput) 
 	return resp, nil
 }
 
-// OAuthCallback handles Google's OAuth callback and returns HTML redirect
+// OAuthCallback handles Google's OAuth callback and 302s the in-app browser
+// back into the app via the kindred:// deep link. Expo's WebBrowser auto-
+// dismisses the auth session when it sees navigation to the custom scheme.
 func (h *Handler) OAuthCallback(ctx context.Context, input *OAuthCallbackInput) (*OAuthCallbackOutput, error) {
 	slog.Info("OAuth callback received", "has_code", input.Code != "", "has_state", input.State != "", "has_error", input.Error != "")
-	resp := &OAuthCallbackOutput{}
 
-	var redirectURL string
-
-	// Check for OAuth error
 	if input.Error != "" {
 		slog.Warn("OAuth error from provider", "error", input.Error)
-		redirectURL = fmt.Sprintf("kindred://calendar/error?message=%s", input.Error)
-		resp.Body.HTML = fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0;url=%s">
-    <title>Redirecting...</title>
-</head>
-<body>
-    <p>Redirecting to app...</p>
-</body>
-</html>`, redirectURL)
-		return resp, nil
+		return &OAuthCallbackOutput{
+			Status:   http.StatusFound,
+			Location: fmt.Sprintf("kindred://calendar/error?message=%s", input.Error),
+		}, nil
 	}
 
-	// Handle callback (state contains user ID)
 	connection, err := h.service.HandleCallback(ctx, ProviderGoogle, input.Code, input.State)
 	if err != nil {
 		slog.Error("Failed to handle OAuth callback", "error", err)
-		redirectURL = "kindred://calendar/error?message=connection_failed"
-		resp.Body.HTML = fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0;url=%s">
-    <title>Redirecting...</title>
-</head>
-<body>
-    <p>Redirecting to app...</p>
-</body>
-</html>`, redirectURL)
-		return resp, nil
+		return &OAuthCallbackOutput{
+			Status:   http.StatusFound,
+			Location: "kindred://calendar/error?message=connection_failed",
+		}, nil
 	}
 
 	slog.Info("OAuth callback completed successfully", "account", connection.ProviderAccountID, "connection_id", connection.ID.Hex())
-
-	// Success - redirect to deep link
-	redirectURL = fmt.Sprintf("kindred://calendar/linked?connectionId=%s", connection.ID.Hex())
-	resp.Body.HTML = fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0;url=%s">
-    <title>Redirecting...</title>
-</head>
-<body>
-    <p>Redirecting to app...</p>
-</body>
-</html>`, redirectURL)
-
-	return resp, nil
+	return &OAuthCallbackOutput{
+		Status:   http.StatusFound,
+		Location: fmt.Sprintf("kindred://calendar/linked?connectionId=%s", connection.ID.Hex()),
+	}, nil
 }
 
 // GetConnections lists user's calendar connections

--- a/backend/internal/handlers/calendar/cleanup_test.go
+++ b/backend/internal/handlers/calendar/cleanup_test.go
@@ -1,0 +1,186 @@
+package calendar
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type CleanupAfterDisconnectSuite struct {
+	testpkg.BaseSuite
+	svc           *Service
+	pushOutboxCol bson.M // placeholder so tests can find the collection by name
+}
+
+func TestCleanupAfterDisconnect(t *testing.T) {
+	suite.Run(t, new(CleanupAfterDisconnectSuite))
+}
+
+func (s *CleanupAfterDisconnectSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+
+	// Build a Service directly with the test DB collections — we only exercise
+	// the cleanup path, which depends solely on `categories` and `pushOutbox`.
+	categories := s.Collections["categories"]
+	db := categories.Database()
+	connections := db.Collection("calendar_connections")
+	pushOutbox := NewPushOutbox(db.Collection("calendar_push_outbox"))
+
+	s.svc = &Service{
+		connections: connections,
+		categories:  categories,
+		pushOutbox:  pushOutbox,
+	}
+}
+
+func (s *CleanupAfterDisconnectSuite) TestClearsPushEnabledOnMatchingCategories() {
+	user := s.GetUser(0)
+	connID := primitive.NewObjectID()
+	otherConnID := primitive.NewObjectID()
+
+	matching := bson.M{
+		"_id":           primitive.NewObjectID(),
+		"name":          "Work",
+		"workspaceName": "Cal",
+		"user":          user.ID,
+		"tasks":         []bson.M{},
+		"integration":   "gcal:" + connID.Hex() + ":cal-a",
+		"push_enabled":  true,
+	}
+	otherUser := bson.M{
+		"_id":           primitive.NewObjectID(),
+		"name":          "Someone else's",
+		"workspaceName": "Cal",
+		"user":          primitive.NewObjectID(),
+		"tasks":         []bson.M{},
+		"integration":   "gcal:" + connID.Hex() + ":cal-b",
+		"push_enabled":  true,
+	}
+	otherConnection := bson.M{
+		"_id":           primitive.NewObjectID(),
+		"name":          "Other connection",
+		"workspaceName": "Cal",
+		"user":          user.ID,
+		"tasks":         []bson.M{},
+		"integration":   "gcal:" + otherConnID.Hex() + ":cal-x",
+		"push_enabled":  true,
+	}
+	plain := bson.M{
+		"_id":           primitive.NewObjectID(),
+		"name":          "Not a calendar",
+		"workspaceName": "Personal",
+		"user":          user.ID,
+		"tasks":         []bson.M{},
+		"push_enabled":  false,
+	}
+
+	for _, doc := range []bson.M{matching, otherUser, otherConnection, plain} {
+		_, err := s.Collections["categories"].InsertOne(s.Ctx, doc)
+		s.Require().NoError(err)
+	}
+
+	s.svc.cleanupAfterDisconnect(s.Ctx, user.ID, connID)
+
+	cases := []struct {
+		id   primitive.ObjectID
+		want bool
+		desc string
+	}{
+		{matching["_id"].(primitive.ObjectID), false, "matching category should be cleared"},
+		{otherUser["_id"].(primitive.ObjectID), true, "other user's category should be untouched"},
+		{otherConnection["_id"].(primitive.ObjectID), true, "category linked to a different connection should be untouched"},
+		{plain["_id"].(primitive.ObjectID), false, "non-calendar category should be unchanged (was false)"},
+	}
+	for _, tc := range cases {
+		var got struct {
+			PushEnabled bool `bson:"push_enabled"`
+		}
+		err := s.Collections["categories"].FindOne(s.Ctx, bson.M{"_id": tc.id}).Decode(&got)
+		s.Require().NoError(err, tc.desc)
+		s.Equal(tc.want, got.PushEnabled, tc.desc)
+	}
+}
+
+func (s *CleanupAfterDisconnectSuite) TestDropsPendingPushOutboxRows() {
+	user := s.GetUser(0)
+	connID := primitive.NewObjectID()
+	otherConnID := primitive.NewObjectID()
+
+	matchingCatID := primitive.NewObjectID()
+	otherCatID := primitive.NewObjectID()
+
+	// Two categories: one linked to the disconnected connection, one to a different one.
+	for _, doc := range []bson.M{
+		{
+			"_id":           matchingCatID,
+			"name":          "Work",
+			"workspaceName": "Cal",
+			"user":          user.ID,
+			"tasks":         []bson.M{},
+			"integration":   "gcal:" + connID.Hex() + ":cal-a",
+			"push_enabled":  true,
+		},
+		{
+			"_id":           otherCatID,
+			"name":          "Other",
+			"workspaceName": "Cal",
+			"user":          user.ID,
+			"tasks":         []bson.M{},
+			"integration":   "gcal:" + otherConnID.Hex() + ":cal-b",
+			"push_enabled":  true,
+		},
+	} {
+		_, err := s.Collections["categories"].InsertOne(s.Ctx, doc)
+		s.Require().NoError(err)
+	}
+
+	now := time.Now()
+	outboxCol := s.Collections["categories"].Database().Collection("calendar_push_outbox")
+
+	// Three pending rows + one already-permanent row.
+	upsertForMatching := PushOutboxRow{
+		ID: primitive.NewObjectID(), TaskID: primitive.NewObjectID(), CategoryID: matchingCatID, UserID: user.ID,
+		Op: PushOpUpsert, EnqueuedAt: now, NextAttemptAt: now, Status: pushStatusPending,
+	}
+	deleteForMatching := PushOutboxRow{
+		ID: primitive.NewObjectID(), TaskID: primitive.NewObjectID(), CategoryID: matchingCatID, UserID: user.ID,
+		Op: PushOpDelete, TargetConnectionID: connID, TargetCalendarID: "cal-a", TargetEventID: "evt1",
+		EnqueuedAt: now, NextAttemptAt: now, Status: pushStatusPending,
+	}
+	upsertForOther := PushOutboxRow{
+		ID: primitive.NewObjectID(), TaskID: primitive.NewObjectID(), CategoryID: otherCatID, UserID: user.ID,
+		Op: PushOpUpsert, EnqueuedAt: now, NextAttemptAt: now, Status: pushStatusPending,
+	}
+	alreadyPermanent := PushOutboxRow{
+		ID: primitive.NewObjectID(), TaskID: primitive.NewObjectID(), CategoryID: matchingCatID, UserID: user.ID,
+		Op: PushOpUpsert, EnqueuedAt: now, NextAttemptAt: now, Status: pushStatusFailedPermanent,
+	}
+	for _, r := range []PushOutboxRow{upsertForMatching, deleteForMatching, upsertForOther, alreadyPermanent} {
+		_, err := outboxCol.InsertOne(s.Ctx, r)
+		s.Require().NoError(err)
+	}
+
+	s.svc.cleanupAfterDisconnect(s.Ctx, user.ID, connID)
+
+	// The two pending rows referencing the disconnected connection (one upsert
+	// matched by category_id, one delete matched by target_connection_id) are
+	// gone; the row for the other connection and the already-permanent row
+	// survive.
+	survives := func(id primitive.ObjectID) bool {
+		var dummy bson.M
+		err := outboxCol.FindOne(s.Ctx, bson.M{"_id": id}).Decode(&dummy)
+		return err == nil
+	}
+	s.False(survives(upsertForMatching.ID), "pending upsert for matching category should be dropped")
+	s.False(survives(deleteForMatching.ID), "pending delete for matching connection should be dropped")
+	s.True(survives(upsertForOther.ID), "pending upsert for unrelated category should survive")
+	s.True(survives(alreadyPermanent.ID), "failed_permanent row should not be touched")
+}
+
+// Compile-time guard: keep the context import used in the file.
+var _ = context.Background

--- a/backend/internal/handlers/calendar/push_outbox.go
+++ b/backend/internal/handlers/calendar/push_outbox.go
@@ -177,6 +177,29 @@ func (o *PushOutbox) ClaimBatch(ctx context.Context, limit int) ([]PushOutboxRow
 	return rows, nil
 }
 
+// DeletePendingForConnection removes pending outbox rows tied to a disconnected
+// connection — both upserts (matched by category_id, since they look the
+// connection up via the category's integration field at process time) and
+// deletes (matched by their snapshotted target_connection_id). Without this,
+// rows queued before disconnect would retry against a missing connection for
+// hours of exponential backoff before flipping to failed_permanent.
+func (o *PushOutbox) DeletePendingForConnection(ctx context.Context, connectionID primitive.ObjectID, categoryIDs []primitive.ObjectID) (int64, error) {
+	or := []bson.M{
+		{"target_connection_id": connectionID},
+	}
+	if len(categoryIDs) > 0 {
+		or = append(or, bson.M{"category_id": bson.M{"$in": categoryIDs}})
+	}
+	res, err := o.col.DeleteMany(ctx, bson.M{
+		"status": pushStatusPending,
+		"$or":    or,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return res.DeletedCount, nil
+}
+
 // MarkSuccess deletes the row after a successful drain.
 func (o *PushOutbox) MarkSuccess(ctx context.Context, id primitive.ObjectID) error {
 	_, err := o.col.DeleteOne(ctx, bson.M{"_id": id})

--- a/backend/internal/handlers/calendar/push_service.go
+++ b/backend/internal/handlers/calendar/push_service.go
@@ -114,6 +114,10 @@ func (s *Service) processPushUpsert(ctx context.Context, row PushOutboxRow) erro
 
 	conn, err := s.connectionByID(ctx, connID)
 	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			slog.Info("Push upsert: connection gone, dropping row", "connection_id", connID, "task_id", row.TaskID)
+			return nil
+		}
 		return fmt.Errorf("load connection: %w", err)
 	}
 	provider, ok2 := s.providers[conn.Provider]
@@ -170,6 +174,10 @@ func (s *Service) deleteEventForTask(ctx context.Context, task *types.TaskDocume
 	}
 	conn, err := s.connectionByID(ctx, connID)
 	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			slog.Info("deleteEventForTask: connection gone, treating as success", "connection_id", connID, "task_id", task.ID)
+			return nil
+		}
 		return fmt.Errorf("load connection for delete: %w", err)
 	}
 	provider, ok := s.providers[conn.Provider]

--- a/backend/internal/handlers/calendar/service.go
+++ b/backend/internal/handlers/calendar/service.go
@@ -523,6 +523,10 @@ func (s *Service) DisconnectProvider(ctx context.Context, userID, connectionID p
 		return fmt.Errorf("connection not found during deletion")
 	}
 
+	// Clean up downstream state so a future task in an orphaned category
+	// doesn't enqueue push rows that can never resolve.
+	s.cleanupAfterDisconnect(ctx, userID, connectionID)
+
 	slog.Info("Calendar disconnected successfully", "user_id", userID, "connection_id", connectionID)
 
 	// Track disconnection in PostHog
@@ -540,6 +544,61 @@ func (s *Service) DisconnectProvider(ctx context.Context, userID, connectionID p
 	}
 
 	return nil
+}
+
+// cleanupAfterDisconnect flips push_enabled=false on every category linked
+// to the disconnected connection and drops any pending push-outbox rows
+// destined for it. Failures are logged but not propagated: the connection
+// itself is already deleted and we don't want to surface a 500 to the user
+// over best-effort downstream cleanup. We intentionally keep the categories'
+// `integration` field intact so the UI can still surface that they were
+// once linked and so a future re-link could re-bind them.
+func (s *Service) cleanupAfterDisconnect(ctx context.Context, userID, connectionID primitive.ObjectID) {
+	integrationPrefix := fmt.Sprintf("^gcal:%s:", connectionID.Hex())
+
+	// Collect category IDs first so we can target outbox rows precisely.
+	categoryFilter := bson.M{
+		"user":        userID,
+		"integration": bson.M{"$regex": integrationPrefix},
+	}
+	cur, err := s.categories.Find(ctx, categoryFilter, options.Find().SetProjection(bson.M{"_id": 1}))
+	var categoryIDs []primitive.ObjectID
+	if err != nil {
+		slog.Warn("cleanupAfterDisconnect: failed to find orphaned categories", "connection_id", connectionID, "error", err)
+	} else {
+		var rows []struct {
+			ID primitive.ObjectID `bson:"_id"`
+		}
+		if decodeErr := cur.All(ctx, &rows); decodeErr != nil {
+			slog.Warn("cleanupAfterDisconnect: failed to decode orphaned categories", "connection_id", connectionID, "error", decodeErr)
+		}
+		for _, r := range rows {
+			categoryIDs = append(categoryIDs, r.ID)
+		}
+	}
+
+	if len(categoryIDs) > 0 {
+		updRes, updErr := s.categories.UpdateMany(ctx, categoryFilter, bson.M{
+			"$set": bson.M{"push_enabled": false},
+		})
+		if updErr != nil {
+			slog.Warn("cleanupAfterDisconnect: failed to clear push_enabled on orphaned categories", "connection_id", connectionID, "error", updErr)
+		} else {
+			slog.Info("cleanupAfterDisconnect: cleared push_enabled on orphaned categories",
+				"connection_id", connectionID,
+				"matched", updRes.MatchedCount,
+				"modified", updRes.ModifiedCount)
+		}
+	}
+
+	if s.pushOutbox != nil {
+		dropped, dropErr := s.pushOutbox.DeletePendingForConnection(ctx, connectionID, categoryIDs)
+		if dropErr != nil {
+			slog.Warn("cleanupAfterDisconnect: failed to drop pending push-outbox rows", "connection_id", connectionID, "error", dropErr)
+		} else if dropped > 0 {
+			slog.Info("cleanupAfterDisconnect: dropped pending push-outbox rows", "connection_id", connectionID, "dropped", dropped)
+		}
+	}
 }
 
 // getValidToken gets a valid access token, refreshing if necessary

--- a/backend/internal/handlers/calendar/types.go
+++ b/backend/internal/handlers/calendar/types.go
@@ -15,10 +15,13 @@ type OAuthCallbackInput struct {
 	Error string `query:"error"`
 }
 
+// OAuthCallbackOutput returns a 302 redirect so the in-app browser navigates
+// to the kindred:// deep link and auto-dismisses. Previously this returned
+// JSON with a discarded HTML field; that left users staring at a {} body
+// until they manually closed the auth session.
 type OAuthCallbackOutput struct {
-	Body struct {
-		HTML string `json:"-"` // HTML response for redirect
-	} `contentType:"text/html"`
+	Status   int
+	Location string `header:"Location"`
 }
 
 type GetConnectionsInput struct{}

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -838,12 +838,12 @@ paths:
                   schema:
                     type: string
             responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
+                "204":
+                    description: No Content
+                    headers:
+                        Location:
                             schema:
-                                $ref: '#/components/schemas/OAuthCallbackOutputBody'
+                                type: string
                 default:
                     description: Error
                     content:
@@ -10246,17 +10246,6 @@ components:
                 - encouragements
                 - congratulations
                 - friend_requests
-        OAuthCallbackOutputBody:
-            type: object
-            additionalProperties: false
-            properties:
-                $schema:
-                    type: string
-                    description: A URL to the JSON Schema for this object.
-                    format: uri
-                    examples:
-                        - https://example.com/schemas/OAuthCallbackOutputBody.json
-                    readOnly: true
         PostDocumentAPI:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -5435,14 +5435,6 @@ export interface components {
             near_deadlines: boolean;
             reactions: boolean;
         };
-        OAuthCallbackOutputBody: {
-            /**
-             * Format: uri
-             * @description A URL to the JSON Schema for this object.
-             * @example https://example.com/schemas/OAuthCallbackOutputBody.json
-             */
-            readonly $schema?: string;
-        };
         PostDocumentAPI: {
             /**
              * Format: uri
@@ -8010,14 +8002,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
-            200: {
+            /** @description No Content */
+            204: {
                 headers: {
+                    Location?: string;
                     [name: string]: unknown;
                 };
-                content: {
-                    "application/json": components["schemas"]["OAuthCallbackOutputBody"];
-                };
+                content?: never;
             };
             /** @description Error */
             default: {

--- a/frontend/components/modals/CalendarSetupBottomSheet.tsx
+++ b/frontend/components/modals/CalendarSetupBottomSheet.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import { View, StyleSheet, TouchableOpacity, Switch, ActivityIndicator, useWindowDimensions } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedText } from "@/components/ThemedText";
@@ -34,6 +34,21 @@ export default function CalendarSetupBottomSheet({
     const [makePublic, setMakePublic] = useState(false);
     const [fetching, setFetching] = useState(false);
     const [creating, setCreating] = useState(false);
+
+    // Tracks whether the user successfully completed setup in this open. When
+    // false on dismiss, we treat the dismiss as a cancel and disconnect the
+    // pending connection; when true, the dismiss is the success path and we
+    // leave the connection alone. Without this, DefaultModal's onChange(-1)
+    // callback would route every modal close through handleCancel —
+    // including the close-on-success path — silently disconnecting the
+    // calendar the user just finished setting up.
+    const completedRef = useRef(false);
+
+    useEffect(() => {
+        if (visible) {
+            completedRef.current = false;
+        }
+    }, [visible]);
 
     useEffect(() => {
         if (visible && connectionId) {
@@ -71,6 +86,10 @@ export default function CalendarSetupBottomSheet({
                 mergeIntoOne,
                 makePublic,
             );
+            // Mark completion BEFORE onComplete triggers the parent to close
+            // the modal — otherwise handleDismiss would race and treat the
+            // success-path close as a cancel.
+            completedRef.current = true;
             onComplete();
         } catch (err) {
             console.error("Failed to set up workspaces:", err);
@@ -79,14 +98,22 @@ export default function CalendarSetupBottomSheet({
         }
     };
 
-    const handleCancel = async () => {
-        setVisible(false);
+    // Routes both explicit cancels (Cancel button) and implicit dismisses
+    // (backdrop tap, swipe-down, parent flipping `visible`). Only the no-
+    // completion case is treated as a user-cancel that drops the connection.
+    const handleDismiss = async (open: boolean) => {
+        setVisible(open);
+        if (open || completedRef.current) return;
         try {
             await disconnectCalendar(connectionId);
         } catch (err) {
             console.error("Failed to remove pending calendar connection:", err);
         }
         onCancel();
+    };
+
+    const handleCancelPress = () => {
+        setVisible(false);
     };
 
     const renderCalendarItem = ({ item }: { item: CalendarInfo }) => {
@@ -131,7 +158,7 @@ export default function CalendarSetupBottomSheet({
     return (
         <DefaultModal
             visible={visible}
-            setVisible={handleCancel}
+            setVisible={handleDismiss}
             snapPoints={["90%"]}
             enableContentPanningGesture={false}
         >
@@ -226,7 +253,7 @@ export default function CalendarSetupBottomSheet({
                             <View style={styles.buttonContainer}>
                                 <PrimaryButton
                                     title="Cancel"
-                                    onPress={handleCancel}
+                                    onPress={handleCancelPress}
                                     secondary
                                     style={styles.button}
                                 />


### PR DESCRIPTION
## What was happening

The push-outbox worker was looping with `load connection: mongo: no documents in result` after every Google Calendar setup. Tracing the logs showed the connection was being deleted ~700ms after the setup sheet closed — even though the user clicked **Create**, not Cancel.

Four bugs, one incident:

### 1. The setup sheet auto-disconnects on every close (root cause)

`CalendarSetupBottomSheet.tsx` passed `handleCancel` as `DefaultModal`'s `setVisible` prop:
```tsx
<DefaultModal visible={visible} setVisible={handleCancel} ... />
```

`DefaultModal` calls its `setVisible(false)` on **every** dismissal — backdrop tap, swipe-down, and the programmatic close-after-success (when the parent flips `visible` to `false`, `DefaultModal`'s effect calls `ref.dismiss()` which fires `onChange(-1)` → `setVisible(false)`).

So the success path was:
1. `handleCreate` → `setupCalendarWorkspaces` ✓
2. `handleCreate` → `onComplete()` → parent does `setShowCalendarSetup(false)`
3. `DefaultModal` dismisses → calls `setVisible(false)` → which **is `handleCancel`** → `disconnectCalendar` 💥

Fix: a `completedRef` set true before `onComplete()` triggers dismissal, and a `handleDismiss` that only disconnects when `completedRef` is false.

### 2. OAuth callback returned JSON instead of redirecting

`OAuthCallbackOutput.Body.HTML` was tagged `json:\"-\"`. The handler was building a `<meta http-equiv=\"refresh\">` page and assigning it to `HTML`, but Huma stripped it during serialization and returned `{}`. The in-app browser sat on a JSON blob until the user manually X'd out — never auto-dismissing on the `kindred://` deep link.

Fix: return a proper HTTP 302 with `Location: kindred://calendar/linked?connectionId=...`.

### 3. Disconnect left orphaned state behind

`DisconnectProvider` deleted the connection but didn't touch the categories that pointed at it. They kept `integration=gcal:<dead-conn-id>:...` and `push_enabled=true`, so every future task in those categories enqueued a push that could never resolve.

Fix: after deleting the connection, flip `push_enabled=false` on every matching category and drop the corresponding pending push-outbox rows.

### 4. Push upsert didn't handle missing connection

`processPushDelete` handled `ErrNoDocuments` on `connectionByID` gracefully (dropped the row). `processPushUpsert` and `deleteEventForTask` did not — they returned wrapped errors, so the worker retried for ~10 attempts of exponential backoff before flipping to `failed_permanent` (hours).

Fix: mirror the delete path — log and return nil on `ErrNoDocuments`.

## Files changed

**Backend:**
- `calendar.go` / `types.go` — OAuth 302 redirect
- `service.go` — `cleanupAfterDisconnect` (new) wired into `DisconnectProvider`
- `push_outbox.go` — `DeletePendingForConnection` (new)
- `push_service.go` — drop orphan rows in upsert + helper paths
- `cleanup_test.go` (new) — 2 DB-backed tests for the cleanup

**Frontend:**
- `CalendarSetupBottomSheet.tsx` — `completedRef` + `handleDismiss`
- `api/generated/types.ts` + `api-spec.yaml` — regenerated

## Test plan

- [x] `go test ./internal/handlers/calendar/...` — passes including 2 new cleanup tests
- [x] `go build ./...` — clean
- [x] `bun tsc --noEmit` — no new errors in touched files
- [ ] Manual: connect a Google Calendar, complete setup, verify connection survives (no DELETE in logs)
- [ ] Manual: create a task in a calendar-linked category, watch outbox process it cleanly
- [ ] Manual: explicit disconnect from settings → verify categories' `push_enabled` flipped to false and no orphan outbox rows remain
- [ ] Manual: OAuth flow auto-closes the in-app browser when redirect to `kindred://` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)