### PR TITLE
feat: animated ring-update toast on ring progress

### DIFF
--- a/frontend/api/post.ts
+++ b/frontend/api/post.ts
@@ -453,7 +453,11 @@ export const createPostToBackend = async (
     size?: { width: number; height: number; bytes: number },
     groups?: string[],
     dual?: string
-): Promise<{ post: PostDocumentAPI; userStats: { posts_made: number; points: number } | null }> => {
+): Promise<{
+    post: PostDocumentAPI;
+    userStats: { posts_made: number; points: number } | null;
+    ringDelta?: RingDelta;
+}> => {
     try {
         const result = await createPost(images, caption, taskReference, blueprintId, isPublic, size, groups, dual);
         return result;

--- a/frontend/app/(logged-in)/posting/caption.tsx
+++ b/frontend/app/(logged-in)/posting/caption.tsx
@@ -15,6 +15,7 @@ import { useSelectedGroup } from "@/contexts/SelectedGroupContext";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
 import { Ionicons } from "@expo/vector-icons";
 import PostCardHeader from "@/components/cards/PostCardHeader";
 import PostCardMedia from "@/components/cards/PostCardMedia";
@@ -38,6 +39,7 @@ export default function Caption() {
     const ThemedColor = useThemeColor();
     const { user, updateUser } = useAuth();
     const { capture } = useAnalytics();
+    const { showRingUpdate } = useRingUpdate();
     const { selectedGroupId, selectedGroupName, getGroupIds } = useSelectedGroup();
 
     // Compute display text based on state
@@ -146,6 +148,8 @@ export default function Caption() {
                     points: result.userStats.points
                 });
             }
+
+            showRingUpdate(result.ringDelta);
 
             capture(AnalyticsEvents.POST_CREATED, {
                 has_caption: !!data.caption?.trim(),

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -37,6 +37,8 @@ import { useCacheCleanup } from "@/hooks/useCacheCleanup";
 import { logger } from "@/utils/logger";
 import { RevenueCatProvider } from "@/hooks/useRevenueCat";
 import { AnalyticsProvider } from "@/hooks/useAnalytics";
+import { RingUpdateProvider } from "@/contexts/ringUpdateContext";
+import { RingUpdateOverlay } from "@/components/ui/RingUpdateOverlay";
 
 try {
     const previousHandler = ErrorUtils.getGlobalHandler();
@@ -154,6 +156,7 @@ export default Sentry.wrap(function RootLayout() {
 
     return (
         <QueryClientProvider client={queryClient}>
+            <RingUpdateProvider>
             <AnalyticsProvider>
             <AnimatePresence>
                 <AuthProvider>
@@ -181,6 +184,7 @@ export default Sentry.wrap(function RootLayout() {
                                                                             offset={top}
                                                                         />
                                                                         <Slot />
+                                                                        <RingUpdateOverlay />
                                                                         <StatusBar style="light" />
                                                                     </AlertProvider>
                                                                 </BottomSheetModalProvider>
@@ -199,6 +203,7 @@ export default Sentry.wrap(function RootLayout() {
                 </AuthProvider>
             </AnimatePresence>
             </AnalyticsProvider>
+            </RingUpdateProvider>
         </QueryClientProvider>
     );
 });

--- a/frontend/components/cards/SwipableTaskCard.tsx
+++ b/frontend/components/cards/SwipableTaskCard.tsx
@@ -23,6 +23,7 @@ import { AttachStep } from "react-native-spotlight-tour";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
 import DeadlineBottomSheetModal from "../modals/DeadlineBottomSheetModal";
 import ReminderBottomSheetModal from "../modals/ReminderBottomSheetModal";
 
@@ -47,6 +48,7 @@ const SwipableTaskCard = ({
     const { deleteWithUndo, alertElement } = useUndoableDelete();
     const { capture } = useAnalytics();
     const queryClient = useQueryClient();
+    const { showRingUpdate } = useRingUpdate();
     const [showDeadlineModal, setShowDeadlineModal] = useState(false);
     const [showReminderModal, setShowReminderModal] = useState(false);
 
@@ -90,6 +92,15 @@ const SwipableTaskCard = ({
             });
             // Only update UI state after successful API call
             removeFromCategory(categoryId, taskId);
+            // For public tasks we pop a "tap to post" toast at the top for ~5.5s.
+            // The do ring lives in the same top region, so wait for the toast
+            // to clear before animating it.
+            const ringDelta = res.ringDelta;
+            if (ringDelta?.ring === "do" && task.public) {
+                setTimeout(() => showRingUpdate(ringDelta), 5600);
+            } else {
+                showRingUpdate(ringDelta);
+            }
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
             capture(AnalyticsEvents.TASK_COMPLETED, {
                 source: "swipe",

--- a/frontend/components/modals/CongratulateModal.tsx
+++ b/frontend/components/modals/CongratulateModal.tsx
@@ -21,6 +21,7 @@ import CustomAlert, { AlertButton } from "./CustomAlert";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
 
 interface CongratulateModalProps {
     visible: boolean;
@@ -44,6 +45,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
     const ThemedColor = useThemeColor();
     const queryClient = useQueryClient();
     const { updateUser } = useAuth();
+    const { showRingUpdate } = useRingUpdate();
     const [congratulationMessage, setCongratulationMessage] = useState("");
     const [selectedImage, setSelectedImage] = useState<string | null>(null);
     const [isUploading, setIsUploading] = useState(false);
@@ -223,7 +225,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
             };
 
             // Make the API call
-            await createCongratulationAPI(congratulationData);
+            const congratulationResult = await createCongratulationAPI(congratulationData);
 
             // Only update state if component is still mounted
             if (!isMountedRef.current) return;
@@ -233,6 +235,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
             });
 
             setIsUploading(false);
+            showRingUpdate(congratulationResult?.ringDelta);
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
 
             // Update user's congratulation count locally

--- a/frontend/components/modals/EncourageModal.tsx
+++ b/frontend/components/modals/EncourageModal.tsx
@@ -21,6 +21,7 @@ import CustomAlert, { AlertButton } from "./CustomAlert";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
 
 interface EncourageModalProps {
     visible: boolean;
@@ -46,6 +47,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
     const { updateUser } = useAuth();
     const { capture } = useAnalytics();
     const queryClient = useQueryClient();
+    const { showRingUpdate } = useRingUpdate();
     const [encouragementMessage, setEncouragementMessage] = useState("");
     const [selectedImage, setSelectedImage] = useState<string | null>(null);
     const [isUploading, setIsUploading] = useState(false);
@@ -250,12 +252,13 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                 };
 
             // Make the API call
-            await createEncouragementAPI(encouragementData as any);
+            const encouragementResult = await createEncouragementAPI(encouragementData as any);
 
             // Only update state if component is still mounted
             if (!isMountedRef.current) return;
 
             setIsUploading(false);
+            showRingUpdate(encouragementResult?.ringDelta);
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
 
             capture(AnalyticsEvents.ENCOURAGEMENT_SENT, {

--- a/frontend/components/modals/create/Standard.tsx
+++ b/frontend/components/modals/create/Standard.tsx
@@ -32,6 +32,7 @@ import * as Haptics from "expo-haptics";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
 
 type CreateTaskParams = components["schemas"]["CreateTaskParams"];
 
@@ -157,6 +158,7 @@ const StandardContent = ({
     const ThemedColor = useThemeColor();
     const { capture } = useAnalytics();
     const queryClient = useQueryClient();
+    const { showRingUpdate } = useRingUpdate();
     const { start } = useSpotlightTour();
 
     // Determine which categories to use based on blueprint mode
@@ -346,6 +348,7 @@ const StandardContent = ({
             // This ensures we don't have ID mismatches
             removeFromCategory(selectedCategory.id, tempId);
             addToCategory(selectedCategory.id, response);
+            showRingUpdate((response as any)?.ringDelta);
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
             capture(AnalyticsEvents.TASK_CREATED, {
                 source: "create_modal",

--- a/frontend/components/ui/RingUpdateOverlay.tsx
+++ b/frontend/components/ui/RingUpdateOverlay.tsx
@@ -1,0 +1,402 @@
+import React, { useEffect, useRef, useState } from "react";
+import {
+    Animated,
+    Dimensions,
+    Easing,
+    StyleSheet,
+    View,
+} from "react-native";
+import { LinearGradient } from "expo-linear-gradient";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Svg, { Circle } from "react-native-svg";
+import ConfettiCannon from "react-native-confetti-cannon";
+import * as Haptics from "expo-haptics";
+import { Check } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useRingUpdate } from "@/contexts/ringUpdateContext";
+
+const { width: SCREEN_WIDTH, height: SCREEN_HEIGHT } =
+    Dimensions.get("screen");
+const GRADIENT_HEIGHT = SCREEN_HEIGHT * 0.38;
+const RING_SIZE = 88;
+const STROKE_WIDTH = 7;
+const RADIUS = (RING_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+const PRIMARY_COLOR = "#854DFF";
+const TRACK_COLOR = "rgba(255,255,255,0.18)";
+
+const RING_LABELS: Record<"plan" | "do" | "share", string> = {
+    plan: "Plan",
+    do: "Do",
+    share: "Share",
+};
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+// Phased timings — let each beat breathe.
+//   0ms .. 1000ms  : gradient slowly fades in (the room dims)
+//   1000ms .. 1500ms : ring slides in from above + fades in
+//   1700ms .. 2500ms : arc animates previous → current
+//   then hold, then exit (ring leaves first, gradient lingers)
+const GRADIENT_ENTER_DURATION = 1000;
+const RING_ENTER_DELAY = 1000;
+const RING_ENTER_DURATION = 520;
+const ARC_DELAY = 1700;
+const ARC_DURATION = 800;
+const ENTER_TOTAL = ARC_DELAY + ARC_DURATION; // 2500
+const HOLD_NORMAL = 500;
+const HOLD_CLOSE = 1600;
+const RING_EXIT_DURATION = 480;
+const GRADIENT_EXIT_DELAY = 220;
+const GRADIENT_EXIT_DURATION = 720;
+const EXIT_TOTAL = GRADIENT_EXIT_DELAY + GRADIENT_EXIT_DURATION;
+// Fire heavy haptic + confetti slightly before the arc snaps home so the
+// haptic feels like it _caused_ the ring to close.
+const CLOSE_FX_DELAY = ENTER_TOTAL - 120;
+
+export const RingUpdateOverlay: React.FC = () => {
+    const { currentDelta, onAnimationComplete } = useRingUpdate();
+    const insets = useSafeAreaInsets();
+
+    const gradientOpacity = useRef(new Animated.Value(0)).current;
+    const ringOpacity = useRef(new Animated.Value(0)).current;
+    const ringTranslateY = useRef(new Animated.Value(-32)).current;
+    const arcAnim = useRef(new Animated.Value(0)).current;
+    const checkOpacity = useRef(new Animated.Value(0)).current;
+    const countOpacity = useRef(new Animated.Value(1)).current;
+    const celebrationOpacity = useRef(new Animated.Value(0)).current;
+    const celebrationTranslateY = useRef(new Animated.Value(8)).current;
+
+    const [showConfetti, setShowConfetti] = useState(false);
+    const [mounted, setMounted] = useState(false);
+    const closeFxTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        if (!currentDelta) return;
+
+        setMounted(true);
+        setShowConfetti(false);
+
+        gradientOpacity.setValue(0);
+        ringOpacity.setValue(0);
+        ringTranslateY.setValue(-56);
+        arcAnim.setValue(0);
+        checkOpacity.setValue(0);
+        countOpacity.setValue(1);
+        celebrationOpacity.setValue(0);
+        celebrationTranslateY.setValue(8);
+
+        const isClose = currentDelta.just_closed;
+        const isCloseAll = currentDelta.just_closed_all;
+
+        // Enter phase — gradient sweeps in alone, then ring drops in,
+        // then the arc animates. Each animation has its own delay so
+        // they layer cleanly inside a single parallel.
+        const enter = Animated.parallel([
+            Animated.timing(gradientOpacity, {
+                toValue: 1,
+                duration: GRADIENT_ENTER_DURATION,
+                easing: Easing.out(Easing.ease),
+                useNativeDriver: true,
+            }),
+            Animated.timing(ringOpacity, {
+                toValue: 1,
+                delay: RING_ENTER_DELAY,
+                duration: RING_ENTER_DURATION,
+                easing: Easing.out(Easing.ease),
+                useNativeDriver: true,
+            }),
+            Animated.timing(ringTranslateY, {
+                toValue: 0,
+                delay: RING_ENTER_DELAY,
+                duration: RING_ENTER_DURATION + 60,
+                easing: Easing.out(Easing.cubic),
+                useNativeDriver: true,
+            }),
+            Animated.timing(arcAnim, {
+                toValue: 1,
+                delay: ARC_DELAY,
+                duration: ARC_DURATION,
+                easing: Easing.inOut(Easing.cubic),
+                useNativeDriver: false,
+            }),
+        ]);
+
+        const hold = Animated.delay(isClose ? HOLD_CLOSE : HOLD_NORMAL);
+
+        // Exit phase — ring leaves first, gradient lingers a beat and then fades.
+        const exit = Animated.parallel([
+            Animated.timing(ringOpacity, {
+                toValue: 0,
+                duration: RING_EXIT_DURATION,
+                easing: Easing.in(Easing.ease),
+                useNativeDriver: true,
+            }),
+            Animated.timing(ringTranslateY, {
+                toValue: -56,
+                duration: RING_EXIT_DURATION,
+                easing: Easing.in(Easing.cubic),
+                useNativeDriver: true,
+            }),
+            Animated.timing(celebrationOpacity, {
+                toValue: 0,
+                duration: RING_EXIT_DURATION,
+                useNativeDriver: true,
+            }),
+            Animated.timing(gradientOpacity, {
+                toValue: 0,
+                delay: GRADIENT_EXIT_DELAY,
+                duration: GRADIENT_EXIT_DURATION,
+                easing: Easing.in(Easing.ease),
+                useNativeDriver: true,
+            }),
+        ]);
+
+        const sequence = Animated.sequence([enter, hold, exit]);
+        sequence.start(({ finished }) => {
+            if (closeFxTimer.current) {
+                clearTimeout(closeFxTimer.current);
+                closeFxTimer.current = null;
+            }
+            setMounted(false);
+            setShowConfetti(false);
+            if (finished) onAnimationComplete();
+        });
+
+        if (isClose) {
+            closeFxTimer.current = setTimeout(() => {
+                Haptics.impactAsync(
+                    isCloseAll
+                        ? Haptics.ImpactFeedbackStyle.Heavy
+                        : Haptics.ImpactFeedbackStyle.Heavy
+                ).catch(() => {});
+                if (isCloseAll) {
+                    setTimeout(() => {
+                        Haptics.notificationAsync(
+                            Haptics.NotificationFeedbackType.Success
+                        ).catch(() => {});
+                    }, 140);
+                }
+                setShowConfetti(true);
+                Animated.parallel([
+                    Animated.timing(countOpacity, {
+                        toValue: 0,
+                        duration: 180,
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(checkOpacity, {
+                        toValue: 1,
+                        duration: 220,
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(celebrationOpacity, {
+                        toValue: 1,
+                        duration: 320,
+                        useNativeDriver: true,
+                    }),
+                    Animated.timing(celebrationTranslateY, {
+                        toValue: 0,
+                        duration: 320,
+                        easing: Easing.out(Easing.cubic),
+                        useNativeDriver: true,
+                    }),
+                ]).start();
+            }, CLOSE_FX_DELAY);
+        }
+
+        return () => {
+            sequence.stop();
+            if (closeFxTimer.current) {
+                clearTimeout(closeFxTimer.current);
+                closeFxTimer.current = null;
+            }
+        };
+    }, [currentDelta]);
+
+    if (!mounted || !currentDelta) return null;
+
+    const targetSafe = currentDelta.target > 0 ? currentDelta.target : 1;
+    const previousFraction = Math.min(
+        Math.max(currentDelta.previous, 0) / targetSafe,
+        1
+    );
+    const currentFraction = Math.min(
+        Math.max(currentDelta.current, 0) / targetSafe,
+        1
+    );
+
+    const strokeDashoffset = arcAnim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [
+            CIRCUMFERENCE * (1 - previousFraction),
+            CIRCUMFERENCE * (1 - currentFraction),
+        ],
+    });
+
+    const label = RING_LABELS[currentDelta.ring] ?? currentDelta.ring;
+    const celebrationText = currentDelta.just_closed_all
+        ? "All rings closed!"
+        : `${label} ring closed!`;
+
+    return (
+        <View style={styles.root} pointerEvents="none">
+            <Animated.View
+                style={[styles.gradientWrapper, { opacity: gradientOpacity }]}
+            >
+                <LinearGradient
+                    colors={[
+                        "rgba(0,0,0,0.92)",
+                        "rgba(0,0,0,0.78)",
+                        "rgba(0,0,0,0.28)",
+                        "transparent",
+                    ]}
+                    locations={[0, 0.38, 0.72, 1]}
+                    style={StyleSheet.absoluteFill}
+                />
+            </Animated.View>
+
+            <Animated.View
+                style={[
+                    styles.content,
+                    {
+                        top: insets.top + 36,
+                        opacity: ringOpacity,
+                        transform: [{ translateY: ringTranslateY }],
+                    },
+                ]}
+            >
+                <ThemedText style={styles.label}>
+                    {label.toUpperCase()}
+                </ThemedText>
+                <View style={styles.ringWrapper}>
+                    <Svg width={RING_SIZE} height={RING_SIZE}>
+                        <Circle
+                            cx={RING_SIZE / 2}
+                            cy={RING_SIZE / 2}
+                            r={RADIUS}
+                            stroke={TRACK_COLOR}
+                            strokeWidth={STROKE_WIDTH}
+                            fill="none"
+                        />
+                        <AnimatedCircle
+                            cx={RING_SIZE / 2}
+                            cy={RING_SIZE / 2}
+                            r={RADIUS}
+                            stroke={PRIMARY_COLOR}
+                            strokeWidth={STROKE_WIDTH}
+                            fill="none"
+                            strokeDasharray={`${CIRCUMFERENCE}`}
+                            strokeDashoffset={strokeDashoffset}
+                            strokeLinecap="round"
+                            rotation={-90}
+                            origin={`${RING_SIZE / 2}, ${RING_SIZE / 2}`}
+                        />
+                    </Svg>
+                    <Animated.View
+                        style={[styles.ringCenter, { opacity: countOpacity }]}
+                    >
+                        <ThemedText style={styles.ringCount}>
+                            {currentDelta.current}/{currentDelta.target}
+                        </ThemedText>
+                    </Animated.View>
+                    <Animated.View
+                        style={[styles.ringCenter, { opacity: checkOpacity }]}
+                    >
+                        <Check size={30} color={PRIMARY_COLOR} weight="bold" />
+                    </Animated.View>
+                </View>
+                {currentDelta.just_closed && (
+                    <Animated.View
+                        style={{
+                            opacity: celebrationOpacity,
+                            transform: [{ translateY: celebrationTranslateY }],
+                        }}
+                    >
+                        <ThemedText style={styles.celebrationText}>
+                            {celebrationText}
+                        </ThemedText>
+                    </Animated.View>
+                )}
+            </Animated.View>
+
+            {showConfetti && (
+                <View
+                    style={StyleSheet.absoluteFill}
+                    pointerEvents="none"
+                >
+                    <ConfettiCannon
+                        count={currentDelta.just_closed_all ? 110 : 60}
+                        // Pop at the ring's vertical center. Low explosion speed
+                        // + high fall speed keeps the burst from launching
+                        // particles visibly upward — they spread outward and
+                        // immediately rain down past the ring.
+                        origin={{
+                            x: SCREEN_WIDTH / 2,
+                            y: insets.top + 80,
+                        }}
+                        fallSpeed={3400}
+                        explosionSpeed={140}
+                        fadeOut
+                        autoStart
+                    />
+                </View>
+            )}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    root: {
+        ...StyleSheet.absoluteFillObject,
+        zIndex: 99999,
+        elevation: 99999,
+    },
+    gradientWrapper: {
+        position: "absolute",
+        top: 0,
+        left: 0,
+        right: 0,
+        height: GRADIENT_HEIGHT,
+    },
+    content: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        alignItems: "center",
+        gap: 12,
+    },
+    label: {
+        color: "rgba(255,255,255,0.72)",
+        fontSize: 11,
+        fontFamily: "Outfit",
+        letterSpacing: 1.6,
+        fontWeight: "600",
+    },
+    ringWrapper: {
+        width: RING_SIZE,
+        height: RING_SIZE,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringCenter: {
+        position: "absolute",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ringCount: {
+        color: "#ffffff",
+        fontSize: 15,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+    },
+    celebrationText: {
+        color: "#ffffff",
+        fontSize: 16,
+        fontFamily: "Outfit",
+        fontWeight: "600",
+        letterSpacing: 0.2,
+        marginTop: 6,
+    },
+});
+
+export default RingUpdateOverlay;

--- a/frontend/contexts/ringUpdateContext.tsx
+++ b/frontend/contexts/ringUpdateContext.tsx
@@ -1,0 +1,118 @@
+import React, {
+    createContext,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import type { RingDelta, RingTodayResponse } from "@/api/types";
+
+interface RingUpdateContextValue {
+    currentDelta: RingDelta | null;
+    showRingUpdate: (delta: RingDelta | undefined | null) => void;
+    onAnimationComplete: () => void;
+}
+
+const RingUpdateContext = createContext<RingUpdateContextValue>({
+    currentDelta: null,
+    showRingUpdate: () => {},
+    onAnimationComplete: () => {},
+});
+
+export const useRingUpdate = () => useContext(RingUpdateContext);
+
+export const RingUpdateProvider: React.FC<{ children: React.ReactNode }> = ({
+    children,
+}) => {
+    const queryClient = useQueryClient();
+    const [currentDelta, setCurrentDelta] = useState<RingDelta | null>(null);
+    const queueRef = useRef<RingDelta[]>([]);
+    const isAnimatingRef = useRef(false);
+    const mountedRef = useRef(true);
+
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    const applyOptimisticUpdate = useCallback(
+        (delta: RingDelta) => {
+            queryClient.setQueryData<RingTodayResponse>(
+                ["rings", "today"],
+                (prev) => {
+                    if (!prev?.ring_state) return prev;
+                    const ringState = { ...prev.ring_state };
+                    const ring = ringState[delta.ring];
+                    if (!ring) return prev;
+                    ringState[delta.ring] = {
+                        ...ring,
+                        current: delta.current,
+                        target: delta.target,
+                        closed: delta.just_closed || ring.closed,
+                    };
+                    return {
+                        ...prev,
+                        ring_state: {
+                            ...ringState,
+                            all_closed:
+                                delta.all_closed || prev.ring_state.all_closed,
+                        },
+                    };
+                }
+            );
+        },
+        [queryClient]
+    );
+
+    const startNext = useCallback(() => {
+        if (!mountedRef.current) return;
+        const next = queueRef.current.shift();
+        if (!next) {
+            isAnimatingRef.current = false;
+            setCurrentDelta(null);
+            return;
+        }
+        isAnimatingRef.current = true;
+        applyOptimisticUpdate(next);
+        // The overlay handles haptics — heavy on ring close, nothing on a
+        // routine increment. The call site that triggered the action already
+        // fired its own response haptic.
+        setCurrentDelta(next);
+    }, [applyOptimisticUpdate]);
+
+    const showRingUpdate = useCallback(
+        (delta: RingDelta | undefined | null) => {
+            if (!delta) return;
+            // Ring was already closed before this contribution — the user has
+            // already seen the close celebration today, so don't replay the
+            // animation for additional progress on a closed ring. Still patch
+            // the cache so the underlying count stays accurate.
+            if (delta.target > 0 && delta.previous >= delta.target) {
+                applyOptimisticUpdate(delta);
+                return;
+            }
+            queueRef.current.push(delta);
+            if (!isAnimatingRef.current) startNext();
+        },
+        [applyOptimisticUpdate, startNext]
+    );
+
+    const onAnimationComplete = useCallback(() => {
+        // Tiny gap between consecutive animations so they don't feel mashed together.
+        setTimeout(() => {
+            if (mountedRef.current) startNext();
+        }, 120);
+    }, [startNext]);
+
+    return (
+        <RingUpdateContext.Provider
+            value={{ currentDelta, showRingUpdate, onAnimationComplete }}
+        >
+            {children}
+        </RingUpdateContext.Provider>
+    );
+};

--- a/frontend/hooks/useTaskCompletion.tsx
+++ b/frontend/hooks/useTaskCompletion.tsx
@@ -13,6 +13,7 @@ import { updateStreakWidget } from '@/widgets/updateStreakWidget';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import { AnalyticsEvents } from '@/utils/analytics';
 import { useQueryClient } from '@tanstack/react-query';
+import { useRingUpdate } from '@/contexts/ringUpdateContext';
 
 interface TaskCompletionData {
     id: string;
@@ -36,6 +37,7 @@ export const useTaskCompletion = (options?: UseTaskCompletionOptions) => {
     const { user } = useAuth();
     const { capture } = useAnalytics();
     const queryClient = useQueryClient();
+    const { showRingUpdate } = useRingUpdate();
     const confettiTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     const markTaskAsCompleted = useCallback(async (
@@ -59,6 +61,15 @@ export const useTaskCompletion = (options?: UseTaskCompletionOptions) => {
             });
 
             removeFromCategory(categoryId, taskId);
+            // The do ring is fed by task completion, which also pops a "tap to post"
+            // toast at the top of the screen for ~5s. Wait for it to clear before
+            // animating the ring so the two top-of-screen layers don't fight.
+            const ringDelta = res.ringDelta;
+            if (ringDelta?.ring === "do") {
+                setTimeout(() => showRingUpdate(ringDelta), 5100);
+            } else {
+                showRingUpdate(ringDelta);
+            }
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
             capture(AnalyticsEvents.TASK_COMPLETED, {
                 source: "detail_page",
@@ -148,7 +159,7 @@ export const useTaskCompletion = (options?: UseTaskCompletionOptions) => {
             isCompletingRef.current = false;
             setIsCompleting(false);
         }
-    }, [removeFromCategory, addToCategory, setShowConfetti, categories, user, capture]);
+    }, [removeFromCategory, addToCategory, setShowConfetti, categories, user, capture, showRingUpdate, queryClient]);
 
     return {
         markTaskAsCompleted,


### PR DESCRIPTION
## Summary
- New global `RingUpdateProvider` + `RingUpdateOverlay` show a top-of-screen animation whenever a task / post / encouragement / congratulation contributes to a ring: gradient slowly fades in, then a labeled ring drops in, then the arc animates `previous → current`, then a held beat, then a layered exit. Ring closes get a heavy haptic + downward-falling confetti pop + check icon swap + "Ring closed!" celebration text. All-rings-closed adds an extra success haptic and a heavier burst.
- Optimistically patches the `["rings", "today"]` React Query cache via the existing `RingDelta` payload so the rings card reflects the new value immediately, then invalidates as a safety net.
- Wired `showRingUpdate` into every API call site that returns a `RingDelta`:
  - `useTaskCompletion` (detail-page completion)
  - `SwipableTaskCard` (swipe-to-complete)
  - `components/modals/create/Standard` (task creation → plan ring)
  - `app/(logged-in)/posting/caption` (post creation → share ring); widened `createPostToBackend` return type to forward `ringDelta`
  - `EncourageModal` and `CongratulateModal`
- **Do-ring waits for the post toast.** Task completion already pops a "tap to post" toast at the top of the screen for ~5s. When the resulting ring delta is for `do`, `showRingUpdate` is deferred 5.1s (`useTaskCompletion`) or 5.6s for public swipes (`SwipableTaskCard`) so the two top-of-screen layers don't collide. Plan and share rings still animate immediately.
- **Skip re-celebrating a closed ring.** If `delta.previous >= delta.target` the overlay is skipped (cache still patched). Once a user has seen a ring close today, additional contributions to that ring don't replay the animation.
- Confetti origin is exactly the ring's vertical center; `explosionSpeed=140` + `fallSpeed=3400` keeps particles from launching visibly upward — they spread at the pop point and fall straight down past the ring.
- Celebration text uses Outfit 16/600 (per design preferences); Fraunces is reserved for headings.

## Test plan
- [ ] Complete a task that increments the **do** ring (not yet closed) → confirm the existing "tap to post" toast plays out fully, then the ring overlay animates `prev → current` afterward.
- [ ] Complete a task that **closes** the do ring → after toast clears, ring fills, heavy haptic, confetti pops at the ring (no upward travel) and falls down, check icon swaps in, "Do ring closed!" appears in Outfit.
- [ ] Create a new task → **plan** ring overlay fires immediately (no toast wait).
- [ ] Post (with task ref) → **share** ring overlay fires.
- [ ] Send an encouragement / congratulation → share ring overlay fires.
- [ ] Complete a task whose ring is already closed → no overlay, but ProductivityRings card still reflects the new count.
- [ ] Close the final ring of the day → "All rings closed!" copy + heavier confetti + extra success haptic.
- [ ] Spam several task completions quickly → animations queue with a small gap, no stacking/flicker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)