### PR TITLE
feat: ring-update animation, calendar fix, posting polish, live activity buttons

### DIFF
--- a/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
@@ -62,7 +62,7 @@ export const unstable_settings = {
 export default function Task() {
     // Removed activeTab state - no longer using PagerView
     // const [activeTab, setActiveTab] = useState(0);
-    const { name, id, categoryId } = useLocalSearchParams();
+    const { name, id, categoryId, action } = useLocalSearchParams();
     let ThemedColor = useThemeColor();
     const { getTaskById, updateTask, removeFromCategory } = useTasks();
     const { loadTaskData } = useTaskCreation();
@@ -109,6 +109,22 @@ export default function Task() {
             router.back();
         },
     });
+
+    // Handle deep-link actions from Live Activity (e.g. action=complete, action=dismiss)
+    const handledActionRef = useRef<string | null>(null);
+    useEffect(() => {
+        if (!action || typeof action !== 'string') return;
+        const actionKey = `${id}:${action}`;
+        if (handledActionRef.current === actionKey) return;
+        handledActionRef.current = actionKey;
+
+        if (action === 'dismiss') {
+            endActivity(id as string).finally(() => router.back());
+        } else if (action === 'complete' && task) {
+            endActivity(id as string);
+            markTaskAsCompleted(task);
+        }
+    }, [action, id, task, markTaskAsCompleted]);
 
     // Function to refresh task data after edit
     const refreshTaskData = () => {

--- a/frontend/app/(logged-in)/posting/caption.tsx
+++ b/frontend/app/(logged-in)/posting/caption.tsx
@@ -256,18 +256,6 @@ export default function Caption() {
                             fontSize={16}
                             minHeight={120}
                         />
-                        <View
-                            style={{
-                                width: "100%",
-                                padding: 20,
-                                justifyContent: "space-between",
-                                backgroundColor: ThemedColor.lightened,
-                                borderRadius: 8,
-                                flexDirection: "row",
-                            }}>
-                            <ThemedText>Points Gained</ThemedText>
-                            <ThemedText>{taskInfo?.points || 1} points</ThemedText>
-                        </View>
                         <TouchableOpacity
                             style={{
                                 width: "100%",
@@ -276,13 +264,17 @@ export default function Caption() {
                                 backgroundColor: ThemedColor.lightened,
                                 borderRadius: 8,
                                 flexDirection: "row",
+                                alignItems: "center",
                             }}
                             onPress={() => {
                                 router.push("/(logged-in)/posting/groups");
                             }}
                             activeOpacity={0.7}>
                             <ThemedText>Who can see this post?</ThemedText>
-                            <ThemedText>{groupDisplayText}</ThemedText>
+                            <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                                <ThemedText style={{ color: ThemedColor.primary }}>{groupDisplayText}</ThemedText>
+                                <Ionicons name="chevron-forward" size={16} color={ThemedColor.primary} />
+                            </View>
                         </TouchableOpacity>
                         <PrimaryButton
                             title={isPosting ? "Posting..." : "Post"}

--- a/frontend/components/cards/PostCardFooter.tsx
+++ b/frontend/components/cards/PostCardFooter.tsx
@@ -89,33 +89,20 @@ const PostCardFooter = ({
                     </ThemedText>
                 ) : null}
 
-                <View style={styles.reactionsRow}>
-                    {readOnly ? (
-                        reactions.map((react, index) => (
-                            <View
+                {!readOnly && (
+                    <View style={styles.reactionsRow}>
+                        {reactions.map((react, index) => (
+                            <ReactPills
                                 key={`${react.emoji}-${index}`}
-                                style={[styles.reactionPill, { backgroundColor: ThemedColor.lightened }]}
-                            >
-                                <ThemedText style={styles.reactionPillText}>
-                                    {react.emoji} {react.count}
-                                </ThemedText>
-                            </View>
-                        ))
-                    ) : (
-                        <>
-                            {reactions.map((react, index) => (
-                                <ReactPills
-                                    key={`${react.emoji}-${index}`}
-                                    reaction={react}
-                                    postId={0}
-                                    isHighlighted={hasUserReacted?.(react.emoji) ?? false}
-                                    onPress={() => onReaction?.(react.emoji)}
-                                />
-                            ))}
-                            <ReactionAction onAddReaction={(emoji) => onReaction?.(emoji)} postId={0} />
-                        </>
-                    )}
-                </View>
+                                reaction={react}
+                                postId={0}
+                                isHighlighted={hasUserReacted?.(react.emoji) ?? false}
+                                onPress={() => onReaction?.(react.emoji)}
+                            />
+                        ))}
+                        <ReactionAction onAddReaction={(emoji) => onReaction?.(emoji)} postId={0} />
+                    </View>
+                )}
 
                 <TouchableOpacity
                     onPress={readOnly ? undefined : onOpenComments}
@@ -184,14 +171,6 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         gap: 8,
         flexWrap: "wrap",
-    },
-    reactionPill: {
-        borderRadius: 20,
-        paddingHorizontal: 10,
-        paddingVertical: 4,
-    },
-    reactionPillText: {
-        fontSize: 14,
     },
     commentButton: {
         paddingTop: 4,

--- a/frontend/widgets/DeadlineCountdownActivity.tsx
+++ b/frontend/widgets/DeadlineCountdownActivity.tsx
@@ -30,6 +30,7 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
     const encodedName = encodeURIComponent(taskName);
     const taskLink = `kindred:///(logged-in)/(tabs)/(task)/task/${taskId}?categoryId=${categoryId}&name=${encodedName}`;
     const completeLink = `kindred:///(logged-in)/(tabs)/(task)/task/${taskId}?categoryId=${categoryId}&name=${encodedName}&action=complete`;
+    const dismissLink = `kindred:///(logged-in)/(tabs)/(task)/task/${taskId}?categoryId=${categoryId}&name=${encodedName}&action=dismiss`;
 
     return {
         banner: (
@@ -76,7 +77,7 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                 {/* Row 5: CTA Buttons */}
                 <HStack spacing={8}>
                     <Link
-                        destination={{completeLink}}
+                        destination={completeLink}
                         modifiers={[
                             font({ weight: 'semibold', size: 14 }),
                             foregroundStyle('#FFFFFF'),
@@ -87,13 +88,14 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                         ]}
                     >
                         <Text modifiers={[font({ weight: 'semibold', size: 14 }), foregroundStyle('#FFFFFF')]}>
-                            Mark Complete
+                            Mark as Complete
                         </Text>
                     </Link>
                     <Link
-                        destination={taskLink}
+                        destination={dismissLink}
                         modifiers={[
                             font({ weight: 'medium', size: 14 }),
+                            foregroundStyle('#FFFFFF'),
                             padding({ horizontal: 16, vertical: 10 }),
                             background('#4C1D95'),
                             cornerRadius(12),
@@ -101,7 +103,7 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                         ]}
                     >
                         <Text modifiers={[font({ weight: 'medium', size: 14 }), foregroundStyle('#FFFFFF')]}>
-                            Open Task
+                            Dismiss
                         </Text>
                     </Link>
                 </HStack>
@@ -159,7 +161,7 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                 />
                 <HStack spacing={8}>
                     <Link
-                        destination={{completeLink}}
+                        destination={completeLink}
                         modifiers={[
                             font({ weight: 'semibold', size: 13 }),
                             foregroundStyle('#FFFFFF'),
@@ -174,9 +176,10 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                         </Text>
                     </Link>
                     <Link
-                        destination={taskLink}
+                        destination={dismissLink}
                         modifiers={[
                             font({ weight: 'medium', size: 13 }),
+                            foregroundStyle('#FFFFFF'),
                             padding({ horizontal: 14, vertical: 8 }),
                             background('#4C1D95'),
                             cornerRadius(10),
@@ -184,7 +187,7 @@ const DeadlineCountdownComponent = (props: DeadlineCountdownProps) => {
                         ]}
                     >
                         <Text modifiers={[font({ weight: 'medium', size: 13 }), foregroundStyle('#FFFFFF')]}>
-                            Open
+                            Dismiss
                         </Text>
                     </Link>
                 </HStack>


### PR DESCRIPTION
## Summary
- Adds a ring-update animation toast that fires after a post is created, showing the user's progress delta toward their daily ring goal.
- Fixes a bug where closing the calendar setup sheet would silently disconnect the user's connected calendars.
- Polishes the posting preview screen: hides the slack reacts row on the read-only post card so it doesn't suggest interactivity, drops the redundant "Points Gained" row, and styles the "Who can see this post?" group name in purple with a chevron to make the tap affordance explicit.
- Fixes the deadline-approaching Live Activity buttons: the secondary CTA was rendering light blue because `foregroundStyle` wasn't set at the Link level (so SwiftUI's default Link tint bled through). Adds `foregroundStyle('#FFFFFF')` on both Links, replaces "Open Task" with "Dismiss", renames "Mark Complete" → "Mark as Complete", and fixes a `destination={{completeLink}}` bug (object instead of URL string). Wires `action=complete` / `action=dismiss` deep-link handlers in the task screen so the buttons actually end the live activity and either complete the task or close out.

## Test plan
- [ ] Complete a task → confirm the ring-update overlay animates in with the correct delta and dismisses cleanly
- [ ] Open the calendar setup sheet with a connected calendar, then close it without changes → calendar stays connected
- [ ] Open the posting flow → confirm the preview post card has no slack reacts, the "Who can see this post?" group label is purple with a right-facing chevron, and tapping still navigates to the groups picker
- [ ] Trigger a deadline-approaching live activity → confirm both "Mark as Complete" and "Dismiss" buttons render with white text (no light blue), Dismiss closes the activity, and Mark as Complete marks the task done

🤖 Generated with [Claude Code](https://claude.com/claude-code)