### PR TITLE
feat: add tags to categories

### DIFF
--- a/backend/internal/handlers/category/category.go
+++ b/backend/internal/handlers/category/category.go
@@ -293,6 +293,27 @@ func (h *Handler) SetWorkspacePushEnabled(ctx context.Context, input *SetWorkspa
 	return resp, nil
 }
 
+func (h *Handler) GetUserTags(ctx context.Context, input *GetUserTagsInput) (*GetUserTagsOutput, error) {
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+	userID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid ID format for UserId", err)
+	}
+
+	tags, err := h.service.GetUserTags(userID)
+	if err != nil {
+		slog.Error("unable to get user tags", "userId", userIDStr, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to get tags. Please try again.", err)
+	}
+
+	resp := &GetUserTagsOutput{}
+	resp.Body.Tags = tags
+	return resp, nil
+}
+
 func (h *Handler) SetupDefaultWorkspace(ctx context.Context, input *SetupDefaultWorkspaceInput) (*SetupDefaultWorkspaceOutput, error) {
 	// Extract user_id from context (set by auth middleware)
 	user_id, err := auth.RequireAuth(ctx)

--- a/backend/internal/handlers/category/operations.go
+++ b/backend/internal/handlers/category/operations.go
@@ -265,6 +265,28 @@ func RegisterSetWorkspacePushEnabledOperation(api huma.API, handler *Handler) {
 	}, handler.SetWorkspacePushEnabled)
 }
 
+// Get User Tags
+type GetUserTagsInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+}
+
+type GetUserTagsOutput struct {
+	Body struct {
+		Tags []string `json:"tags"`
+	}
+}
+
+func RegisterGetUserTagsOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-user-tags",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/tags",
+		Summary:     "Get user tags",
+		Description: "Retrieve the distinct list of category tags for the authenticated user",
+		Tags:        []string{"categories"},
+	}, handler.GetUserTags)
+}
+
 func RegisterUpdateWorkspaceOperation(api huma.API, handler *Handler) {
 	huma.Register(api, huma.Operation{
 		OperationID: "update-workspace",

--- a/backend/internal/handlers/category/routes.go
+++ b/backend/internal/handlers/category/routes.go
@@ -29,6 +29,7 @@ func RegisterCategoryOperations(api huma.API, handler *Handler) {
 	RegisterGetCategoryOperation(api, handler)
 	RegisterGetCategoriesByUserOperation(api, handler)
 	RegisterGetWorkspacesOperation(api, handler)
+	RegisterGetUserTagsOperation(api, handler)
 	RegisterUpdateCategoryOperation(api, handler)
 	RegisterDeleteCategoryOperation(api, handler)
 	RegisterDeleteWorkspaceOperation(api, handler)

--- a/backend/internal/handlers/category/service.go
+++ b/backend/internal/handlers/category/service.go
@@ -186,6 +186,23 @@ func (s *Service) UpdatePartialCategory(id primitive.ObjectID, updated UpdateCat
 	return s.GetCategoryByID(id)
 }
 
+// GetUserTags returns the distinct, normalized list of tags across all of a
+// user's categories.
+func (s *Service) GetUserTags(user primitive.ObjectID) ([]string, error) {
+	ctx := context.Background()
+	values, err := s.Categories.Distinct(ctx, "tags", bson.M{"user": user})
+	if err != nil {
+		return nil, err
+	}
+	tags := make([]string, 0, len(values))
+	for _, v := range values {
+		if str, ok := v.(string); ok {
+			tags = append(tags, str)
+		}
+	}
+	return tags, nil
+}
+
 // DeleteCategory removes a Category document by ObjectID.
 func (s *Service) DeleteCategory(userId primitive.ObjectID, id primitive.ObjectID) error {
 	ctx := context.Background()

--- a/backend/internal/handlers/category/service.go
+++ b/backend/internal/handlers/category/service.go
@@ -13,6 +13,25 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
+// normalizeTags trims, lowercases, drops empties, and dedupes (preserving
+// first-seen order). Always returns a non-nil slice.
+func normalizeTags(tags []string) []string {
+	seen := make(map[string]struct{}, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		t = strings.ToLower(strings.TrimSpace(t))
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; ok {
+			continue
+		}
+		seen[t] = struct{}{}
+		out = append(out, t)
+	}
+	return out
+}
+
 // newService receives the map of collections and picks out Jobs
 func newService(collections map[string]*mongo.Collection) *Service {
 	return &Service{

--- a/backend/internal/handlers/category/service.go
+++ b/backend/internal/handlers/category/service.go
@@ -152,44 +152,37 @@ func (s *Service) CreateCategory(r *CategoryDocument) (*CategoryDocument, error)
 	return r, nil
 }
 
-// UpdatePartialCategory updates only specified fields of a Category document by ObjectID.
+// UpdatePartialCategory updates only the provided fields of a Category by ObjectID.
 func (s *Service) UpdatePartialCategory(id primitive.ObjectID, updated UpdateCategoryDocument, user primitive.ObjectID) (*CategoryDocument, error) {
 	ctx := context.Background()
 
-	updateFields, err := xutils.ToDoc(updated)
-	if err != nil {
-		return nil, err
+	set := bson.D{{Key: "lastEdited", Value: xutils.NowUTC()}}
+	if updated.Name != "" {
+		set = append(set, bson.E{Key: "name", Value: updated.Name})
+	}
+	if updated.IsBlueprint != nil {
+		set = append(set, bson.E{Key: "isBlueprint", Value: *updated.IsBlueprint})
+	}
+	if updated.BlueprintID != nil {
+		set = append(set, bson.E{Key: "blueprintId", Value: *updated.BlueprintID})
+	}
+	if updated.Tags != nil {
+		set = append(set, bson.E{Key: "tags", Value: normalizeTags(*updated.Tags)})
 	}
 
-	fmt.Println(updateFields)
-
-	// Update with user ownership validation
 	filter := bson.M{"_id": id, "user": user}
-	update := bson.D{{Key: "$set", Value: bson.D{
-		{Key: "name", Value: updated.Name},
-		{Key: "lastEdited", Value: xutils.NowUTC()},
-	}}}
-
-	result, err := s.Categories.UpdateOne(ctx, filter, update)
+	result, err := s.Categories.UpdateOne(ctx, filter, bson.D{{Key: "$set", Value: set}})
 	if err != nil {
 		slog.LogAttrs(ctx, slog.LevelError, "Failed to update Category",
-			slog.String("categoryID", id.Hex()),
-			slog.String("error", err.Error()))
+			slog.String("categoryID", id.Hex()), slog.String("error", err.Error()))
 		return nil, err
 	}
-
 	if result.MatchedCount == 0 {
 		slog.LogAttrs(ctx, slog.LevelError, "Category not found or user doesn't own it",
-			slog.String("categoryID", id.Hex()),
-			slog.String("userID", user.Hex()))
+			slog.String("categoryID", id.Hex()), slog.String("userID", user.Hex()))
 		return nil, fmt.Errorf("category not found or access denied")
 	}
 
-	slog.LogAttrs(ctx, slog.LevelInfo, "Category updated successfully",
-		slog.String("categoryID", id.Hex()),
-		slog.String("newName", updated.Name))
-
-	// Fetch and return the updated category
 	return s.GetCategoryByID(id)
 }
 

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -583,6 +583,36 @@ func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_DisablesAllInWork
 	}
 }
 
+func (s *CategoryServiceTestSuite) TestUpdatePartialCategory_SetsNormalizedTags() {
+	user := s.GetUser(0)
+	created, err := s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "Health", User: user.ID, Tasks: []types.TaskDocument{},
+	})
+	s.NoError(err)
+
+	tags := []string{"  Fitness ", "fitness", "Gym"}
+	result, err := s.service.UpdatePartialCategory(created.ID, UpdateCategoryDocument{Tags: &tags}, user.ID)
+
+	s.NoError(err)
+	s.Equal([]string{"fitness", "gym"}, result.Tags)
+	s.Equal("Health", result.Name) // name preserved on a tags-only update
+}
+
+func (s *CategoryServiceTestSuite) TestUpdatePartialCategory_NilTagsLeavesTagsUntouched() {
+	user := s.GetUser(0)
+	existing := []string{"work"}
+	created, err := s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "Job", User: user.ID, Tasks: []types.TaskDocument{}, Tags: existing,
+	})
+	s.NoError(err)
+
+	result, err := s.service.UpdatePartialCategory(created.ID, UpdateCategoryDocument{Name: "Career"}, user.ID)
+
+	s.NoError(err)
+	s.Equal("Career", result.Name)
+	s.Equal([]string{"work"}, result.Tags) // untouched because Tags was nil
+}
+
 func (s *CategoryServiceTestSuite) TestNormalizeTags() {
 	cases := []struct {
 		name string

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -583,6 +583,29 @@ func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_DisablesAllInWork
 	}
 }
 
+func (s *CategoryServiceTestSuite) TestGetUserTags() {
+	user := s.GetUser(0)
+	other := s.GetUser(1)
+
+	_, err := s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "A", User: user.ID, Tasks: []types.TaskDocument{}, Tags: []string{"fitness", "work"},
+	})
+	s.NoError(err)
+	_, err = s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "B", User: user.ID, Tasks: []types.TaskDocument{}, Tags: []string{"work", "errands"},
+	})
+	s.NoError(err)
+	_, err = s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "C", User: other.ID, Tasks: []types.TaskDocument{}, Tags: []string{"secret"},
+	})
+	s.NoError(err)
+
+	tags, err := s.service.GetUserTags(user.ID)
+
+	s.NoError(err)
+	s.ElementsMatch([]string{"fitness", "work", "errands"}, tags)
+}
+
 func (s *CategoryServiceTestSuite) TestUpdatePartialCategory_SetsNormalizedTags() {
 	user := s.GetUser(0)
 	created, err := s.service.CreateCategory(&CategoryDocument{

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -583,6 +583,25 @@ func (s *CategoryServiceTestSuite) TestSetWorkspacePushEnabled_DisablesAllInWork
 	}
 }
 
+func (s *CategoryServiceTestSuite) TestNormalizeTags() {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"trims and lowercases", []string{"  Fitness "}, []string{"fitness"}},
+		{"drops empty and whitespace", []string{"work", "", "   "}, []string{"work"}},
+		{"dedupes after normalizing", []string{"Work", "work", "WORK"}, []string{"work"}},
+		{"preserves first-seen order", []string{"b", "a", "b"}, []string{"b", "a"}},
+		{"nil input returns empty slice", nil, []string{}},
+	}
+	for _, c := range cases {
+		s.Run(c.name, func() {
+			s.Equal(c.want, normalizeTags(c.in))
+		})
+	}
+}
+
 func (s *CategoryServiceTestSuite) TestRenameWorkspace_Success() {
 	user := s.GetUser(0)
 

--- a/backend/internal/handlers/category/types.go
+++ b/backend/internal/handlers/category/types.go
@@ -24,6 +24,7 @@ type UpdateCategoryDocument struct {
 	Name        string              `bson:"name,omitempty" json:"name,omitempty"`
 	IsBlueprint *bool               `bson:"isBlueprint,omitempty" json:"isBlueprint,omitempty"`
 	BlueprintID *primitive.ObjectID `bson:"blueprintId,omitempty" json:"blueprintId,omitempty"`
+	Tags        *[]string           `bson:"tags,omitempty" json:"tags,omitempty"`
 }
 
 type WorkspaceResult struct {

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -25,6 +25,7 @@ type CategoryDocument struct {
 	BlueprintID   *primitive.ObjectID `bson:"blueprintId,omitempty" json:"blueprintId,omitempty"`
 	Integration   string              `bson:"integration,omitempty" json:"integration,omitempty"` // Format: "gcal:{connection_id}:{calendar_id}"
 	PushEnabled   bool                `bson:"push_enabled,omitempty" json:"push_enabled,omitempty"`
+	Tags          []string            `bson:"tags,omitempty" json:"tags,omitempty"`
 }
 
 type WorkspaceDocument struct {

--- a/frontend/__tests__/TagChip.test.tsx
+++ b/frontend/__tests__/TagChip.test.tsx
@@ -1,0 +1,16 @@
+import { render, fireEvent } from "@testing-library/react-native";
+import TagChip from "@/components/TagChip";
+
+describe("TagChip", () => {
+    test("renders the tag label", () => {
+        const { getByText } = render(<TagChip tag="fitness" />);
+        getByText("fitness");
+    });
+
+    test("calls onPress with the tag when pressed", () => {
+        const onPress = jest.fn();
+        const { getByText } = render(<TagChip tag="work" onPress={onPress} />);
+        fireEvent.press(getByText("work"));
+        expect(onPress).toHaveBeenCalledWith("work");
+    });
+});

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -6308,6 +6308,32 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tags:
+        get:
+            tags:
+                - categories
+            summary: Get user tags
+            description: Retrieve the distinct list of category tags for the authenticated user
+            operationId: get-user-tags
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetUserTagsOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/workspaces:
         get:
             tags:
@@ -7293,6 +7319,10 @@ components:
                     type: string
                 push_enabled:
                     type: boolean
+                tags:
+                    type: array
+                    items:
+                        type: string
                 tasks:
                     type: array
                     items:
@@ -9676,6 +9706,23 @@ components:
                 - total
                 - hasMore
                 - nextOffset
+        GetUserTagsOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/GetUserTagsOutputBody.json
+                    readOnly: true
+                tags:
+                    type: array
+                    items:
+                        type: string
+            required:
+                - tags
         GetUserTemplatesOutputBody:
             type: object
             additionalProperties: false
@@ -12247,6 +12294,10 @@ components:
                     type: boolean
                 name:
                     type: string
+                tags:
+                    type: array
+                    items:
+                        type: string
         UpdateCategoryOutputBody:
             type: object
             additionalProperties: false

--- a/frontend/api/category.ts
+++ b/frontend/api/category.ts
@@ -197,6 +197,19 @@ export const setWorkspacePushEnabled = async (
 };
 
 /**
+ * Get all distinct tags used by the current user
+ */
+export const getUserTags = async (): Promise<string[]> => {
+    const { data, error } = await (client.GET as any)("/v1/user/tags", {
+        params: withAuthHeaders({}),
+    });
+    if (error) {
+        throw new Error(`Failed to get tags: ${JSON.stringify(error)}`);
+    }
+    return data?.tags ?? [];
+};
+
+/**
  * Setup default workspace with starter tasks
  * Creates the "🌺 Kindred Guide" workspace with onboarding tasks for new users
  */

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -3048,6 +3048,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user tags
+         * @description Retrieve the distinct list of category tags for the authenticated user
+         */
+        get: operations["get-user-tags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/workspaces": {
         parameters: {
             query?: never;
@@ -3667,6 +3687,7 @@ export interface components {
             lastEdited: string;
             name: string;
             push_enabled?: boolean;
+            tags?: string[];
             tasks: components["schemas"]["TaskDocument"][];
             user: string;
             workspaceName: string;
@@ -5135,6 +5156,15 @@ export interface components {
              */
             total: number;
         };
+        GetUserTagsOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/GetUserTagsOutputBody.json
+             */
+            readonly $schema?: string;
+            tags: string[];
+        };
         GetUserTemplatesOutputBody: {
             /**
              * Format: uri
@@ -6519,6 +6549,7 @@ export interface components {
             blueprintId?: string;
             isBlueprint?: boolean;
             name?: string;
+            tags?: string[];
         };
         UpdateCategoryOutputBody: {
             /**
@@ -13243,6 +13274,37 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeleteWaitlistOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-user-tags": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetUserTagsOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -106,6 +106,7 @@ export interface Categories {
     id: string;
     name: string;
     tasks: Task[];
+    tags: string[];
 }
 
 

--- a/frontend/api/workspace.tsx
+++ b/frontend/api/workspace.tsx
@@ -48,7 +48,15 @@ export const fetchUserWorkspaces = async (userId: string): Promise<Workspace[]> 
         const { request } = useRequest();
         const result = await request("GET", `/user/Categories/${userId}`);
         logger.debug("Workspaces fetched", { count: result?.length });
-        return result;
+        // Ensure every category carries a tags array (the hand-written Categories
+        // type requires it; the API may omit it for untagged categories).
+        return (result ?? []).map((ws: Workspace) => ({
+            ...ws,
+            categories: (ws.categories ?? []).map((c: Categories) => ({
+                ...c,
+                tags: c.tags ?? [],
+            })),
+        }));
     } catch (error) {
         // Log the error for debugiging
         logger.error("Failed to fetch workspaces", error);

--- a/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
@@ -482,6 +482,7 @@ const WorkspaceContent = ({
                                                         id={category.id}
                                                         name={category.name}
                                                         tasks={filteredTasks}
+                                                        tags={category.tags}
                                                         onLongPress={(categoryId) => {
                                                             setEditing(true);
                                                             setFocusedCategory(categoryId);

--- a/frontend/app/(logged-in)/tag/[tag].tsx
+++ b/frontend/app/(logged-in)/tag/[tag].tsx
@@ -1,0 +1,43 @@
+import React, { useMemo } from "react";
+import { ScrollView, View } from "react-native";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { ThemedText } from "@/components/ThemedText";
+import { Category } from "@/components/category";
+import { useTasks } from "@/contexts/tasksContext";
+
+export default function TagView() {
+    const { tag } = useLocalSearchParams<{ tag: string }>();
+    const router = useRouter();
+    const { getCategoriesByTag } = useTasks();
+
+    const tagValue = (Array.isArray(tag) ? tag[0] : tag) ?? "";
+    const matches = useMemo(() => getCategoriesByTag(tagValue), [getCategoriesByTag, tagValue]);
+
+    return (
+        <SafeAreaView style={{ flex: 1 }}>
+            <Stack.Screen options={{ title: `#${tagValue}` }} />
+            <ScrollView contentContainerStyle={{ padding: 20, gap: 24 }}>
+                <ThemedText type="title">#{tagValue}</ThemedText>
+                {matches.length === 0 ? (
+                    <ThemedText type="caption">No categories tagged "{tagValue}" yet.</ThemedText>
+                ) : (
+                    matches.map(({ workspaceName, category }) => (
+                        <View key={category.id} style={{ gap: 8 }}>
+                            <ThemedText type="caption">{workspaceName}</ThemedText>
+                            <Category
+                                id={category.id}
+                                name={category.name}
+                                tasks={category.tasks}
+                                tags={category.tags}
+                                viewOnly
+                                onPress={() => {}}
+                                onLongPress={() => {}}
+                            />
+                        </View>
+                    ))
+                )}
+            </ScrollView>
+        </SafeAreaView>
+    );
+}

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -126,7 +126,7 @@
         "eslint-plugin-import": "^2.32.0",
         "jest": "~29.7.0",
         "jest-expo": "~55.0.15",
-        "react-test-renderer": "19.1.1",
+        "react-test-renderer": "19.2.0",
         "typescript": "~5.9.2",
       },
     },
@@ -2164,7 +2164,7 @@
 
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
-    "react-test-renderer": ["react-test-renderer@19.1.1", "", { "dependencies": { "react-is": "^19.1.1", "scheduler": "^0.26.0" }, "peerDependencies": { "react": "^19.1.1" } }, "sha512-aGRXI+zcBTtg0diHofc7+Vy97nomBs9WHHFY1Csl3iV0x6xucjNYZZAkiVKGiNYUv23ecOex5jE67t8ZzqYObA=="],
+    "react-test-renderer": ["react-test-renderer@19.2.0", "", { "dependencies": { "react-is": "^19.2.0", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ=="],
 
     "react-text-truncate": ["react-text-truncate@0.19.0", "", { "dependencies": { "prop-types": "^15.5.7" }, "peerDependencies": { "react": "^15.4.1 || ^16.0.0 || ^17.0.0 ||  || ^18.0.0", "react-dom": "^15.4.1 || ^16.0.0 || ^17.0.0 || ^18.0.0" } }, "sha512-QxHpZABfGG0Z3WEYbRTZ+rXdZn50Zvp+sWZXgVAd7FCKAMzv/kcwctTpNmWgXDTpAoHhMjOVwmgRtX3x5yeF4w=="],
 
@@ -2236,7 +2236,7 @@
 
     "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
-    "scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
@@ -2728,8 +2728,6 @@
 
     "jest-config/parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
-    "jest-expo/react-test-renderer": ["react-test-renderer@19.2.0", "", { "dependencies": { "react-is": "^19.2.0", "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-zLCFMHFE9vy/w3AxO0zNxy6aAupnCuLSVOJYDe/Tp+ayGI1f2PLQsFVPANSD42gdSbmYx5oN+1VWDhcXtq7hAQ=="],
-
     "jest-matcher-utils/jest-diff": ["jest-diff@30.3.0", "", { "dependencies": { "@jest/diff-sequences": "30.3.0", "@jest/get-type": "30.1.0", "chalk": "^4.1.2", "pretty-format": "30.3.0" } }, "sha512-n3q4PDQjS4LrKxfWB3Z5KNk1XjXtZTBwQp71OP0Jo03Z6V60x++K5L8k6ZrW8MY8pOFylZvHM0zsjS1RqlHJZQ=="],
 
     "jest-matcher-utils/pretty-format": ["pretty-format@30.3.0", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ=="],
@@ -2804,11 +2802,7 @@
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
-
     "react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
-
-    "react-native/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "react-native/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
@@ -2939,8 +2933,6 @@
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.3", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA=="],
-
-    "jest-expo/react-test-renderer/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "jest-matcher-utils/pretty-format/@jest/schemas": ["@jest/schemas@30.0.5", "", { "dependencies": { "@sinclair/typebox": "^0.34.0" } }, "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA=="],
 

--- a/frontend/components/TagChip.tsx
+++ b/frontend/components/TagChip.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { getCategoryDuotoneColors } from "@/utils/categoryColors";
+
+interface TagChipProps {
+    tag: string;
+    onPress?: (tag: string) => void;
+}
+
+export default function TagChip({ tag, onPress }: TagChipProps) {
+    const { primary, light } = getCategoryDuotoneColors(undefined, tag);
+
+    const content = (
+        <View style={[styles.chip, { backgroundColor: light }]}>
+            <ThemedText type="caption" style={{ color: primary }}>
+                {tag}
+            </ThemedText>
+        </View>
+    );
+
+    if (!onPress) return content;
+
+    return (
+        <TouchableOpacity onPress={() => onPress(tag)} accessibilityRole="button">
+            {content}
+        </TouchableOpacity>
+    );
+}
+
+const styles = StyleSheet.create({
+    chip: {
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 999,
+    },
+});

--- a/frontend/components/category.tsx
+++ b/frontend/components/category.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View, TouchableOpacity } from "react-native";
+import { StyleSheet, View, TouchableOpacity, ScrollView } from "react-native";
 import { ThemedText } from "./ThemedText";
 import TaskCard from "./cards/TaskCard";
 import { Task } from "../api/types";
@@ -8,11 +8,14 @@ import { useTasks } from "@/contexts/tasksContext";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { AttachStep } from "react-native-spotlight-tour";
 import { Plus } from "phosphor-react-native";
+import { useRouter } from "expo-router";
+import TagChip from "@/components/TagChip";
 
 interface CategoryProps {
     id: string;
     name: string;
     tasks: Task[];
+    tags?: string[];
     onLongPress: (categoryId: string) => void;
     onPress: (categoryId: string) => void;
     viewOnly?: boolean;
@@ -24,6 +27,7 @@ export const Category: React.FC<CategoryProps> = ({
     id,
     name,
     tasks,
+    tags = [],
     onLongPress,
     onPress,
     viewOnly = false,
@@ -32,6 +36,7 @@ export const Category: React.FC<CategoryProps> = ({
 }) => {
     const { setCreateCategory } = useTasks();
     const ThemedColor = useThemeColor();
+    const router = useRouter();
 
     const categoryNameText = (
         <ThemedText type={tasks.length > 0 ? "subtitle" : "disabledTitle"}>{name}</ThemedText>
@@ -39,23 +44,40 @@ export const Category: React.FC<CategoryProps> = ({
 
     return (
         <View style={styles.container}>
-            <TouchableOpacity
-                style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}
-                onLongPress={() => onLongPress(id)}
-                disabled={viewOnly}
-                onPress={() => {
-                    onPress(id);
-                    setCreateCategory({ label: name, id: id, special: false });
-                }}>
-                {highlightCategoryHeader ? (
-                    <AttachStep index={2}>
-                        {categoryNameText}
-                    </AttachStep>
-                ) : (
-                    categoryNameText
-                )}
+            <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
+                <TouchableOpacity
+                    style={{ flexDirection: "row", alignItems: "center", gap: 8, flexShrink: 1 }}
+                    onLongPress={() => onLongPress(id)}
+                    disabled={viewOnly}
+                    onPress={() => {
+                        onPress(id);
+                        setCreateCategory({ label: name, id: id, special: false });
+                    }}>
+                    {highlightCategoryHeader ? (
+                        <AttachStep index={2}>
+                            {categoryNameText}
+                        </AttachStep>
+                    ) : (
+                        categoryNameText
+                    )}
+                    {tags.length > 0 && (
+                        <ScrollView
+                            horizontal
+                            showsHorizontalScrollIndicator={false}
+                            contentContainerStyle={{ gap: 6, alignItems: "center" }}
+                            style={{ flexShrink: 1 }}>
+                            {tags.map((tag) => (
+                                <TagChip
+                                    key={tag}
+                                    tag={tag}
+                                    onPress={(t) => router.push(`/tag/${encodeURIComponent(t)}`)}
+                                />
+                            ))}
+                        </ScrollView>
+                    )}
+                </TouchableOpacity>
                 {!viewOnly && <Plus size={16} weight="bold" color={ThemedColor.text} />}
-            </TouchableOpacity>
+            </View>
             {tasks.map((task, index) => {
                 const isFirstTask = index === 0 && highlightFirstTask;
 

--- a/frontend/components/modals/edit/EditCategory.tsx
+++ b/frontend/components/modals/edit/EditCategory.tsx
@@ -23,11 +23,12 @@ const EditCategory = (props: Props) => {
     const editCategorySheetRef = useRef<BottomSheetModal>(null);
 
     // Define snap points for the edit modal
-    const snapPoints = useMemo(() => ["30%"], []);
+    const snapPoints = useMemo(() => ["50%"], []);
 
     // Find the current category to get its name
     const currentCategory = categories.find(cat => cat.id === id);
     const currentName = currentCategory?.name || "";
+    const currentTags = currentCategory?.tags ?? [];
 
     // Helper function to find which workspace contains this category
     const findWorkspaceNameForCategory = (categoryId: string): string | null => {
@@ -112,6 +113,7 @@ const EditCategory = (props: Props) => {
                     <EditCategoryModal
                         categoryId={id}
                         currentName={currentName}
+                        currentTags={currentTags}
                         hide={() => {
                             setShowEditModal(false);
                             editCategorySheetRef.current?.dismiss();

--- a/frontend/components/modals/edit/EditCategoryModal.tsx
+++ b/frontend/components/modals/edit/EditCategoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { View, StyleSheet, TouchableOpacity, Alert } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import ThemedInput from "@/components/inputs/ThemedInput";
@@ -8,17 +8,45 @@ import Feather from "@expo/vector-icons/Feather";
 import { useTasks } from "@/contexts/tasksContext";
 import { showToastable } from "react-native-toastable";
 import DefaultToast from "@/components/ui/DefaultToast";
+import { getUserTags, updateCategory } from "@/api/category";
+import TagChip from "@/components/TagChip";
 
 type Props = {
     hide: () => void;
     categoryId: string;
     currentName: string;
+    currentTags?: string[];
 };
 
-const EditCategoryModal = ({ hide, categoryId, currentName }: Props) => {
+const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props) => {
     let ThemedColor = useThemeColor();
     const [name, setName] = useState(currentName);
-    const { renameCategory } = useTasks();
+    const { renameCategory, updateCategoryTags } = useTasks();
+
+    const [tags, setTags] = useState<string[]>(currentTags ?? []);
+    const [tagInput, setTagInput] = useState("");
+    const [suggestions, setSuggestions] = useState<string[]>([]);
+
+    useEffect(() => {
+        getUserTags()
+            .then(setSuggestions)
+            .catch(() => setSuggestions([]));
+    }, []);
+
+    const normalize = (t: string) => t.trim().toLowerCase();
+    const addTag = (raw: string) => {
+        const t = normalize(raw);
+        if (t.length === 0 || tags.includes(t)) {
+            setTagInput("");
+            return;
+        }
+        setTags([...tags, t]);
+        setTagInput("");
+    };
+    const removeTag = (t: string) => setTags(tags.filter((x) => x !== t));
+    const filteredSuggestions = suggestions
+        .filter((s) => s.includes(normalize(tagInput)) && !tags.includes(s))
+        .slice(0, 5);
 
     const handleEditCategory = async () => {
         if (name.length == 0) {
@@ -26,40 +54,52 @@ const EditCategoryModal = ({ hide, categoryId, currentName }: Props) => {
             return;
         }
 
-        if (name === currentName) {
+        const nameChanged = name !== currentName && name.length > 0;
+        const tagsChanged = JSON.stringify(tags) !== JSON.stringify(currentTags ?? []);
+
+        if (!nameChanged && !tagsChanged) {
             // No change, just close the modal
             hide();
             return;
         }
 
         try {
-            await renameCategory(categoryId, name);
-            
+            if (nameChanged) {
+                await renameCategory(categoryId, name);
+            }
+            if (tagsChanged) {
+                await updateCategory(categoryId, { tags } as any);
+                updateCategoryTags(categoryId, tags);
+            }
+
             // Show success toast
             showToastable({
-                title: "Category renamed!",
+                title: "Category updated!",
                 status: "success",
                 position: "top",
                 swipeDirection: "up",
                 duration: 2500,
-                message: `Category renamed from "${currentName}" to "${name}"`,
+                message: nameChanged
+                    ? `Category renamed from "${currentName}" to "${name}"`
+                    : "Category tags updated",
                 renderContent: (props) => <DefaultToast {...props} />,
             });
-            
+
             hide();
         } catch (err) {
             console.log(err);
-            
+
             // Show error toast
             showToastable({
                 title: "Error",
                 status: "danger",
                 position: "top",
-                message: "Failed to rename category. Please try again.",
+                message: "Failed to update category. Please try again.",
                 renderContent: (props) => <DefaultToast {...props} />,
             });
-            
+
             setName(currentName); // Reset to original name on error
+            setTags(currentTags ?? []);
         }
     };
 
@@ -87,6 +127,37 @@ const EditCategoryModal = ({ hide, categoryId, currentName }: Props) => {
                     value={name}
                     setValue={setName}
                 />
+                <View style={{ gap: 8, marginTop: 8 }}>
+                    <ThemedText type="caption">Tags</ThemedText>
+                    {tags.length > 0 && (
+                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+                            {tags.map((t) => (
+                                <TouchableOpacity
+                                    key={t}
+                                    onPress={() => removeTag(t)}
+                                    accessibilityLabel={`Remove ${t}`}>
+                                    <TagChip tag={`${t}  ×`} />
+                                </TouchableOpacity>
+                            ))}
+                        </View>
+                    )}
+                    <ThemedInput
+                        useBottomSheetInput={true}
+                        placeHolder="Add a tag"
+                        onSubmit={() => addTag(tagInput)}
+                        value={tagInput}
+                        setValue={setTagInput}
+                    />
+                    {filteredSuggestions.length > 0 && (
+                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+                            {filteredSuggestions.map((s) => (
+                                <TouchableOpacity key={s} onPress={() => addTag(s)}>
+                                    <TagChip tag={s} />
+                                </TouchableOpacity>
+                            ))}
+                        </View>
+                    )}
+                </View>
                 <View style={styles.buttonContainer}>
                     <PrimaryButton
                         title="Update Category"

--- a/frontend/components/task/WorkspaceContent.tsx
+++ b/frontend/components/task/WorkspaceContent.tsx
@@ -479,6 +479,7 @@ const WorkspaceContentBody: React.FC<WorkspaceContentBodyProps> = ({
                                                     id={category.id}
                                                     name={category.name}
                                                     tasks={filteredTasks}
+                                                    tags={category.tags}
                                                     onLongPress={(categoryId) => {
                                                         setEditing(true);
                                                         setFocusedCategory(categoryId);

--- a/frontend/contexts/tasksContext.tsx
+++ b/frontend/contexts/tasksContext.tsx
@@ -40,6 +40,8 @@ type TaskContextType = {
     restoreWorkspace: (workspace: Workspace) => void;
     renameWorkspace: (oldName: string, newName: string) => Promise<void>;
     renameCategory: (categoryId: string, newName: string) => Promise<void>;
+    getCategoriesByTag: (tag: string) => { workspaceName: string; category: Categories }[];
+    updateCategoryTags: (categoryId: string, tags: string[]) => void;
     updateWorkspaceIconColor: (name: string, icon?: string | null, color?: string | null) => Promise<void>;
     fetchingWorkspaces: boolean;
 
@@ -297,7 +299,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
     const addToWorkspace = useCallback((name: string, category: Categories) => {
         setRawWorkspaces(prev => prev.map(workspace => {
             if (workspace.name === name) {
-                return { ...workspace, categories: [...workspace.categories, { ...category, tasks: category.tasks ?? [] }] };
+                return { ...workspace, categories: [...workspace.categories, { ...category, tasks: category.tasks ?? [], tags: category.tags ?? [] }] };
             }
             return workspace;
         }));
@@ -426,6 +428,31 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
             throw error;
         }
     }, [invalidateWorkspacesCache, fetchWorkspaces]);
+
+    const getCategoriesByTag = useCallback(
+        (tag: string) => {
+            const target = tag.trim().toLowerCase();
+            const matches: { workspaceName: string; category: Categories }[] = [];
+            for (const ws of rawWorkspaces) {
+                for (const category of ws.categories) {
+                    if ((category.tags ?? []).includes(target)) {
+                        matches.push({ workspaceName: ws.name, category });
+                    }
+                }
+            }
+            return matches;
+        },
+        [rawWorkspaces]
+    );
+
+    const updateCategoryTags = useCallback((categoryId: string, tags: string[]) => {
+        setRawWorkspaces((prev) =>
+            prev.map((ws) => ({
+                ...ws,
+                categories: ws.categories.map((c) => (c.id === categoryId ? { ...c, tags } : c)),
+            }))
+        );
+    }, []);
 
     const handleSetSelected = useCallback((workspaceName: string) => {
         setSelected(workspaceName);
@@ -562,6 +589,8 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
         restoreWorkspace,
         renameWorkspace,
         renameCategory,
+        getCategoriesByTag,
+        updateCategoryTags,
         updateWorkspaceIconColor,
         setCreateCategory,
         selectedCategory,
@@ -587,7 +616,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
         workspaces, getWorkspace, fetchWorkspaces, selected, handleSetSelected,
         categories, addToCategory, updateTask, addToWorkspace, addWorkspace,
         removeFromCategory, removeFromWorkspace, removeWorkspace, restoreWorkspace,
-        renameWorkspace, renameCategory, updateWorkspaceIconColor, setCreateCategory,
+        renameWorkspace, renameCategory, getCategoriesByTag, updateCategoryTags, updateWorkspaceIconColor, setCreateCategory,
         selectedCategory, showConfetti, task, getTaskById, doesWorkspaceExist,
         unnestedTasks, startTodayTasks, dueTodayTasks, pastStartTasks, pastDueTasks,
         futureTasks, fetchingWorkspaces, windowTasks, recentWorkspaces,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -139,7 +139,7 @@
     "eslint-plugin-import": "^2.32.0",
     "jest": "~29.7.0",
     "jest-expo": "~55.0.15",
-    "react-test-renderer": "19.1.1",
+    "react-test-renderer": "19.2.0",
     "typescript": "~5.9.2"
   },
   "resolutions": {


### PR DESCRIPTION
## Summary

Adds free-form **tags** to categories — a cross-cutting dimension over the existing Workspace → Category → Task tree. Tags render as inline chips on the category header; tapping a chip opens a cross-workspace view of every category with that tag.

Scope is the **first cut** from the design spec: tagging + cross-workspace filtering. Tag-scoped analytics/rings/planner filters are deferred as a fast-follow.

## Backend
- `Tags []string` on `CategoryDocument` (normalized: trim + lowercase + dedupe)
- `normalizeTags` helper; `UpdatePartialCategory` builds its `$set` dynamically and sets tags (also no longer blanks the name on a tags-only update)
- `GetUserTags` service + `GET /v1/user/tags` for the distinct per-user tag list (autocomplete)
- 27 category tests pass

## Frontend
- `tags` on the `Categories` type; `getUserTags` API client
- `tasksContext`: tags carried through; `getCategoriesByTag` + `updateCategoryTags` helpers
- `TagChip` component (hash-based duotone colors, 2 unit tests)
- Inline, horizontally-scrolling chips on the category header → navigate to `/tag/[tag]`
- Tag editor (removable chips + autocomplete) in the existing `EditCategoryModal` bottom sheet
- New cross-workspace `app/(logged-in)/tag/[tag].tsx` route

## Notes for reviewers
- **OpenAPI codegen was hand-edited** then fed to `generate-types` (the server needs live Mongo + Calendar secrets to run `make quick-openapi`). Output matches Huma conventions but please run the real codegen once to confirm.
- Includes a **test-infra fix** bumping `react-test-renderer` 19.1.1 → 19.2.0 (peer requirement of `@testing-library/react-native`); frontend tests were broken on `main` without it.
- **Pre-existing, unrelated:** `frontend/components/daily/DatePager.tsx` has a JSX syntax error on `main` (breaks full `tsc`); not addressed here.
- Minor follow-up: removable chips render the "×" as part of the pill text — works, but a proper close icon would be cleaner.

Spec: `docs/superpowers/specs/2026-05-30-category-tags-design.md` · Plan: `docs/superpowers/plans/2026-05-30-category-tags.md` (both gitignored, local only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)