### PR TITLE
feat: onboarding checklist, category tags (inline creator + tag-view controls), typed-route fixes

### DIFF
--- a/backend/internal/handlers/category/category.go
+++ b/backend/internal/handlers/category/category.go
@@ -40,6 +40,7 @@ func (h *Handler) CreateCategory(ctx context.Context, input *CreateCategoryInput
 		WorkspaceName: input.Body.WorkspaceName,
 		User:          user_id_obj,
 		Tasks:         make([]task.TaskDocument, 0),
+		Tags:          normalizeTags(input.Body.Tags),
 		LastEdited:    xutils.NowUTC(),
 	}
 

--- a/backend/internal/handlers/category/service_test.go
+++ b/backend/internal/handlers/category/service_test.go
@@ -195,6 +195,19 @@ func (s *CategoryServiceTestSuite) TestUpdatePartialCategory_WrongUser() {
 	s.Nil(result)
 }
 
+func (s *CategoryServiceTestSuite) TestCreateCategory_PersistsTags() {
+	user := s.GetUser(0)
+	created, err := s.service.CreateCategory(&CategoryDocument{
+		ID: primitive.NewObjectID(), Name: "Tagged", User: user.ID, Tasks: []types.TaskDocument{}, Tags: []string{"fitness", "work"},
+	})
+	s.NoError(err)
+
+	fetched, err := s.service.GetCategoryByID(created.ID)
+
+	s.NoError(err)
+	s.ElementsMatch([]string{"fitness", "work"}, fetched.Tags)
+}
+
 // ========================================
 // DeleteCategory Tests
 // ========================================

--- a/backend/internal/handlers/category/types.go
+++ b/backend/internal/handlers/category/types.go
@@ -7,10 +7,11 @@ import (
 )
 
 type CreateCategoryParams struct {
-	Name          string  `bson:"name" json:"name"`
-	WorkspaceName string  `bson:"workspaceName" json:"workspaceName"`
-	Icon          *string `bson:"icon,omitempty" json:"icon,omitempty"`
-	Color         *string `bson:"color,omitempty" json:"color,omitempty"`
+	Name          string   `bson:"name" json:"name"`
+	WorkspaceName string   `bson:"workspaceName" json:"workspaceName"`
+	Icon          *string  `bson:"icon,omitempty" json:"icon,omitempty"`
+	Color         *string  `bson:"color,omitempty" json:"color,omitempty"`
+	Tags          []string `bson:"tags,omitempty" json:"tags,omitempty"`
 }
 
 type UpdateWorkspaceParams struct {

--- a/frontend/__tests__/categorySort.test.ts
+++ b/frontend/__tests__/categorySort.test.ts
@@ -1,0 +1,65 @@
+import { sortCategories } from "@/utils/categorySort";
+import { Categories, Task } from "@/api/types";
+
+const task = (over: Partial<Task>): Task => ({ id: "t", content: "", priority: 1, ...(over as any) });
+
+const cat = (name: string, tasks: Partial<Task>[]): Categories => ({
+    id: name,
+    name,
+    tags: [],
+    tasks: tasks.map(task),
+});
+
+describe("sortCategories", () => {
+    it("does not mutate the input array", () => {
+        const input = [cat("b", []), cat("a", [])];
+        const snapshot = [...input];
+        sortCategories(input, "alphabetical", "ascending");
+        expect(input).toEqual(snapshot);
+    });
+
+    it("sorts alphabetically in both directions", () => {
+        const cats = [cat("Banana", []), cat("apple", []), cat("Cherry", [])];
+        expect(sortCategories(cats, "alphabetical", "ascending").map((c) => c.name)).toEqual([
+            "apple",
+            "Banana",
+            "Cherry",
+        ]);
+        expect(sortCategories(cats, "alphabetical", "descending").map((c) => c.name)).toEqual([
+            "Cherry",
+            "Banana",
+            "apple",
+        ]);
+    });
+
+    it("sorts by task count", () => {
+        const cats = [
+            cat("one", [{}]),
+            cat("three", [{}, {}, {}]),
+            cat("two", [{}, {}]),
+        ];
+        expect(sortCategories(cats, "task-count", "descending").map((c) => c.name)).toEqual([
+            "three",
+            "two",
+            "one",
+        ]);
+        expect(sortCategories(cats, "task-count", "ascending").map((c) => c.name)).toEqual([
+            "one",
+            "two",
+            "three",
+        ]);
+    });
+
+    it("sorts by earliest due date, categories without deadlines last (ascending)", () => {
+        const cats = [
+            cat("none", [{ content: "x" }]),
+            cat("later", [{ deadline: "2026-02-01T00:00:00Z" }]),
+            cat("soon", [{ deadline: "2026-01-01T00:00:00Z" }]),
+        ];
+        expect(sortCategories(cats, "due-date", "ascending").map((c) => c.name)).toEqual([
+            "soon",
+            "later",
+            "none",
+        ]);
+    });
+});

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -7833,6 +7833,10 @@ components:
                     type: string
                 name:
                     type: string
+                tags:
+                    type: array
+                    items:
+                        type: string
                 workspaceName:
                     type: string
             required:

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -4011,6 +4011,7 @@ export interface components {
             color?: string;
             icon?: string;
             name: string;
+            tags?: string[];
             workspaceName: string;
         };
         CreateCongratulationOutputBody: {

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -264,7 +264,7 @@ const Notifications = () => {
             case "encouragement":
                 // referenceId is the task ID (task-scope) or empty (profile-scope).
                 if (notification.referenceId) {
-                    router.push(`/(logged-in)/(tabs)/(task)/task/${notification.referenceId}` as any);
+                    router.push(`/(logged-in)/(tabs)/(task)/task/${notification.referenceId}`);
                 } else {
                     router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=encouragements");
                 }

--- a/frontend/app/(logged-in)/(tabs)/(task)/preview.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/preview.tsx
@@ -25,11 +25,11 @@ interface GroupedCategory {
 }
 
 // Preview task item that looks like a real task but isn't swipable
-const PreviewTaskItem = ({ 
-    task, 
-    categoryId 
-}: { 
-    task: Task; 
+const PreviewTaskItem = ({
+    task,
+    categoryId
+}: {
+    task: Task;
     categoryId: string;
 }) => {
     return (
@@ -58,7 +58,7 @@ const PreviewCategorySection = ({
     isNew?: boolean;
 }) => {
     const ThemedColor = useThemeColor();
-    
+
     return (
         <View style={styles.categorySection}>
             {/* Workspace label if provided */}
@@ -76,7 +76,7 @@ const PreviewCategorySection = ({
                     )}
                 </View>
             )}
-            
+
             {/* Category header */}
             <View style={styles.categoryHeader}>
                 <ThemedText type="subtitle" style={styles.categoryTitle}>
@@ -90,14 +90,14 @@ const PreviewCategorySection = ({
                     </View>
                 )}
             </View>
-            
+
             {/* Tasks list */}
             <View style={styles.tasksList}>
                 {tasks.map((task, index) => (
-                    <PreviewTaskItem 
-                        key={index} 
-                        task={task} 
-                        categoryId={`preview-${index}`} 
+                    <PreviewTaskItem
+                        key={index}
+                        task={task}
+                        categoryId={`preview-${index}`}
                     />
                 ))}
             </View>
@@ -143,7 +143,7 @@ const Preview = (props: Props) => {
     // Build a map of categoryId to category info from workspaces and new categories
     const categoryMap = useMemo(() => {
         const map = new Map<string, { name: string; workspace: string; isNew: boolean }>();
-        
+
         // Add existing categories from workspaces
         workspaces.forEach(workspace => {
             workspace.categories.forEach(category => {
@@ -154,7 +154,7 @@ const Preview = (props: Props) => {
                 });
             });
         });
-        
+
         // Add newly created categories from API response
         newCategoriesData.forEach(category => {
             map.set(category.id, {
@@ -163,18 +163,18 @@ const Preview = (props: Props) => {
                 isNew: true, // Newly created categories
             });
         });
-        
+
         return map;
     }, [workspaces, newCategoriesData]);
 
     // Group tasks by category
     const groupedCategories = useMemo(() => {
         const groups = new Map<string, GroupedCategory>();
-        
+
         tasksData.forEach((taskDoc) => {
             const categoryId = taskDoc.categoryID;
             if (!categoryId) return;
-            
+
             // Convert TaskDocument to Task format
             const task: Task = {
                 id: taskDoc.id,
@@ -193,10 +193,10 @@ const Preview = (props: Props) => {
                 userID: taskDoc.userID,
                 categoryID: taskDoc.categoryID,
             };
-            
+
             if (!groups.has(categoryId)) {
                 const categoryInfo = categoryMap.get(categoryId);
-                
+
                 groups.set(categoryId, {
                     categoryId,
                     categoryName: categoryInfo?.name || "Unknown Category",
@@ -205,10 +205,10 @@ const Preview = (props: Props) => {
                     isNew: categoryInfo?.isNew || false, // Use isNew from categoryMap
                 });
             }
-            
+
             groups.get(categoryId)!.tasks.push(task);
         });
-        
+
         return Array.from(groups.values());
     }, [tasksData, categoryMap]);
 
@@ -220,7 +220,7 @@ const Preview = (props: Props) => {
             categoryName: "Homework",
             isNew: true,
             tasks: [
-                { 
+                {
                     id: "preview-1",
                     content: "Complete math assignment chapter 5",
                     value: 10,
@@ -232,7 +232,7 @@ const Preview = (props: Props) => {
                     timestamp: new Date().toISOString(),
                     lastEdited: new Date().toISOString(),
                 },
-                { 
+                {
                     id: "preview-2",
                     content: "Write essay for English class",
                     value: 8,
@@ -251,7 +251,7 @@ const Preview = (props: Props) => {
             categoryName: "Fitness",
             isNew: true,
             tasks: [
-                { 
+                {
                     id: "preview-3",
                     content: "Go to the gym at 7 AM",
                     value: 5,
@@ -263,7 +263,7 @@ const Preview = (props: Props) => {
                     timestamp: new Date().toISOString(),
                     lastEdited: new Date().toISOString(),
                 },
-                { 
+                {
                     id: "preview-4",
                     content: "Prepare protein shake",
                     value: 3,
@@ -283,7 +283,7 @@ const Preview = (props: Props) => {
             categoryName: "Development",
             isNew: false,
             tasks: [
-                { 
+                {
                     id: "preview-5",
                     content: "Review pull requests",
                     value: 12,
@@ -338,17 +338,17 @@ const Preview = (props: Props) => {
             <View
                 style={[
                     styles.bottomButtonContainer,
-                    { 
+                    {
                         backgroundColor: ThemedColor.background,
                         borderTopColor: ThemedColor.tertiary + '40',
                     },
                 ]}>
-                <PrimaryButton 
-                    title="Create Tasks" 
+                <PrimaryButton
+                    title="Create Tasks"
                     onPress={() => {
                         // Navigate to tasks index page
-                        router.push("/(logged-in)/(tabs)/(task)" as any);
-                    }} 
+                        router.push("/(logged-in)/(tabs)/(task)");
+                    }}
                 />
             </View>
         </ThemedView>

--- a/frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/text-dump.tsx
@@ -75,7 +75,7 @@ const TextDump = (props: Props) => {
 
             // Navigate to preview screen with the task data
             router.push({
-                pathname: "/(logged-in)/(tabs)/(task)/preview" as any,
+                pathname: "/(logged-in)/(tabs)/(task)/preview",
                 params: {
                     tasks: JSON.stringify(result.tasks),
                     newCategories: JSON.stringify(result.newCategories || []),

--- a/frontend/app/(logged-in)/(tabs)/(task)/voice.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/voice.tsx
@@ -142,7 +142,7 @@ const VoiceDump = (props: Props) => {
 
             // Navigate to preview screen with the task data
             router.push({
-                pathname: "/(logged-in)/(tabs)/(task)/preview" as any,
+                pathname: "/(logged-in)/(tabs)/(task)/preview",
                 params: {
                     tasks: JSON.stringify(result.tasks),
                     newCategories: JSON.stringify(result.newCategories || []),

--- a/frontend/app/(logged-in)/_layout.tsx
+++ b/frontend/app/(logged-in)/_layout.tsx
@@ -2,7 +2,7 @@
 
 import BackButton from "@/components/BackButton";
 import { useAuth } from "@/hooks/useAuth";
-import { Redirect, Slot, Stack, router, usePathname } from "expo-router";
+import { Redirect, Slot, Stack, router, usePathname, type Href } from "expo-router";
 import React, { useCallback, useEffect, useState, useRef } from "react";
 
 import { ScrollView, View, ActivityIndicator, Animated, AppState, InteractionManager, LogBox } from "react-native";
@@ -172,7 +172,7 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     const { fetchKudosData } = useKudos();
     const { identify, capture } = useAnalytics();
     const [isLoading, setIsLoading] = useState(true);
-    const [redirectPath, setRedirectPath] = useState<string | null>(null);
+    const [redirectPath, setRedirectPath] = useState<Href | null>(null);
     const [expoPushToken, setExpoPushToken] = useState<string | undefined>();
     const notificationListener = useRef<Notifications.Subscription | null>(null);
     const responseListener = useRef<Notifications.Subscription | null>(null);
@@ -402,7 +402,7 @@ const layout = ({ children }: { children: React.ReactNode }) => {
     // If no user after loading, redirect based on onboarding status
     if (!user) {
         if (redirectPath) {
-            return <Redirect href={redirectPath as any} />;
+            return <Redirect href={redirectPath} />;
         }
         // Still determining redirect path (shouldn't happen, but fallback)
         return <EnhancedSplashScreen onAnimationComplete={handleAnimationComplete} />;

--- a/frontend/app/(logged-in)/posting/[id].tsx
+++ b/frontend/app/(logged-in)/posting/[id].tsx
@@ -25,7 +25,7 @@ export default function PostDetail() {
             router.back();
         } else {
             // No navigation stack, go to feed
-            router.replace("/(logged-in)/(tabs)/(feed)/" as any);
+            router.replace("/(logged-in)/(tabs)/(feed)/feed");
         }
     };
 

--- a/frontend/app/(logged-in)/tag/[tag].tsx
+++ b/frontend/app/(logged-in)/tag/[tag].tsx
@@ -1,34 +1,107 @@
-import React, { useMemo } from "react";
-import { ScrollView, View } from "react-native";
+import React, { useCallback, useMemo, useRef } from "react";
+import { ScrollView, TouchableOpacity, View } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { BottomSheetModal, BottomSheetBackdrop, BottomSheetView } from "@gorhom/bottom-sheet";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { FunnelSimple, SortAscending } from "phosphor-react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { Category } from "@/components/category";
 import { useTasks } from "@/contexts/tasksContext";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useWorkspaceFilters } from "@/hooks/useWorkspaceFilters";
+import { useWorkspaceState } from "@/hooks/useWorkspaceState";
+import { SortContent, FilterContent } from "@/components/ListControls";
+import { sortCategories } from "@/utils/categorySort";
 
 export default function TagView() {
     const { tag } = useLocalSearchParams<{ tag: string }>();
     const router = useRouter();
+    const ThemedColor = useThemeColor();
     const { getCategoriesByTag } = useTasks();
 
     const tagValue = (Array.isArray(tag) ? tag[0] : tag) ?? "";
+    // Scope filter/sort state to this tag (independent of any workspace).
+    const storageKey = `tag:${tagValue}`;
+    const { applyFilters } = useWorkspaceFilters(storageKey);
+    const { state } = useWorkspaceState(storageKey);
+
     const matches = useMemo(() => getCategoriesByTag(tagValue), [getCategoriesByTag, tagValue]);
+
+    // Sort is applied as a derived ordering — we can't reorder global state
+    // because these categories span multiple workspaces.
+    const ordered = useMemo(() => {
+        if (!state.sort) return matches;
+        const sortedCats = sortCategories(
+            matches.map((m) => m.category),
+            state.sort,
+            state.sortDirection ?? "descending"
+        );
+        return sortedCats
+            .map((cat) => matches.find((m) => m.category.id === cat.id))
+            .filter((m): m is (typeof matches)[number] => m !== undefined);
+    }, [matches, state.sort, state.sortDirection]);
+
+    const sortSheetRef = useRef<BottomSheetModal>(null);
+    const filterSheetRef = useRef<BottomSheetModal>(null);
+    const sortSnapPoints = useMemo(() => ["40%"], []);
+    const filterSnapPoints = useMemo(() => ["50%"], []);
+
+    const renderBackdrop = useCallback(
+        (backdropProps) => (
+            <BottomSheetBackdrop {...backdropProps} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.5} />
+        ),
+        []
+    );
 
     return (
         <SafeAreaView style={{ flex: 1 }}>
-            <Stack.Screen options={{ title: `#${tagValue}` }} />
+            <Stack.Screen options={{ headerShown: false }} />
+            <View
+                style={{
+                    flexDirection: "row",
+                    alignItems: "center",
+                    gap: 8,
+                    paddingHorizontal: 20,
+                    paddingTop: 8,
+                }}>
+                {router.canGoBack() && (
+                    <TouchableOpacity onPress={() => router.back()} hitSlop={8} accessibilityLabel="Go back">
+                        <Ionicons name="chevron-back" size={28} color={ThemedColor.text} />
+                    </TouchableOpacity>
+                )}
+                <ThemedText type="title" style={{ flex: 1 }}>
+                    #{tagValue}
+                </ThemedText>
+                <View style={{ flexDirection: "row", alignItems: "center", gap: 16 }}>
+                    <TouchableOpacity onPress={() => filterSheetRef.current?.present()} hitSlop={8} accessibilityLabel="Filter">
+                        <FunnelSimple
+                            size={20}
+                            weight="regular"
+                            color={state.filters !== null ? ThemedColor.primary : ThemedColor.caption}
+                        />
+                    </TouchableOpacity>
+                    <TouchableOpacity onPress={() => sortSheetRef.current?.present()} hitSlop={8} accessibilityLabel="Sort">
+                        <SortAscending
+                            size={20}
+                            weight="regular"
+                            color={state.sort !== null ? ThemedColor.primary : ThemedColor.caption}
+                        />
+                    </TouchableOpacity>
+                </View>
+            </View>
+
             <ScrollView contentContainerStyle={{ padding: 20, gap: 24 }}>
-                <ThemedText type="title">#{tagValue}</ThemedText>
-                {matches.length === 0 ? (
+                {ordered.length === 0 ? (
                     <ThemedText type="caption">No categories tagged "{tagValue}" yet.</ThemedText>
                 ) : (
-                    matches.map(({ workspaceName, category }) => (
+                    ordered.map(({ workspaceName, category }) => (
                         <View key={category.id} style={{ gap: 8 }}>
                             <ThemedText type="caption">{workspaceName}</ThemedText>
                             <Category
                                 id={category.id}
                                 name={category.name}
-                                tasks={category.tasks}
+                                tasks={applyFilters(category.tasks)}
                                 tags={category.tags}
                                 viewOnly
                                 onPress={() => {}}
@@ -38,6 +111,32 @@ export default function TagView() {
                     ))
                 )}
             </ScrollView>
+
+            <BottomSheetModal
+                ref={sortSheetRef}
+                index={0}
+                snapPoints={sortSnapPoints}
+                backdropComponent={renderBackdrop}
+                handleIndicatorStyle={{ backgroundColor: ThemedColor.text }}
+                backgroundStyle={{ backgroundColor: ThemedColor.background }}
+                enablePanDownToClose={true}>
+                <BottomSheetView style={{ paddingHorizontal: 20, paddingBottom: 20, flex: 1 }}>
+                    <SortContent storageKey={storageKey} onApply={() => sortSheetRef.current?.dismiss()} />
+                </BottomSheetView>
+            </BottomSheetModal>
+
+            <BottomSheetModal
+                ref={filterSheetRef}
+                index={0}
+                snapPoints={filterSnapPoints}
+                backdropComponent={renderBackdrop}
+                handleIndicatorStyle={{ backgroundColor: ThemedColor.text }}
+                backgroundStyle={{ backgroundColor: ThemedColor.background }}
+                enablePanDownToClose={true}>
+                <BottomSheetView style={{ paddingHorizontal: 20, paddingBottom: 20, flex: 1 }}>
+                    <FilterContent storageKey={storageKey} onApply={() => filterSheetRef.current?.dismiss()} />
+                </BottomSheetView>
+            </BottomSheetModal>
         </SafeAreaView>
     );
 }

--- a/frontend/app/(onboarding)/calendar.tsx
+++ b/frontend/app/(onboarding)/calendar.tsx
@@ -89,7 +89,7 @@ const CalendarOnboarding = () => {
                 if (completed) {
                     showToast("Calendar connected!", "success");
                     capture(AnalyticsEvents.ONBOARDING_COMPLETED, {});
-                    router.replace("/(logged-in)/(tabs)/(task)" as any);
+                    router.replace("/(logged-in)/(tabs)/(task)");
                     return;
                 }
             }
@@ -106,12 +106,12 @@ const CalendarOnboarding = () => {
         setPendingConnectionId(null);
         showToast("Calendar connected!", "success");
         capture(AnalyticsEvents.ONBOARDING_COMPLETED, {});
-        router.replace("/(logged-in)/(tabs)/(task)" as any);
+        router.replace("/(logged-in)/(tabs)/(task)");
     };
 
     const handleSkip = () => {
         capture(AnalyticsEvents.ONBOARDING_COMPLETED, {});
-        router.replace("/(logged-in)/(tabs)/(task)" as any);
+        router.replace("/(logged-in)/(tabs)/(task)");
     };
 
     return (

--- a/frontend/app/index.tsx
+++ b/frontend/app/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'expo-router';
+import { useRouter, type Href } from 'expo-router';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useOptionalAuth } from '@/hooks/useAuth';
 import EnhancedSplashScreen from '@/components/ui/EnhancedSplashScreen';
@@ -16,7 +16,7 @@ export default function Index() {
     const auth = useOptionalAuth();
     const user = auth?.user ?? null;
     const [isChecking, setIsChecking] = useState(true);
-    const [nextRoute, setNextRoute] = useState<string | null>(null);
+    const [nextRoute, setNextRoute] = useState<Href | null>(null);
     const [canTransition, setCanTransition] = useState(false);
 
     useEffect(() => {
@@ -52,7 +52,7 @@ export default function Index() {
     // Navigate once both route is determined and animation is complete
     useEffect(() => {
         if (nextRoute && canTransition) {
-            router.replace(nextRoute as any);
+            router.replace(nextRoute);
         }
     }, [nextRoute, canTransition]);
 

--- a/frontend/components/InlineCategoryCreator.tsx
+++ b/frontend/components/InlineCategoryCreator.tsx
@@ -1,9 +1,13 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { View, TextInput, TouchableOpacity, StyleSheet, ActivityIndicator, Animated, Dimensions } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useTasks } from "@/contexts/tasksContext";
 import { useRequest } from "@/hooks/useRequest";
-import { Plus, X } from "phosphor-react-native";
+import { Plus, X, Tag } from "phosphor-react-native";
+import { BottomSheetModal, BottomSheetBackdrop, BottomSheetView } from "@gorhom/bottom-sheet";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import TagEditor, { type TagEditorHandle } from "@/components/TagEditor";
 
 const SCREEN_SCALE = Dimensions.get("screen").width / 393;
 
@@ -15,6 +19,7 @@ type Props = {
 
 const InlineCategoryCreator = ({ onCreated, onCancel, initialName }: Props) => {
     const [name, setName] = useState(initialName ?? "");
+    const [tags, setTags] = useState<string[]>([]);
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(false);
     const inputRef = useRef<TextInput>(null);
@@ -23,6 +28,10 @@ const InlineCategoryCreator = ({ onCreated, onCancel, initialName }: Props) => {
     const ThemedColor = useThemeColor();
     const { selected, addToWorkspace } = useTasks();
     const { request } = useRequest();
+
+    const tagsSheetRef = useRef<BottomSheetModal>(null);
+    const tagEditorRef = useRef<TagEditorHandle>(null);
+    const tagsSnapPoints = useMemo(() => ["50%"], []);
 
     useEffect(() => {
         Animated.timing(fadeAnim, {
@@ -52,9 +61,10 @@ const InlineCategoryCreator = ({ onCreated, onCancel, initialName }: Props) => {
             const response = await request("POST", `/user/categories`, {
                 name: trimmed,
                 workspaceName: selected,
+                tags,
             });
             if (!mountedRef.current) return;
-            addToWorkspace(selected, { ...response, tasks: response.tasks ?? [] });
+            addToWorkspace(selected, { ...response, tasks: response.tasks ?? [], tags: response.tags ?? tags });
             animateOut(() => onCreated?.(response.id, trimmed));
         } catch (e) {
             if (!mountedRef.current) return;
@@ -68,57 +78,107 @@ const InlineCategoryCreator = ({ onCreated, onCancel, initialName }: Props) => {
         animateOut(onCancel);
     };
 
+    const openTagsSheet = () => {
+        inputRef.current?.blur();
+        tagsSheetRef.current?.present();
+    };
+
+    const closeTagsSheet = () => {
+        // Commit any tag still in the editor input before closing.
+        tagEditorRef.current?.flush();
+        tagsSheetRef.current?.dismiss();
+    };
+
+    const renderBackdrop = useCallback(
+        (backdropProps) => (
+            <BottomSheetBackdrop {...backdropProps} disappearsOnIndex={-1} appearsOnIndex={0} opacity={0.5} />
+        ),
+        []
+    );
+
+    const hasTags = tags.length > 0;
+    const sheetTitle = name.trim().length > 0 ? `Tags for "${name.trim()}"` : "Add tags";
+
     return (
-        <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
-            <TextInput
-                ref={inputRef}
-                value={name}
-                onChangeText={(text) => {
-                    setName(text);
-                    if (error) setError(false);
-                }}
-                onSubmitEditing={handleCreate}
-                placeholder="Category name"
-                placeholderTextColor={error ? ThemedColor.error : ThemedColor.caption}
-                returnKeyType="done"
-                editable={!loading}
-                style={[
-                    styles.input,
-                    { color: error ? ThemedColor.error : ThemedColor.text },
-                ]}
-            />
-            <View style={styles.actions}>
-                {loading ? (
-                    <ActivityIndicator size="small" color={ThemedColor.primary} />
-                ) : (
-                    <>
-                        <TouchableOpacity onPress={handleCancel} hitSlop={8}>
-                            <View style={[styles.iconCircle, { backgroundColor: ThemedColor.lightened }]}>
-                                <X size={14} weight="bold" color={ThemedColor.caption} />
-                            </View>
-                        </TouchableOpacity>
-                        <TouchableOpacity
-                            onPress={handleCreate}
-                            disabled={name.trim().length === 0}
-                            hitSlop={8}
-                        >
-                            <View
-                                style={[
-                                    styles.iconCircle,
-                                    {
-                                        backgroundColor: name.trim().length > 0
-                                            ? ThemedColor.primary
-                                            : ThemedColor.primary + "40",
-                                    },
-                                ]}
+        <>
+            <Animated.View style={[styles.container, { opacity: fadeAnim }]}>
+                <TextInput
+                    ref={inputRef}
+                    value={name}
+                    onChangeText={(text) => {
+                        setName(text);
+                        if (error) setError(false);
+                    }}
+                    onSubmitEditing={handleCreate}
+                    placeholder="Category name"
+                    placeholderTextColor={error ? ThemedColor.error : ThemedColor.caption}
+                    returnKeyType="done"
+                    editable={!loading}
+                    style={[
+                        styles.input,
+                        { color: error ? ThemedColor.error : ThemedColor.text },
+                    ]}
+                />
+                <View style={styles.actions}>
+                    {loading ? (
+                        <ActivityIndicator size="small" color={ThemedColor.primary} />
+                    ) : (
+                        <>
+                            <TouchableOpacity onPress={handleCancel} hitSlop={8}>
+                                <View style={[styles.iconCircle, { backgroundColor: ThemedColor.lightened }]}>
+                                    <X size={14} weight="bold" color={ThemedColor.caption} />
+                                </View>
+                            </TouchableOpacity>
+                            <TouchableOpacity onPress={openTagsSheet} hitSlop={8} accessibilityLabel="Add tags">
+                                <View
+                                    style={[
+                                        styles.iconCircle,
+                                        { backgroundColor: hasTags ? ThemedColor.primary + "20" : ThemedColor.lightened },
+                                    ]}
+                                >
+                                    <Tag size={14} weight={hasTags ? "fill" : "bold"} color={hasTags ? ThemedColor.primary : ThemedColor.caption} />
+                                </View>
+                            </TouchableOpacity>
+                            <TouchableOpacity
+                                onPress={handleCreate}
+                                disabled={name.trim().length === 0}
+                                hitSlop={8}
                             >
-                                <Plus size={14} weight="bold" color="#FFFFFF" />
-                            </View>
-                        </TouchableOpacity>
-                    </>
-                )}
-            </View>
-        </Animated.View>
+                                <View
+                                    style={[
+                                        styles.iconCircle,
+                                        {
+                                            backgroundColor: name.trim().length > 0
+                                                ? ThemedColor.primary
+                                                : ThemedColor.primary + "40",
+                                        },
+                                    ]}
+                                >
+                                    <Plus size={14} weight="bold" color="#FFFFFF" />
+                                </View>
+                            </TouchableOpacity>
+                        </>
+                    )}
+                </View>
+            </Animated.View>
+
+            <BottomSheetModal
+                ref={tagsSheetRef}
+                index={0}
+                snapPoints={tagsSnapPoints}
+                backdropComponent={renderBackdrop}
+                handleIndicatorStyle={{ backgroundColor: ThemedColor.text }}
+                backgroundStyle={{ backgroundColor: ThemedColor.background }}
+                enablePanDownToClose={true}
+                onDismiss={() => tagEditorRef.current?.flush()}
+            >
+                <BottomSheetView style={{ paddingHorizontal: 20, gap: 16, paddingBottom: 24 }}>
+                    <ThemedText type="subtitle">{sheetTitle}</ThemedText>
+                    <TagEditor ref={tagEditorRef} tags={tags} onChange={setTags} />
+                    <PrimaryButton title="Done" onPress={closeTagsSheet} />
+                </BottomSheetView>
+            </BottomSheetModal>
+        </>
     );
 };
 

--- a/frontend/components/ListControls.tsx
+++ b/frontend/components/ListControls.tsx
@@ -1,0 +1,318 @@
+import React, { useState } from "react";
+import { StyleSheet, View, TouchableOpacity } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { showToastable } from "react-native-toastable";
+import DefaultToast from "@/components/ui/DefaultToast";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { workspaceStateEvents } from "@/utils/workspaceStateEvents";
+import { SortOption, SortDirection } from "@/utils/categorySort";
+import {
+    ChartBar,
+    ChartBarHorizontal,
+    CalendarBlank,
+    CalendarCheck,
+    ArrowRight,
+    Minus,
+    WarningCircle,
+    Hash,
+    SortAscending,
+    ArrowUp,
+    ArrowDown,
+} from "phosphor-react-native";
+
+// ============================================================
+// Sort
+// ============================================================
+
+type SortContentProps = {
+    // AsyncStorage scope: workspace name, or `tag:<value>` for the tag view.
+    storageKey: string;
+    // Host-specific application of the chosen ordering (e.g. the workspace view
+    // reorders global state; the tag view re-derives its list). Persistence and
+    // the state-change event are handled here regardless.
+    onApplySort?: (option: SortOption, direction: SortDirection) => void | Promise<void>;
+    onApply: () => void;
+};
+
+export const SortContent = ({ storageKey, onApplySort, onApply }: SortContentProps) => {
+    const ThemedColor = useThemeColor();
+    const [selectedSort, setSelectedSort] = useState<SortOption>("task-count");
+    const [sortDirection, setSortDirection] = useState<SortDirection>("descending");
+
+    const handleSort = async () => {
+        await onApplySort?.(selectedSort, sortDirection);
+
+        try {
+            await Promise.all([
+                AsyncStorage.setItem(`workspace-sort-${storageKey}`, selectedSort),
+                AsyncStorage.setItem(`workspace-sort-direction-${storageKey}`, sortDirection),
+            ]);
+            workspaceStateEvents.emit(storageKey);
+        } catch (error) {
+            console.error("Error saving sort option:", error);
+        }
+
+        onApply();
+    };
+
+    const handleSortOptionPress = async (option: SortOption) => {
+        if (selectedSort === option) {
+            if (sortDirection === "descending") {
+                setSortDirection("ascending");
+                await AsyncStorage.setItem(`workspace-sort-direction-${storageKey}`, "ascending");
+                workspaceStateEvents.emit(storageKey);
+            } else if (sortDirection === "ascending") {
+                setSelectedSort("task-count");
+                setSortDirection("descending");
+                try {
+                    await AsyncStorage.removeItem(`workspace-sort-${storageKey}`);
+                    await AsyncStorage.removeItem(`workspace-sort-direction-${storageKey}`);
+                    workspaceStateEvents.emit(storageKey);
+                } catch (error) {
+                    console.error("Error clearing sort:", error);
+                }
+            }
+        } else {
+            setSelectedSort(option);
+            setSortDirection("descending");
+            try {
+                await AsyncStorage.setItem(`workspace-sort-${storageKey}`, option);
+                await AsyncStorage.setItem(`workspace-sort-direction-${storageKey}`, "descending");
+                workspaceStateEvents.emit(storageKey);
+            } catch (error) {
+                console.error("Error saving sort:", error);
+            }
+        }
+    };
+
+    const SortOptionRow = ({
+        option,
+        label,
+        IconComponent,
+    }: {
+        option: SortOption;
+        label: string;
+        IconComponent: React.ComponentType<any>;
+    }) => {
+        const isSelected = selectedSort === option;
+        const textColor = isSelected ? ThemedColor.primary : ThemedColor.text;
+        const iconColor = isSelected ? ThemedColor.primary : ThemedColor.text;
+        const DirectionIcon = sortDirection === "ascending" ? ArrowUp : ArrowDown;
+
+        return (
+            <TouchableOpacity onPress={() => handleSortOptionPress(option)}>
+                <View style={styles.sortOptionRow}>
+                    <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
+                        <IconComponent color={iconColor} size={24} weight="regular" />
+                        <ThemedText type="default" style={{ color: textColor, fontSize: 16 }}>
+                            {label}
+                        </ThemedText>
+                    </View>
+                    {isSelected && <DirectionIcon color={iconColor} size={20} weight="bold" />}
+                </View>
+            </TouchableOpacity>
+        );
+    };
+
+    return (
+        <>
+            <ThemedText type="subtitle" style={{ marginBottom: 24 }}>
+                Sort By
+            </ThemedText>
+            <View style={{ flex: 1, gap: 20 }}>
+                <View style={{ gap: 8 }}>
+                    <SortOptionRow option="task-count" label="Task Count" IconComponent={(props) => <Hash {...props} />} />
+                    <SortOptionRow option="alphabetical" label="Alphabetical" IconComponent={(props) => <SortAscending {...props} />} />
+                    <SortOptionRow option="due-date" label="Due Date" IconComponent={(props) => <CalendarCheck {...props} />} />
+                    <SortOptionRow option="start-date" label="Start Date" IconComponent={(props) => <CalendarBlank {...props} />} />
+                    <SortOptionRow option="priority" label="Priority" IconComponent={(props) => <ChartBar {...props} />} />
+                </View>
+
+                <PrimaryButton title="Apply Sort" onPress={handleSort} />
+            </View>
+        </>
+    );
+};
+
+// ============================================================
+// Filter
+// ============================================================
+
+type FilterState = {
+    priorities: { low: boolean; medium: boolean; high: boolean };
+    deadlines: { overdue: boolean; today: boolean; thisWeek: boolean; future: boolean; none: boolean };
+};
+
+const EMPTY_FILTERS: FilterState = {
+    priorities: { low: false, medium: false, high: false },
+    deadlines: { overdue: false, today: false, thisWeek: false, future: false, none: false },
+};
+
+export const FilterContent = ({ storageKey, onApply }: { storageKey: string; onApply: () => void }) => {
+    const ThemedColor = useThemeColor();
+    const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
+
+    React.useEffect(() => {
+        const loadFilters = async () => {
+            try {
+                const saved = await AsyncStorage.getItem(`workspace-filters-${storageKey}`);
+                if (saved) {
+                    setFilters(JSON.parse(saved));
+                }
+            } catch (error) {
+                console.error("Error loading filters:", error);
+            }
+        };
+        loadFilters();
+    }, [storageKey]);
+
+    const handleClearFilters = async () => {
+        setFilters(EMPTY_FILTERS);
+        try {
+            await AsyncStorage.removeItem(`workspace-filters-${storageKey}`);
+            workspaceStateEvents.emit(storageKey);
+            showToastable({
+                title: "Filters Cleared",
+                status: "info",
+                position: "top",
+                duration: 2000,
+                message: "All filters have been removed",
+                renderContent: (props) => <DefaultToast {...props} />,
+            });
+        } catch (error) {
+            console.error("Error clearing filters:", error);
+        }
+    };
+
+    const toggleFilter = async (category: keyof FilterState, option: string) => {
+        const newFilters = {
+            ...filters,
+            [category]: {
+                ...filters[category],
+                [option]: !filters[category][option],
+            },
+        };
+
+        setFilters(newFilters);
+
+        try {
+            await AsyncStorage.setItem(`workspace-filters-${storageKey}`, JSON.stringify(newFilters));
+            workspaceStateEvents.emit(storageKey);
+        } catch (error) {
+            console.error("Error saving filters:", error);
+        }
+    };
+
+    const FilterCard = ({
+        label,
+        isSelected,
+        onPress,
+        IconComponent,
+    }: {
+        label: string;
+        isSelected: boolean;
+        onPress: () => void;
+        IconComponent: React.ComponentType<any>;
+    }) => {
+        const iconColor = isSelected ? ThemedColor.primary : ThemedColor.text;
+
+        return (
+            <TouchableOpacity onPress={onPress} style={styles.filterCardWrapper}>
+                <View
+                    style={[
+                        styles.filterCard,
+                        {
+                            backgroundColor: ThemedColor.lightenedCard,
+                            borderWidth: isSelected ? 2 : 0,
+                            borderColor: isSelected ? ThemedColor.primary : "transparent",
+                        },
+                    ]}>
+                    <View style={styles.filterIconContainer}>
+                        <IconComponent color={iconColor} />
+                    </View>
+                    <ThemedText type="default" style={{ fontSize: 15, textAlign: "center", color: iconColor }}>
+                        {label}
+                    </ThemedText>
+                </View>
+            </TouchableOpacity>
+        );
+    };
+
+    const hasActiveFilters =
+        Object.values(filters.priorities).some((v) => v) || Object.values(filters.deadlines).some((v) => v);
+
+    return (
+        <>
+            <ThemedText type="subtitle" style={{ marginBottom: 16 }}>
+                Filters
+            </ThemedText>
+            <View style={{ flex: 1, gap: 24 }}>
+                <View style={{ gap: 12 }}>
+                    <ThemedText type="default" style={{ fontSize: 16 }}>
+                        Priority Level
+                    </ThemedText>
+                    <View style={styles.filterGrid}>
+                        <FilterCard label="Low" isSelected={filters.priorities.low} onPress={() => toggleFilter("priorities", "low")} IconComponent={(props) => <ChartBarHorizontal size={28} weight="regular" {...props} />} />
+                        <FilterCard label="Medium" isSelected={filters.priorities.medium} onPress={() => toggleFilter("priorities", "medium")} IconComponent={(props) => <ChartBar size={28} weight="regular" {...props} />} />
+                        <FilterCard label="High" isSelected={filters.priorities.high} onPress={() => toggleFilter("priorities", "high")} IconComponent={(props) => <ChartBar size={28} weight="fill" {...props} />} />
+                    </View>
+                </View>
+
+                <View style={{ gap: 12 }}>
+                    <ThemedText type="default" style={{ fontSize: 16 }}>
+                        Deadline
+                    </ThemedText>
+                    <View style={styles.filterGrid}>
+                        <FilterCard label="Overdue" isSelected={filters.deadlines.overdue} onPress={() => toggleFilter("deadlines", "overdue")} IconComponent={(props) => <WarningCircle size={28} weight="regular" {...props} />} />
+                        <FilterCard label="Today" isSelected={filters.deadlines.today} onPress={() => toggleFilter("deadlines", "today")} IconComponent={(props) => <CalendarCheck size={28} weight="regular" {...props} />} />
+                        <FilterCard label="This Week" isSelected={filters.deadlines.thisWeek} onPress={() => toggleFilter("deadlines", "thisWeek")} IconComponent={(props) => <CalendarBlank size={28} weight="regular" {...props} />} />
+                        <FilterCard label="Future" isSelected={filters.deadlines.future} onPress={() => toggleFilter("deadlines", "future")} IconComponent={(props) => <ArrowRight size={28} weight="regular" {...props} />} />
+                        <FilterCard label="No Deadline" isSelected={filters.deadlines.none} onPress={() => toggleFilter("deadlines", "none")} IconComponent={(props) => <Minus size={28} weight="bold" {...props} />} />
+                    </View>
+                </View>
+
+                {hasActiveFilters && (
+                    <View style={{ marginTop: "auto", paddingBottom: 8 }}>
+                        <TouchableOpacity onPress={handleClearFilters}>
+                            <ThemedText type="default" style={{ textAlign: "center", color: ThemedColor.caption }}>
+                                Clear All Filters
+                            </ThemedText>
+                        </TouchableOpacity>
+                    </View>
+                )}
+            </View>
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    sortOptionRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        paddingVertical: 12,
+    },
+    filterGrid: {
+        flexDirection: "row",
+        flexWrap: "wrap",
+        gap: 12,
+    },
+    filterCardWrapper: {
+        width: "31%",
+        minWidth: 100,
+    },
+    filterCard: {
+        padding: 16,
+        borderRadius: 12,
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 8,
+        minHeight: 100,
+        position: "relative",
+    },
+    filterIconContainer: {
+        marginBottom: 4,
+    },
+});

--- a/frontend/components/TagChip.tsx
+++ b/frontend/components/TagChip.tsx
@@ -30,7 +30,7 @@ export default function TagChip({ tag, onPress }: TagChipProps) {
 
 const styles = StyleSheet.create({
     chip: {
-        paddingHorizontal: 10,
+        paddingHorizontal: 16,
         paddingVertical: 4,
         borderRadius: 999,
     },

--- a/frontend/components/TagEditor.tsx
+++ b/frontend/components/TagEditor.tsx
@@ -1,0 +1,118 @@
+import React, { forwardRef, useEffect, useImperativeHandle, useState } from "react";
+import { View, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import ThemedInput from "@/components/inputs/ThemedInput";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { getUserTags } from "@/api/category";
+import TagChip from "@/components/TagChip";
+
+const normalize = (t: string) => t.trim().toLowerCase();
+
+export interface TagEditorHandle {
+    /**
+     * Commit any text still sitting in the input and return the resulting tag
+     * list. Lets a host flush a typed-but-not-added tag when its own primary
+     * action fires (e.g. "Save" / "+"), without it being silently dropped.
+     */
+    flush: () => string[];
+}
+
+interface TagEditorProps {
+    tags: string[];
+    onChange: (tags: string[]) => void;
+    // Both current hosts present the editor inside a bottom sheet.
+    useBottomSheetInput?: boolean;
+}
+
+const TagEditor = forwardRef<TagEditorHandle, TagEditorProps>(function TagEditor(
+    { tags, onChange, useBottomSheetInput = true },
+    ref
+) {
+    const ThemedColor = useThemeColor();
+    const [tagInput, setTagInput] = useState("");
+    const [suggestions, setSuggestions] = useState<string[]>([]);
+
+    useEffect(() => {
+        getUserTags()
+            .then(setSuggestions)
+            .catch(() => setSuggestions([]));
+    }, []);
+
+    const addTag = (raw: string) => {
+        const t = normalize(raw);
+        if (t.length === 0 || tags.includes(t)) {
+            setTagInput("");
+            return;
+        }
+        onChange([...tags, t]);
+        setTagInput("");
+    };
+
+    const removeTag = (t: string) => onChange(tags.filter((x) => x !== t));
+
+    useImperativeHandle(ref, () => ({
+        flush: () => {
+            const pending = normalize(tagInput);
+            const effective = pending.length > 0 && !tags.includes(pending) ? [...tags, pending] : tags;
+            if (effective !== tags) {
+                onChange(effective);
+                setTagInput("");
+            }
+            return effective;
+        },
+    }), [tagInput, tags, onChange]);
+
+    const filteredSuggestions = suggestions
+        .filter((s) => s.includes(normalize(tagInput)) && !tags.includes(s))
+        .slice(0, 5);
+
+    return (
+        <View style={{ gap: 12 }}>
+            <ThemedText type="caption">Tags</ThemedText>
+            {tags.length > 0 && (
+                <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                    {tags.map((t) => (
+                        <TouchableOpacity key={t} onPress={() => removeTag(t)} accessibilityLabel={`Remove ${t}`}>
+                            <TagChip tag={`${t}  ×`} />
+                        </TouchableOpacity>
+                    ))}
+                </View>
+            )}
+            <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
+                <View style={{ flex: 1 }}>
+                    <ThemedInput
+                        useBottomSheetInput={useBottomSheetInput}
+                        placeHolder="Add a tag"
+                        onSubmit={() => addTag(tagInput)}
+                        value={tagInput}
+                        setValue={setTagInput}
+                    />
+                </View>
+                <PrimaryButton
+                    title="Add"
+                    secondary
+                    disabled={normalize(tagInput).length === 0}
+                    onPress={() => addTag(tagInput)}
+                    style={{ width: 88 }}
+                />
+            </View>
+            {filteredSuggestions.length > 0 && (
+                <View style={{ gap: 12 }}>
+                    <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                        Suggestions · tap to add
+                    </ThemedText>
+                    <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                        {filteredSuggestions.map((s) => (
+                            <TouchableOpacity key={s} onPress={() => addTag(s)}>
+                                <TagChip tag={s} />
+                            </TouchableOpacity>
+                        ))}
+                    </View>
+                </View>
+            )}
+        </View>
+    );
+});
+
+export default TagEditor;

--- a/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
@@ -21,7 +21,7 @@ type Props = {
 
 const UserInfoEncouragementNotification = ({ name, userId, taskName, icon, time, referenceId, type = "encouragement" }: Props) => {
     const ThemedColor = useThemeColor();
-    
+
     const getTimeLabel = (timestamp: number) => {
         const currentTime = Date.now();
         const notificationDate = new Date(timestamp);
@@ -72,19 +72,19 @@ const UserInfoEncouragementNotification = ({ name, userId, taskName, icon, time,
     };
 
     const timeLabel = getTimeLabel(time);
-    
+
     const handleNotificationPress = () => {
         // Congratulations reference a post; encouragements reference a task.
         // Fall back to the kudos tab if no referenceId (e.g. profile-scope encouragement).
         if (!referenceId) {
             const tab = type === "congratulation" ? "congratulations" : "encouragements";
-            router.push(`/(logged-in)/(tabs)/(task)/kudos?tab=${tab}` as any);
+            router.push(`/(logged-in)/(tabs)/(task)/kudos?tab=${tab}`);
             return;
         }
         if (type === "congratulation") {
             router.push(`/(logged-in)/posting/${referenceId}`);
         } else {
-            router.push(`/(logged-in)/(tabs)/(task)/task/${referenceId}` as any);
+            router.push(`/(logged-in)/(tabs)/(task)/task/${referenceId}`);
         }
     };
 
@@ -135,8 +135,8 @@ const UserInfoEncouragementNotification = ({ name, userId, taskName, icon, time,
                         <ThemedText>
                             <ThemedText type="smallerDefault" style={{ fontWeight: "500" }}>{name}</ThemedText>
                             <ThemedText type="smallerDefault">
-                                {type === "congratulation" 
-                                    ? ` congratulated you on completing ${taskName}` 
+                                {type === "congratulation"
+                                    ? ` congratulated you on completing ${taskName}`
                                     : ` sent you an encouragement for ${taskName}`}
                             </ThemedText>
                         </ThemedText>

--- a/frontend/components/cards/KudosItem.tsx
+++ b/frontend/components/cards/KudosItem.tsx
@@ -75,7 +75,7 @@ export default function KudosItem({ kudos, formatTime, visible = false, index = 
     }, [visible]);
 
     const handleAvatarPress = () => {
-        router.push(`/account/${kudos.sender.id}` as any);
+        router.push(`/account/${kudos.sender.id}`);
     };
 
     return (

--- a/frontend/components/dashboard/OnboardingChecklist.tsx
+++ b/frontend/components/dashboard/OnboardingChecklist.tsx
@@ -85,7 +85,7 @@ export const OnboardingChecklist: React.FC<OnboardingChecklistProps> = ({ scroll
                     router.push('/(logged-in)/(tabs)/(search)/search');
                     break;
                 case 'rings':
-                    router.push('/(logged-in)/(tabs)/(feed,search,profile)/profile' as any);
+                    router.push('/(logged-in)/(tabs)/(profile)/profile');
                     break;
             }
         },

--- a/frontend/components/dashboard/OnboardingChecklist.tsx
+++ b/frontend/components/dashboard/OnboardingChecklist.tsx
@@ -154,7 +154,7 @@ export const OnboardingChecklist: React.FC<OnboardingChecklistProps> = ({ scroll
 
                 <View
                     style={{
-                        height: 4,
+                        height: 8,
                         backgroundColor: ThemedColor.tertiary,
                         borderRadius: 100,
                         marginTop: 10,

--- a/frontend/components/home/Drawer.tsx
+++ b/frontend/components/home/Drawer.tsx
@@ -16,7 +16,7 @@ import {
     Archive,
 } from "phosphor-react-native";
 import * as PhosphorIcons from "phosphor-react-native";
-import { router, usePathname } from "expo-router";
+import { router, usePathname, type Href } from "expo-router";
 import Feather from "@expo/vector-icons/Feather";
 import {
     House,
@@ -109,21 +109,21 @@ const DrawerContent = ({
     };
 
     // Helper function to handle smooth navigation
-    const handleNavigate = useCallback((route: any, workspaceName?: string) => {
+    const handleNavigate = useCallback((route: Href, workspaceName?: string) => {
         close();
         requestAnimationFrame(() => {
             if (workspaceName !== undefined) {
                 setSelected(workspaceName);
             }
-            router.navigate(route as any);
+            router.navigate(route);
         });
     }, [close, setSelected]);
 
     // Helper for router.push instead of navigate
-    const handlePush = useCallback((route: any) => {
+    const handlePush = useCallback((route: Href) => {
         close();
         requestAnimationFrame(() => {
-            router.push(route as any);
+            router.push(route);
         });
     }, [close]);
 

--- a/frontend/components/modals/edit/EditCategoryModal.tsx
+++ b/frontend/components/modals/edit/EditCategoryModal.tsx
@@ -54,8 +54,13 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
             return;
         }
 
+        // Flush any tag still sitting in the input so it isn't silently dropped
+        // when the user taps the primary CTA instead of "Add".
+        const pending = normalize(tagInput);
+        const effectiveTags = pending.length > 0 && !tags.includes(pending) ? [...tags, pending] : tags;
+
         const nameChanged = name !== currentName && name.length > 0;
-        const tagsChanged = JSON.stringify(tags) !== JSON.stringify(currentTags ?? []);
+        const tagsChanged = JSON.stringify(effectiveTags) !== JSON.stringify(currentTags ?? []);
 
         if (!nameChanged && !tagsChanged) {
             // No change, just close the modal
@@ -68,8 +73,8 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
                 await renameCategory(categoryId, name);
             }
             if (tagsChanged) {
-                await updateCategory(categoryId, { tags } as any);
-                updateCategoryTags(categoryId, tags);
+                await updateCategory(categoryId, { tags: effectiveTags } as any);
+                updateCategoryTags(categoryId, effectiveTags);
             }
 
             // Show success toast
@@ -113,7 +118,7 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
                     Edit Category
                 </ThemedText>
             </View>
-            <View style={{ gap: 12 }}>
+            <View style={{ gap: 16 }}>
                 <ThemedInput
                     autofocus
                     useBottomSheetInput={true}
@@ -127,10 +132,10 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
                     value={name}
                     setValue={setName}
                 />
-                <View style={{ gap: 8, marginTop: 8 }}>
+                <View style={{ gap: 12 }}>
                     <ThemedText type="caption">Tags</ThemedText>
                     {tags.length > 0 && (
-                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
+                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
                             {tags.map((t) => (
                                 <TouchableOpacity
                                     key={t}
@@ -141,20 +146,36 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
                             ))}
                         </View>
                     )}
-                    <ThemedInput
-                        useBottomSheetInput={true}
-                        placeHolder="Add a tag"
-                        onSubmit={() => addTag(tagInput)}
-                        value={tagInput}
-                        setValue={setTagInput}
-                    />
+                    <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
+                        <View style={{ flex: 1 }}>
+                            <ThemedInput
+                                useBottomSheetInput={true}
+                                placeHolder="Add a tag"
+                                onSubmit={() => addTag(tagInput)}
+                                value={tagInput}
+                                setValue={setTagInput}
+                            />
+                        </View>
+                        <PrimaryButton
+                            title="Add"
+                            secondary
+                            disabled={normalize(tagInput).length === 0}
+                            onPress={() => addTag(tagInput)}
+                            style={{ width: 88 }}
+                        />
+                    </View>
                     {filteredSuggestions.length > 0 && (
-                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6 }}>
-                            {filteredSuggestions.map((s) => (
-                                <TouchableOpacity key={s} onPress={() => addTag(s)}>
-                                    <TagChip tag={s} />
-                                </TouchableOpacity>
-                            ))}
+                        <View style={{ gap: 12 }}>
+                            <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                                Suggestions · tap to add
+                            </ThemedText>
+                            <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
+                                {filteredSuggestions.map((s) => (
+                                    <TouchableOpacity key={s} onPress={() => addTag(s)}>
+                                        <TagChip tag={s} />
+                                    </TouchableOpacity>
+                                ))}
+                            </View>
                         </View>
                     )}
                 </View>

--- a/frontend/components/modals/edit/EditCategoryModal.tsx
+++ b/frontend/components/modals/edit/EditCategoryModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useRef, useState } from "react";
 import { View, StyleSheet, TouchableOpacity, Alert } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import ThemedInput from "@/components/inputs/ThemedInput";
@@ -8,8 +8,8 @@ import Feather from "@expo/vector-icons/Feather";
 import { useTasks } from "@/contexts/tasksContext";
 import { showToastable } from "react-native-toastable";
 import DefaultToast from "@/components/ui/DefaultToast";
-import { getUserTags, updateCategory } from "@/api/category";
-import TagChip from "@/components/TagChip";
+import { updateCategory } from "@/api/category";
+import TagEditor, { type TagEditorHandle } from "@/components/TagEditor";
 
 type Props = {
     hide: () => void;
@@ -24,29 +24,7 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
     const { renameCategory, updateCategoryTags } = useTasks();
 
     const [tags, setTags] = useState<string[]>(currentTags ?? []);
-    const [tagInput, setTagInput] = useState("");
-    const [suggestions, setSuggestions] = useState<string[]>([]);
-
-    useEffect(() => {
-        getUserTags()
-            .then(setSuggestions)
-            .catch(() => setSuggestions([]));
-    }, []);
-
-    const normalize = (t: string) => t.trim().toLowerCase();
-    const addTag = (raw: string) => {
-        const t = normalize(raw);
-        if (t.length === 0 || tags.includes(t)) {
-            setTagInput("");
-            return;
-        }
-        setTags([...tags, t]);
-        setTagInput("");
-    };
-    const removeTag = (t: string) => setTags(tags.filter((x) => x !== t));
-    const filteredSuggestions = suggestions
-        .filter((s) => s.includes(normalize(tagInput)) && !tags.includes(s))
-        .slice(0, 5);
+    const tagEditorRef = useRef<TagEditorHandle>(null);
 
     const handleEditCategory = async () => {
         if (name.length == 0) {
@@ -56,8 +34,7 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
 
         // Flush any tag still sitting in the input so it isn't silently dropped
         // when the user taps the primary CTA instead of "Add".
-        const pending = normalize(tagInput);
-        const effectiveTags = pending.length > 0 && !tags.includes(pending) ? [...tags, pending] : tags;
+        const effectiveTags = tagEditorRef.current?.flush() ?? tags;
 
         const nameChanged = name !== currentName && name.length > 0;
         const tagsChanged = JSON.stringify(effectiveTags) !== JSON.stringify(currentTags ?? []);
@@ -132,53 +109,7 @@ const EditCategoryModal = ({ hide, categoryId, currentName, currentTags }: Props
                     value={name}
                     setValue={setName}
                 />
-                <View style={{ gap: 12 }}>
-                    <ThemedText type="caption">Tags</ThemedText>
-                    {tags.length > 0 && (
-                        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-                            {tags.map((t) => (
-                                <TouchableOpacity
-                                    key={t}
-                                    onPress={() => removeTag(t)}
-                                    accessibilityLabel={`Remove ${t}`}>
-                                    <TagChip tag={`${t}  ×`} />
-                                </TouchableOpacity>
-                            ))}
-                        </View>
-                    )}
-                    <View style={{ flexDirection: "row", gap: 8, alignItems: "center" }}>
-                        <View style={{ flex: 1 }}>
-                            <ThemedInput
-                                useBottomSheetInput={true}
-                                placeHolder="Add a tag"
-                                onSubmit={() => addTag(tagInput)}
-                                value={tagInput}
-                                setValue={setTagInput}
-                            />
-                        </View>
-                        <PrimaryButton
-                            title="Add"
-                            secondary
-                            disabled={normalize(tagInput).length === 0}
-                            onPress={() => addTag(tagInput)}
-                            style={{ width: 88 }}
-                        />
-                    </View>
-                    {filteredSuggestions.length > 0 && (
-                        <View style={{ gap: 12 }}>
-                            <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
-                                Suggestions · tap to add
-                            </ThemedText>
-                            <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 8 }}>
-                                {filteredSuggestions.map((s) => (
-                                    <TouchableOpacity key={s} onPress={() => addTag(s)}>
-                                        <TagChip tag={s} />
-                                    </TouchableOpacity>
-                                ))}
-                            </View>
-                        </View>
-                    )}
-                </View>
+                <TagEditor ref={tagEditorRef} tags={tags} onChange={setTags} />
                 <View style={styles.buttonContainer}>
                     <PrimaryButton
                         title="Update Category"

--- a/frontend/components/modals/edit/EditWorkspace.tsx
+++ b/frontend/components/modals/edit/EditWorkspace.tsx
@@ -17,6 +17,8 @@ import { ThemedText } from "@/components/ThemedText";
 import DefaultCard from "@/components/cards/DefaultCard";
 import DraggableFlatList from "react-native-draggable-flatlist";
 import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { SortContent, FilterContent } from "@/components/ListControls";
+import { sortCategories, SortOption, SortDirection } from "@/utils/categorySort";
 import { isToday, isThisWeek, isFuture, isPast, startOfWeek, endOfWeek } from "date-fns";
 import {
     ChartBar,
@@ -248,6 +250,28 @@ const EditWorkspace = (props: Props) => {
             workspaceStateEvents.emit(id);
         } catch (error) {
             console.error("Error saving workspace grouping:", error);
+        }
+    };
+
+    // Workspace-specific application of a sort: reorder this workspace's
+    // categories in global state and invalidate the cache (the tag view, by
+    // contrast, derives its order without mutating global state).
+    const applyWorkspaceSort = async (option: SortOption, direction: SortDirection) => {
+        const workspacesCopy = workspaces.slice();
+        const workspaceIndex = workspacesCopy.findIndex((ws) => ws.name === id);
+        if (workspaceIndex !== -1) {
+            workspacesCopy[workspaceIndex] = {
+                ...workspacesCopy[workspaceIndex],
+                categories: sortCategories(workspacesCopy[workspaceIndex].categories, option, direction),
+            };
+            setWorkSpaces(workspacesCopy);
+            try {
+                await AsyncStorage.removeItem(
+                    `workspaces_cache_${workspacesCopy[0]?.categories[0]?.tasks[0]?.userID || "default"}`
+                );
+            } catch (error) {
+                console.error("Error invalidating workspaces cache:", error);
+            }
         }
     };
 
@@ -487,6 +511,8 @@ const EditWorkspace = (props: Props) => {
                 enablePanDownToClose={true}>
                 <BottomSheetView style={{ paddingHorizontal: 20, paddingBottom: 20, flex: 1 }}>
                     <SortContent
+                        storageKey={id}
+                        onApplySort={applyWorkspaceSort}
                         onApply={() => {
                             setShowSortModal(false);
                             sortSheetRef.current?.dismiss();
@@ -507,7 +533,7 @@ const EditWorkspace = (props: Props) => {
                 enablePanDownToClose={true}>
                 <BottomSheetView style={{ paddingHorizontal: 20, paddingBottom: 20, flex: 1 }}>
                     <FilterContent
-                        workspaceName={id}
+                        storageKey={id}
                         onApply={() => {
                             setShowFilterModal(false);
                             filterSheetRef.current?.dismiss();
@@ -623,470 +649,5 @@ const ReorderContent = ({ categories, onSave }: { categories: any[]; onSave: () 
     );
 };
 
-// Sort Content Component
-type SortOption = "task-count" | "alphabetical" | "due-date" | "start-date" | "priority";
-type SortDirection = "ascending" | "descending";
-
-const SortContent = ({ onApply }: { onApply: () => void }) => {
-    const ThemedColor = useThemeColor();
-    const { setWorkSpaces, workspaces, selected, fetchWorkspaces } = useTasks();
-    const [selectedSort, setSelectedSort] = useState<SortOption>("task-count");
-    const [sortDirection, setSortDirection] = useState<SortDirection>("descending");
-
-    const handleSort = async () => {
-        const workspacesCopy = workspaces.slice();
-        const workspaceIndex = workspacesCopy.findIndex((ws) => ws.name === selected);
-
-        if (workspaceIndex !== -1) {
-            const categories = [...workspacesCopy[workspaceIndex].categories];
-            const isAscending = sortDirection === "ascending";
-
-            let sortedCategories;
-            switch (selectedSort) {
-                case "task-count":
-                    sortedCategories = categories.sort((a, b) =>
-                        isAscending ? a.tasks.length - b.tasks.length : b.tasks.length - a.tasks.length
-                    );
-                    break;
-                case "alphabetical":
-                    sortedCategories = categories.sort((a, b) =>
-                        isAscending ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name)
-                    );
-                    break;
-                case "due-date":
-                    // Sort by earliest due date in category (tasks with deadlines)
-                    sortedCategories = categories.sort((a, b) => {
-                        const aEarliestDeadline =
-                            a.tasks
-                                .filter((t) => t.deadline)
-                                .map((t) => new Date(t.deadline).getTime())
-                                .sort((x, y) => x - y)[0] || Infinity;
-                        const bEarliestDeadline =
-                            b.tasks
-                                .filter((t) => t.deadline)
-                                .map((t) => new Date(t.deadline).getTime())
-                                .sort((x, y) => x - y)[0] || Infinity;
-                        return isAscending
-                            ? aEarliestDeadline - bEarliestDeadline
-                            : bEarliestDeadline - aEarliestDeadline;
-                    });
-                    break;
-                case "start-date":
-                    // Sort by earliest start date in category
-                    sortedCategories = categories.sort((a, b) => {
-                        const aEarliestStart =
-                            a.tasks
-                                .filter((t) => t.startDate)
-                                .map((t) => new Date(t.startDate).getTime())
-                                .sort((x, y) => x - y)[0] || Infinity;
-                        const bEarliestStart =
-                            b.tasks
-                                .filter((t) => t.startDate)
-                                .map((t) => new Date(t.startDate).getTime())
-                                .sort((x, y) => x - y)[0] || Infinity;
-                        return isAscending ? aEarliestStart - bEarliestStart : bEarliestStart - aEarliestStart;
-                    });
-                    break;
-                case "priority":
-                    // Sort by highest priority in category (high=3, medium=2, low=1, none=0)
-                    sortedCategories = categories.sort((a, b) => {
-                        const priorityMap: { [key: string]: number } = { high: 3, medium: 2, low: 1 };
-                        const aHighestPriority = Math.max(...a.tasks.map((t) => priorityMap[t.priority] || 0), 0);
-                        const bHighestPriority = Math.max(...b.tasks.map((t) => priorityMap[t.priority] || 0), 0);
-                        return isAscending ? aHighestPriority - bHighestPriority : bHighestPriority - aHighestPriority;
-                    });
-                    break;
-                default:
-                    sortedCategories = categories;
-            }
-
-            workspacesCopy[workspaceIndex].categories = sortedCategories;
-            setWorkSpaces(workspacesCopy);
-
-            // ✅ CRITICAL FIX: Invalidate cache after sorting
-            try {
-                await AsyncStorage.removeItem(`workspaces_cache_${workspacesCopy[0]?.categories[0]?.tasks[0]?.userID || 'default'}`);
-                console.log("Workspaces cache invalidated after sort");
-            } catch (error) {
-                console.error("Error invalidating workspaces cache:", error);
-            }
-        }
-
-        // Save sort option and direction to AsyncStorage
-        try {
-            await Promise.all([
-                AsyncStorage.setItem(`workspace-sort-${selected}`, selectedSort),
-                AsyncStorage.setItem(`workspace-sort-direction-${selected}`, sortDirection),
-            ]);
-            workspaceStateEvents.emit(selected);
-        } catch (error) {
-            console.error("Error saving sort option:", error);
-        }
-
-        onApply();
-    };
-
-    const handleSortOptionPress = async (option: SortOption) => {
-        if (selectedSort === option) {
-            if (sortDirection === "descending") {
-                setSortDirection("ascending");
-                await AsyncStorage.setItem(`workspace-sort-direction-${selected}`, "ascending");
-                workspaceStateEvents.emit(selected);
-            } else if (sortDirection === "ascending") {
-                setSelectedSort("task-count" as SortOption);
-                setSortDirection("descending");
-                try {
-                    await AsyncStorage.removeItem(`workspace-sort-${selected}`);
-                    await AsyncStorage.removeItem(`workspace-sort-direction-${selected}`);
-                    workspaceStateEvents.emit(selected);
-                } catch (error) {
-                    console.error("Error clearing sort:", error);
-                }
-            }
-        } else {
-            setSelectedSort(option);
-            setSortDirection("descending");
-            try {
-                await AsyncStorage.setItem(`workspace-sort-${selected}`, option);
-                await AsyncStorage.setItem(`workspace-sort-direction-${selected}`, "descending");
-                workspaceStateEvents.emit(selected);
-            } catch (error) {
-                console.error("Error saving sort:", error);
-            }
-        }
-    };
-
-    const SortOptionRow = ({
-        option,
-        label,
-        IconComponent,
-    }: {
-        option: SortOption;
-        label: string;
-        IconComponent: React.ComponentType<any>;
-    }) => {
-        const isSelected = selectedSort === option;
-        const textColor = isSelected ? ThemedColor.primary : ThemedColor.text;
-        const iconColor = isSelected ? ThemedColor.primary : ThemedColor.text;
-
-        const DirectionIcon = sortDirection === "ascending" ? ArrowUp : ArrowDown;
-
-        return (
-            <TouchableOpacity onPress={() => handleSortOptionPress(option)}>
-                <View style={styles.sortOptionRow}>
-                    <View style={{ flexDirection: "row", alignItems: "center", gap: 12 }}>
-                        <IconComponent color={iconColor} size={24} weight="regular" />
-                        <ThemedText type="default" style={{ color: textColor, fontSize: 16 }}>
-                            {label}
-                        </ThemedText>
-                    </View>
-                    {isSelected && <DirectionIcon color={iconColor} size={20} weight="bold" />}
-                </View>
-            </TouchableOpacity>
-        );
-    };
-
-    return (
-        <>
-            <ThemedText type="subtitle" style={{ marginBottom: 24 }}>
-                Sort By
-            </ThemedText>
-            <View style={{ flex: 1, gap: 20 }}>
-                {/* Sort Options */}
-                <View style={{ gap: 8 }}>
-                    <SortOptionRow
-                        option="task-count"
-                        label="Task Count"
-                        IconComponent={(props) => <Hash {...props} />}
-                    />
-                    <SortOptionRow
-                        option="alphabetical"
-                        label="Alphabetical"
-                        IconComponent={(props) => <SortAscending {...props} />}
-                    />
-                    <SortOptionRow
-                        option="due-date"
-                        label="Due Date"
-                        IconComponent={(props) => <CalendarCheck {...props} />}
-                    />
-                    <SortOptionRow
-                        option="start-date"
-                        label="Start Date"
-                        IconComponent={(props) => <CalendarBlank {...props} />}
-                    />
-                    <SortOptionRow
-                        option="priority"
-                        label="Priority"
-                        IconComponent={(props) => <ChartBar {...props} />}
-                    />
-                </View>
-
-                <PrimaryButton title="Apply Sort" onPress={handleSort} />
-            </View>
-        </>
-    );
-};
-
-// Filter Content Component
-type FilterState = {
-    priorities: { low: boolean; medium: boolean; high: boolean };
-    deadlines: { overdue: boolean; today: boolean; thisWeek: boolean; future: boolean; none: boolean };
-};
-
-const FilterContent = ({ workspaceName, onApply }: { workspaceName: string; onApply: () => void }) => {
-    const ThemedColor = useThemeColor();
-    const [filters, setFilters] = useState<FilterState>({
-        priorities: { low: false, medium: false, high: false },
-        deadlines: { overdue: false, today: false, thisWeek: false, future: false, none: false },
-    });
-
-    // Load saved filters from AsyncStorage on mount
-    React.useEffect(() => {
-        const loadFilters = async () => {
-            try {
-                const saved = await AsyncStorage.getItem(`workspace-filters-${workspaceName}`);
-                if (saved) {
-                    setFilters(JSON.parse(saved));
-                }
-            } catch (error) {
-                console.error("Error loading filters:", error);
-            }
-        };
-        loadFilters();
-    }, [workspaceName]);
-
-    const handleApply = async () => {
-        try {
-            await AsyncStorage.setItem(`workspace-filters-${workspaceName}`, JSON.stringify(filters));
-            workspaceStateEvents.emit(workspaceName);
-
-            showToastable({
-                title: "Filters Applied",
-                status: "success",
-                position: "top",
-                duration: 2000,
-                message: "Task filters have been applied to this workspace",
-                renderContent: (props) => <DefaultToast {...props} />,
-            });
-
-            onApply();
-        } catch (error) {
-            console.error("Error saving filters:", error);
-            showToastable({
-                title: "Error",
-                status: "danger",
-                position: "top",
-                message: "Failed to apply filters",
-                renderContent: (props) => <DefaultToast {...props} />,
-            });
-        }
-    };
-
-    const handleClearFilters = async () => {
-        const clearedFilters = {
-            priorities: { low: false, medium: false, high: false },
-            deadlines: { overdue: false, today: false, thisWeek: false, future: false, none: false },
-        };
-        setFilters(clearedFilters);
-
-        try {
-            await AsyncStorage.removeItem(`workspace-filters-${workspaceName}`);
-            workspaceStateEvents.emit(workspaceName);
-            showToastable({
-                title: "Filters Cleared",
-                status: "info",
-                position: "top",
-                duration: 2000,
-                message: "All filters have been removed",
-                renderContent: (props) => <DefaultToast {...props} />,
-            });
-        } catch (error) {
-            console.error("Error clearing filters:", error);
-        }
-    };
-
-    const toggleFilter = async (category: keyof FilterState, option: string) => {
-        const newFilters = {
-            ...filters,
-            [category]: {
-                ...filters[category],
-                [option]: !filters[category][option],
-            },
-        };
-
-        setFilters(newFilters);
-
-        try {
-            await AsyncStorage.setItem(`workspace-filters-${workspaceName}`, JSON.stringify(newFilters));
-            workspaceStateEvents.emit(workspaceName);
-        } catch (error) {
-            console.error("Error saving filters:", error);
-        }
-    };
-
-    const FilterCard = ({
-        label,
-        isSelected,
-        onPress,
-        IconComponent,
-    }: {
-        label: string;
-        isSelected: boolean;
-        onPress: () => void;
-        IconComponent: React.ComponentType<any>;
-    }) => {
-        const iconColor = isSelected ? ThemedColor.primary : ThemedColor.text;
-
-        return (
-            <TouchableOpacity onPress={onPress} style={styles.filterCardWrapper}>
-                <View
-                    style={[
-                        styles.filterCard,
-                        {
-                            backgroundColor: ThemedColor.lightenedCard,
-                            borderWidth: isSelected ? 2 : 0,
-                            borderColor: isSelected ? ThemedColor.primary : "transparent",
-                        },
-                    ]}>
-                    <View style={styles.filterIconContainer}>
-                        <IconComponent color={iconColor} />
-                    </View>
-                    <ThemedText
-                        type="default"
-                        style={{
-                            fontSize: 15,
-                            textAlign: "center",
-                            color: iconColor,
-                        }}>
-                        {label}
-                    </ThemedText>
-                </View>
-            </TouchableOpacity>
-        );
-    };
-
-    const hasActiveFilters =
-        Object.values(filters.priorities).some((v) => v) || Object.values(filters.deadlines).some((v) => v);
-
-    const activeFilterCount =
-        Object.values(filters.priorities).filter((v) => v).length +
-        Object.values(filters.deadlines).filter((v) => v).length;
-
-    return (
-        <>
-            <ThemedText type="subtitle" style={{ marginBottom: 16 }}>
-                Filters
-            </ThemedText>
-            <View style={{ flex: 1, gap: 24 }}>
-                {/* Priority Level */}
-                <View style={{ gap: 12 }}>
-                    <ThemedText type="default" style={{ fontSize: 16 }}>
-                        Priority Level
-                    </ThemedText>
-                    <View style={styles.filterGrid}>
-                        <FilterCard
-                            label="Low"
-                            isSelected={filters.priorities.low}
-                            onPress={() => toggleFilter("priorities", "low")}
-                            IconComponent={(props) => <ChartBarHorizontal size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="Medium"
-                            isSelected={filters.priorities.medium}
-                            onPress={() => toggleFilter("priorities", "medium")}
-                            IconComponent={(props) => <ChartBar size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="High"
-                            isSelected={filters.priorities.high}
-                            onPress={() => toggleFilter("priorities", "high")}
-                            IconComponent={(props) => <ChartBar size={28} weight="fill" {...props} />}
-                        />
-                    </View>
-                </View>
-
-                {/* Deadline */}
-                <View style={{ gap: 12 }}>
-                    <ThemedText type="default" style={{ fontSize: 16 }}>
-                        Deadline
-                    </ThemedText>
-                    <View style={styles.filterGrid}>
-                        <FilterCard
-                            label="Overdue"
-                            isSelected={filters.deadlines.overdue}
-                            onPress={() => toggleFilter("deadlines", "overdue")}
-                            IconComponent={(props) => <WarningCircle size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="Today"
-                            isSelected={filters.deadlines.today}
-                            onPress={() => toggleFilter("deadlines", "today")}
-                            IconComponent={(props) => <CalendarCheck size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="This Week"
-                            isSelected={filters.deadlines.thisWeek}
-                            onPress={() => toggleFilter("deadlines", "thisWeek")}
-                            IconComponent={(props) => <CalendarBlank size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="Future"
-                            isSelected={filters.deadlines.future}
-                            onPress={() => toggleFilter("deadlines", "future")}
-                            IconComponent={(props) => <ArrowRight size={28} weight="regular" {...props} />}
-                        />
-                        <FilterCard
-                            label="No Deadline"
-                            isSelected={filters.deadlines.none}
-                            onPress={() => toggleFilter("deadlines", "none")}
-                            IconComponent={(props) => <Minus size={28} weight="bold" {...props} />}
-                        />
-                    </View>
-                </View>
-
-                {/* Action Buttons */}
-                {hasActiveFilters && (
-                    <View style={{ marginTop: "auto", paddingBottom: 8 }}>
-                        <TouchableOpacity onPress={handleClearFilters}>
-                            <ThemedText type="default" style={{ textAlign: "center", color: ThemedColor.caption }}>
-                                Clear All Filters
-                            </ThemedText>
-                        </TouchableOpacity>
-                    </View>
-                )}
-            </View>
-        </>
-    );
-};
 
 export default EditWorkspace;
-
-const styles = StyleSheet.create({
-    sortOptionRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-        paddingVertical: 12,
-    },
-    filterGrid: {
-        flexDirection: "row",
-        flexWrap: "wrap",
-        gap: 12,
-    },
-    filterCardWrapper: {
-        width: "31%",
-        minWidth: 100,
-    },
-    filterCard: {
-        padding: 16,
-        borderRadius: 12,
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 8,
-        minHeight: 100,
-        position: "relative",
-    },
-    filterIconContainer: {
-        marginBottom: 4,
-    },
-});

--- a/frontend/components/profile/ExpandedRingDetail.tsx
+++ b/frontend/components/profile/ExpandedRingDetail.tsx
@@ -3,7 +3,7 @@ import { View, StyleSheet, TouchableOpacity } from "react-native";
 import Svg, { Circle } from "react-native-svg";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { useRouter } from "expo-router";
+import { useRouter, type Href } from "expo-router";
 import { RingState } from "@/api/types";
 
 type RingKey = "plan" | "do" | "share";
@@ -24,7 +24,7 @@ const RING_GUIDANCE: Record<RingKey, string> = {
 
 interface CTA {
     label: string;
-    route: string;
+    route: Href;
 }
 
 const RING_CTAS: Record<RingKey, CTA[]> = {
@@ -165,7 +165,7 @@ const ExpandedRingDetail: React.FC<ExpandedRingDetailProps> = ({
                     <TouchableOpacity
                         key={cta.label}
                         style={styles.ctaButton}
-                        onPress={() => router.push(cta.route as any)}
+                        onPress={() => router.push(cta.route)}
                         activeOpacity={0.7}
                     >
                         <ThemedText style={styles.ctaText}>{cta.label}</ThemedText>

--- a/frontend/utils/categorySort.ts
+++ b/frontend/utils/categorySort.ts
@@ -1,0 +1,70 @@
+import { Categories, Task } from "@/api/types";
+
+export type SortOption = "task-count" | "alphabetical" | "due-date" | "start-date" | "priority";
+export type SortDirection = "ascending" | "descending";
+
+// Earliest valid timestamp among a date field across a category's tasks, or
+// Infinity when none have one (so empty categories sort last on ascending).
+const earliestTime = (tasks: Task[], field: "deadline" | "startDate"): number => {
+    const times = tasks
+        .map((t) => t[field])
+        .filter((v): v is string => !!v)
+        .map((v) => new Date(v).getTime());
+    return times.length > 0 ? Math.min(...times) : Infinity;
+};
+
+/**
+ * Returns a new array of categories ordered by the given option/direction.
+ * Pure — does not mutate the input. Mirrors the comparators previously inline
+ * in EditWorkspace's SortContent so workspace and tag views sort identically.
+ */
+export function sortCategories(
+    categories: Categories[],
+    option: SortOption,
+    direction: SortDirection
+): Categories[] {
+    const isAscending = direction === "ascending";
+    const sorted = [...categories];
+
+    switch (option) {
+        case "task-count":
+            sorted.sort((a, b) =>
+                isAscending ? a.tasks.length - b.tasks.length : b.tasks.length - a.tasks.length
+            );
+            break;
+        case "alphabetical":
+            sorted.sort((a, b) =>
+                isAscending ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name)
+            );
+            break;
+        case "due-date":
+            sorted.sort((a, b) => {
+                const aT = earliestTime(a.tasks, "deadline");
+                const bT = earliestTime(b.tasks, "deadline");
+                return isAscending ? aT - bT : bT - aT;
+            });
+            break;
+        case "start-date":
+            sorted.sort((a, b) => {
+                const aT = earliestTime(a.tasks, "startDate");
+                const bT = earliestTime(b.tasks, "startDate");
+                return isAscending ? aT - bT : bT - aT;
+            });
+            break;
+        case "priority":
+            // NOTE: preserved bug-for-bug from the original workspace sort — the
+            // priority map is keyed by strings while task.priority is a number, so
+            // this currently evaluates to 0 for every task (a no-op order). Kept
+            // identical to avoid changing workspace behavior; fixing it is a
+            // separate change.
+            sorted.sort((a, b) => {
+                const priorityMap: { [key: string]: number } = { high: 3, medium: 2, low: 1 };
+                const aHighest = Math.max(...a.tasks.map((t) => priorityMap[t.priority] || 0), 0);
+                const bHighest = Math.max(...b.tasks.map((t) => priorityMap[t.priority] || 0), 0);
+                return isAscending ? aHighest - bHighest : bHighest - aHighest;
+            });
+            break;
+    }
+
+    return sorted;
+}


### PR DESCRIPTION
## Summary

Onboarding checklist feature plus a series of category-tags and routing improvements. All in one PR per request.

### 1. Onboarding checklist
"Get started on Kindred" home-screen card (first task / first kudos / add friend / close rings) with persisted dismissal + completion toasts. Progress bar thickened so its pill rounding reads correctly.

### 2. Typed-route fixes
Fixed a "page not found" bug: the checklist "Close your rings" row pushed to a non-existent route group. Removed every `as any` cast from navigation app-wide and typed route variables/state as `Href`, so routes are validated at compile time. Also fixed a latent `posting/[id]` → bare `(feed)/` not-found redirect.

### 3. Category tags — inline creator
- Backend `CreateCategory` now accepts + normalizes `tags` (mirrored into OpenAPI spec/generated types).
- Extracted a shared **`TagEditor`** component out of `EditCategoryModal` (with an imperative `flush()` so a typed-but-not-added tag isn't dropped on the host's primary action).
- Inline category creator gets a **Tag icon between the X and +** that opens a bottom sheet hosting `TagEditor`; tags are collected locally and the category is created with name + tags in one request on `+`.
- Tag editor UX polish: dedicated "Add" button, "Suggestions · tap to add" label, consistent 8/12/16/24 spacing, wider chip padding.

### 4. Tag view — back button + shared list controls (full parity)
- Visible themed **back button** on the tag view.
- Extracted `SortContent`/`FilterContent` out of the ~770-line `EditWorkspace` into a shared **`ListControls`** module + a pure **`sortCategories`** util. `EditWorkspace` keeps its exact behavior (sort still reorders global state, now via an `onApplySort` callback).
- The tag view reuses the **same sort/filter picker sheets** and the per-key state hooks (keyed by `tag:<value>`), applying filter to each category's tasks and sort as a **derived** ordering (cross-workspace, so no global mutation).

## Notes
- The workspace **priority sort** is preserved bug-for-bug (it keys a string map with a numeric `priority`, so it's a no-op today) to avoid changing workspace behavior — fixing it is a separate change.
- Group-by-day (calendar toggle) was **not** added to the tag view: it switches the layout to a task-timeline that doesn't map onto the cross-workspace category list. Filter + sort (the named asks) have full parity. Can be a fast-follow if wanted.

## Test plan
- [x] `tsc` clean for all touched files (only pre-existing `DatePager.tsx` errors remain).
- [x] Frontend: new `categorySort` unit tests + existing `TagChip`/onboarding suites pass (18 tests).
- [x] Backend: category package builds; all category tests pass (incl. new create-with-tags).
- [ ] Manual: inline create-with-tags; tag-view back button; tag-view filter/sort parity; workspace view unchanged.

Pre-existing/unrelated: `AboutScreen.test.tsx` fails (imports a removed `@/app/about`); `DatePager.tsx` tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)