### PR TITLE
fix(calendar): gate push on writer access to stop 403 retries

### DIFF
--- a/backend/internal/handlers/calendar/push_service.go
+++ b/backend/internal/handlers/calendar/push_service.go
@@ -12,7 +12,28 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.opentelemetry.io/otel"
+	"google.golang.org/api/googleapi"
 )
+
+// isCalendarWriteForbidden reports whether the error is Google's per-calendar
+// ACL rejection ("You need to have writer access to this calendar"). This is
+// distinct from a scope failure and isn't recoverable by retry — the token's
+// user lacks writer ACL on the target calendar.
+func isCalendarWriteForbidden(err error) bool {
+	var apiErr *googleapi.Error
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	if apiErr.Code != 403 {
+		return false
+	}
+	for _, e := range apiErr.Errors {
+		if e.Reason == "requiredAccessLevel" {
+			return true
+		}
+	}
+	return false
+}
 
 // ProcessPushRow handles one outbox row end-to-end. Returns nil on success,
 // an error otherwise; the worker translates that into a backoff via MarkFailure.
@@ -133,11 +154,17 @@ func (s *Service) processPushUpsert(ctx context.Context, row PushOutboxRow) erro
 	if task.PushedEventID == "" {
 		written, err = provider.CreateEvent(ctx, token, ev)
 		if err != nil {
+			if isCalendarWriteForbidden(err) {
+				return s.disablePushForUnwritableCategory(ctx, row.CategoryID, calendarID, err)
+			}
 			return fmt.Errorf("provider create: %w", err)
 		}
 	} else {
 		written, err = provider.UpdateEvent(ctx, token, task.PushedEventID, ev)
 		if err != nil {
+			if isCalendarWriteForbidden(err) {
+				return s.disablePushForUnwritableCategory(ctx, row.CategoryID, calendarID, err)
+			}
 			return fmt.Errorf("provider update: %w", err)
 		}
 	}
@@ -248,6 +275,24 @@ func (s *Service) loadTaskWithCategory(ctx context.Context, taskID, categoryID p
 		Integration: doc.Integration,
 		PushEnabled: doc.PushEnabled,
 	}, nil
+}
+
+// disablePushForUnwritableCategory flips push_enabled=false on a category whose
+// underlying calendar rejected our write with a per-calendar ACL 403. Returning
+// nil tells the worker to drop the row instead of retrying — the token's user
+// has reader-level access (or none), and no amount of backoff will help. A
+// successful re-grant requires the user to re-run setup.
+func (s *Service) disablePushForUnwritableCategory(ctx context.Context, categoryID primitive.ObjectID, calendarID string, cause error) error {
+	slog.Warn("Push: calendar rejected write (no writer ACL), disabling push on category",
+		"category_id", categoryID, "calendar_id", calendarID, "error", cause)
+	_, updErr := s.categories.UpdateOne(ctx,
+		bson.M{"_id": categoryID},
+		bson.M{"$set": bson.M{"push_enabled": false}},
+	)
+	if updErr != nil {
+		slog.Warn("Push: failed to disable push on category after 403", "category_id", categoryID, "error", updErr)
+	}
+	return nil
 }
 
 // parseCategoryIntegration extracts (connectionID, calendarID) from "gcal:<connID>:<calID>".

--- a/backend/internal/handlers/calendar/service.go
+++ b/backend/internal/handlers/calendar/service.go
@@ -376,11 +376,27 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 		pushEnabledSet[id] = true
 	}
 
+	// Only owner/writer roles can have events inserted/updated/deleted.
+	// Without this gate, push to a reader/freeBusyReader calendar would 403
+	// with "You need to have writer access to this calendar" on every drain.
+	writableSet := make(map[string]bool, len(allCalendars))
+	for _, cal := range allCalendars {
+		if cal.AccessRole == "owner" || cal.AccessRole == "writer" {
+			writableSet[cal.ID] = true
+		}
+	}
+
 	now := time.Now()
 
 	for _, cal := range allCalendars {
 		if !selectedSet[cal.ID] {
 			continue
+		}
+
+		pushAllowed := pushEnabledSet[cal.ID] && writableSet[cal.ID]
+		if pushEnabledSet[cal.ID] && !writableSet[cal.ID] {
+			slog.Warn("Refusing push for non-writable calendar",
+				"calendar_id", cal.ID, "calendar_name", cal.Name, "access_role", cal.AccessRole)
 		}
 
 		// Determine workspace name
@@ -403,12 +419,12 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 		if err == nil {
 			// Update push_enabled on existing category if it differs.
 			_, updErr := s.categories.UpdateOne(ctx, bson.M{"_id": existing.ID}, bson.M{
-				"$set": bson.M{"push_enabled": pushEnabledSet[cal.ID]},
+				"$set": bson.M{"push_enabled": pushAllowed},
 			})
 			if updErr != nil {
 				slog.Warn("Failed to update push_enabled on existing category", "category_id", existing.ID, "error", updErr)
 			}
-			slog.Info("Category already exists, updated push flag", "calendar_id", cal.ID, "category_id", existing.ID, "push_enabled", pushEnabledSet[cal.ID])
+			slog.Info("Category already exists, updated push flag", "calendar_id", cal.ID, "category_id", existing.ID, "push_enabled", pushAllowed)
 			continue
 		} else if err != mongo.ErrNoDocuments {
 			return fmt.Errorf("failed to check existing category for %s: %w", cal.Name, err)
@@ -422,7 +438,7 @@ func (s *Service) SetupWorkspacesForConnection(ctx context.Context, connectionID
 			"tasks":         []bson.M{},
 			"user":          userID,
 			"integration":   integrationKey,
-			"push_enabled":  pushEnabledSet[cal.ID],
+			"push_enabled":  pushAllowed,
 		}
 
 		_, err = s.categories.InsertOne(ctx, category)


### PR DESCRIPTION
## Summary

- Push to a Google calendar where the OAuth user is `reader` / `freeBusyReader` failed with `403 You need to have writer access to this calendar` — a per-calendar ACL error, *not* a scope problem (`calendar.events` is granted). The setup flow accepted any `push_enabled_calendar_ids` from the client and the worker drained those rows into endless exponential backoff.
- `SetupWorkspacesForConnection` now gates `push_enabled` on the calendar's `AccessRole` being `owner` or `writer`. A user-requested push on a read-only calendar is logged and silently downgraded to `push_enabled: false`.
- Worker upsert path now detects the 403 with `reason: requiredAccessLevel` and self-heals: flips `push_enabled: false` on the category and drops the row instead of retrying. This catches categories that were already broken before this fix, and future permission demotions.

## Notes / follow-ups (not in this PR)

- Frontend picker should also disable the push toggle on calendars where `access_role` is not owner/writer (currently `CalendarInfo.AccessRole` is returned but unused in the UI).
- The redundant `calendar.readonly` scope at `provider_google.go:30` could be dropped (`calendar.events` covers reads) — left alone to avoid invalidating existing tokens.
- The `"primary"` fallback at `provider_google.go:220/256/289` is unrelated to this 403 but is a sharp edge worth converting to an error.

## Test plan

- [x] `go build ./internal/handlers/calendar/...`
- [x] `go vet ./internal/handlers/calendar/...`
- [x] `go test ./internal/handlers/calendar/...`
- [ ] Reproduce: connect a Google account, mark a subscribed/holiday calendar as push-enabled, create a task in that workspace. Expect: setup silently downgrades push to `false` with a warn log; no 403 in worker logs.
- [ ] Already-broken case: existing category with `push_enabled: true` on a reader calendar. Expect: first drain attempt hits 403, category flips to `push_enabled: false`, subsequent task edits don't enqueue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)