### PR TITLE
Notifications redesign: tabs + For You feed

### DIFF
--- a/backend/cmd/db/create_collections/main.go
+++ b/backend/cmd/db/create_collections/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 
 	// Collections to create
-	collections := []string{"encouragements", "congratulations", "notifications", "workspaces", "reports"}
+	collections := []string{"encouragements", "congratulations", "notifications", "workspaces", "reports", "for_you_exposures"}
 
 	for _, collectionName := range collections {
 		if err := createCollectionIfNotExists(ctx, db.DB, collectionName); err != nil {

--- a/backend/internal/handlers/foryou/foryou.go
+++ b/backend/internal/handlers/foryou/foryou.go
@@ -1,0 +1,61 @@
+package foryou
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type Handler struct {
+	service *Service
+}
+
+// GetForYouHuma assembles and returns the current user's For You feed.
+func (h *Handler) GetForYouHuma(ctx context.Context, input *GetForYouInput) (*GetForYouOutput, error) {
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+	userID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID", err)
+	}
+
+	timezone := input.Timezone
+	if timezone == "" {
+		timezone = auth.GetTimezoneOrDefault(ctx)
+	}
+
+	feed, err := h.service.GetForYou(ctx, userID, timezone)
+	if err != nil {
+		slog.Error("failed to build For You feed", "userId", userIDStr, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to load For You", err)
+	}
+	return &GetForYouOutput{Body: *feed}, nil
+}
+
+// RecordInteractionHuma marks that the user tapped a CTA on a card of a given type.
+// Counts toward the threshold that switches the card to compact mode.
+func (h *Handler) RecordInteractionHuma(ctx context.Context, input *RecordInteractionInput) (*RecordInteractionOutput, error) {
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+	userID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID", err)
+	}
+	if input.Body.CardType == "" {
+		return nil, huma.Error400BadRequest("cardType is required", nil)
+	}
+	if err := h.service.RecordInteraction(ctx, userID, input.Body.CardType); err != nil {
+		slog.Error("failed to record For You interaction", "userId", userIDStr, "cardType", input.Body.CardType, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to record interaction", err)
+	}
+	out := &RecordInteractionOutput{}
+	out.Body.Message = "Interaction recorded"
+	return out, nil
+}

--- a/backend/internal/handlers/foryou/operations.go
+++ b/backend/internal/handlers/foryou/operations.go
@@ -1,0 +1,34 @@
+package foryou
+
+import (
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+func RegisterGetForYouOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-for-you",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/for-you",
+		Summary:     "Get the For You feed",
+		Description: "Returns the curated For You feed for the authenticated user, organized into Catch up and Suggested for you sections.",
+		Tags:        []string{"for-you"},
+	}, handler.GetForYouHuma)
+}
+
+func RegisterRecordInteractionOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "record-for-you-interaction",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/for-you/interactions",
+		Summary:     "Record a For You CTA interaction",
+		Description: "Increments the interaction counter for a card type, counting toward the threshold that switches the card to compact display mode.",
+		Tags:        []string{"for-you"},
+	}, handler.RecordInteractionHuma)
+}
+
+func RegisterForYouOperations(api huma.API, handler *Handler) {
+	RegisterGetForYouOperation(api, handler)
+	RegisterRecordInteractionOperation(api, handler)
+}

--- a/backend/internal/handlers/foryou/routes.go
+++ b/backend/internal/handlers/foryou/routes.go
@@ -1,0 +1,14 @@
+package foryou
+
+import (
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Routes wires the For You handler into the Huma API.
+func Routes(api huma.API, collections map[string]*mongo.Collection, ringService *rings.RingService) {
+	service := newService(collections, ringService)
+	handler := Handler{service: service}
+	RegisterForYouOperations(api, &handler)
+}

--- a/backend/internal/handlers/foryou/service.go
+++ b/backend/internal/handlers/foryou/service.go
@@ -1,0 +1,403 @@
+package foryou
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sort"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+// Section IDs and titles are returned verbatim to the client.
+const (
+	sectionCatchUp   = "catch_up"
+	sectionSuggested = "suggested"
+)
+
+// Service assembles the For You feed from existing data sources and tracks
+// per-(user, card_type) exposure so that the educational layer can be dropped
+// once the user has interacted with a feature a few times.
+type Service struct {
+	Encouragements *mongo.Collection
+	Posts          *mongo.Collection
+	Users          *mongo.Collection
+	Exposures      *mongo.Collection
+	RingService    *rings.RingService
+}
+
+func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
+	if collections["for_you_exposures"] == nil {
+		slog.Warn("for_you_exposures collection missing; exposure tracking disabled")
+	}
+	return &Service{
+		Encouragements: collections["encouragements"],
+		Posts:          collections["posts"],
+		Users:          collections["users"],
+		Exposures:      collections["for_you_exposures"],
+		RingService:    ringService,
+	}
+}
+
+// GetForYou returns the assembled feed for a user. Cards within each section
+// are sorted by Priority descending; the client never re-sorts.
+func (s *Service) GetForYou(ctx context.Context, userID primitive.ObjectID, timezone string) (*ForYouFeed, error) {
+	if timezone == "" {
+		timezone = "UTC"
+	}
+
+	exposures, err := s.loadExposures(ctx, userID)
+	if err != nil {
+		slog.Warn("failed to load For You exposures; falling back to full mode", "userId", userID.Hex(), "error", err)
+		exposures = map[string]ExposureDoc{}
+	}
+
+	var catchUp []ForYouCard
+	var suggested []ForYouCard
+
+	if cards := s.buildKudosReceivedCards(ctx, userID, exposures); len(cards) > 0 {
+		catchUp = append(catchUp, cards...)
+	}
+	if card := s.buildRingProgressCard(ctx, userID, timezone, exposures); card != nil {
+		suggested = append(suggested, *card)
+	}
+	if card := s.buildPostPromptCard(ctx, userID, exposures); card != nil {
+		suggested = append(suggested, *card)
+	}
+
+	sortByPriority(catchUp)
+	sortByPriority(suggested)
+
+	s.recordViews(ctx, userID, allCardTypes(catchUp, suggested))
+
+	return &ForYouFeed{
+		Sections: []ForYouSection{
+			{ID: sectionCatchUp, Title: "Catch up", Cards: catchUp},
+			{ID: sectionSuggested, Title: "Suggested for you", Cards: suggested},
+		},
+		UnreadCount: len(catchUp),
+	}, nil
+}
+
+// RecordInteraction is called by the client when the user taps a CTA. It
+// counts toward the threshold that flips a card type to compact mode.
+func (s *Service) RecordInteraction(ctx context.Context, userID primitive.ObjectID, cardType string) error {
+	if s.Exposures == nil {
+		return nil
+	}
+	_, err := s.Exposures.UpdateOne(
+		ctx,
+		bson.M{"user_id": userID, "card_type": cardType},
+		bson.M{
+			"$inc": bson.M{"interactions": 1},
+			"$set": bson.M{"last_interacted_at": time.Now()},
+			"$setOnInsert": bson.M{
+				"user_id":   userID,
+				"card_type": cardType,
+			},
+		},
+		options.Update().SetUpsert(true),
+	)
+	return err
+}
+
+// ---------- Card builders ----------
+
+func (s *Service) buildKudosReceivedCards(ctx context.Context, userID primitive.ObjectID, exposures map[string]ExposureDoc) []ForYouCard {
+	if s.Encouragements == nil {
+		return nil
+	}
+
+	cutoff := time.Now().Add(-7 * 24 * time.Hour)
+	filter := bson.M{
+		"receiver":  userID,
+		"timestamp": bson.M{"$gte": cutoff},
+	}
+	opts := options.Find().SetSort(bson.D{{Key: "timestamp", Value: -1}}).SetLimit(3)
+
+	cursor, err := s.Encouragements.Find(ctx, filter, opts)
+	if err != nil {
+		slog.Warn("failed to fetch kudos for For You", "userId", userID.Hex(), "error", err)
+		return nil
+	}
+	defer cursor.Close(ctx)
+
+	type minimalEncouragement struct {
+		ID     primitive.ObjectID `bson:"_id"`
+		Sender struct {
+			Name    string             `bson:"name"`
+			Picture string             `bson:"picture"`
+			ID      primitive.ObjectID `bson:"id"`
+		} `bson:"sender"`
+		Timestamp time.Time `bson:"timestamp"`
+		Read      bool      `bson:"read"`
+	}
+
+	var docs []minimalEncouragement
+	if err := cursor.All(ctx, &docs); err != nil {
+		slog.Warn("failed to decode kudos", "userId", userID.Hex(), "error", err)
+		return nil
+	}
+
+	mode := displayModeFor(exposures, CardKudosReceived)
+	cards := make([]ForYouCard, 0, len(docs))
+	for i, d := range docs {
+		card := ForYouCard{
+			ID:          fmt.Sprintf("kudos-%s", d.ID.Hex()),
+			Type:        CardKudosReceived,
+			DisplayMode: mode,
+			IconKind:    IconKudos,
+			Title:       fmt.Sprintf("%s sent you a kudos!", senderFirstName(d.Sender.Name)),
+			Subject: &ForYouSubject{
+				UserID:      d.Sender.ID.Hex(),
+				DisplayName: d.Sender.Name,
+				AvatarURL:   d.Sender.Picture,
+			},
+			DeepLink: "/(logged-in)/(tabs)/(task)/kudos",
+			Priority: 100 - i, // newest first within the type
+		}
+		if mode == DisplayModeFull {
+			card.Body = "Kudos are a quick way to celebrate friends' wins."
+			card.Ctas = []ForYouCta{
+				{
+					Label: "Send one back",
+					Kind:  "primary",
+					Action: ForYouCtaAction{
+						Type:         "send_kudos",
+						TargetUserID: d.Sender.ID.Hex(),
+					},
+				},
+				{
+					Label: "Reply",
+					Kind:  "secondary",
+					Action: ForYouCtaAction{
+						Type: "navigate",
+						Href: "/(logged-in)/(tabs)/(task)/kudos",
+					},
+				},
+			}
+		} else {
+			card.Ctas = []ForYouCta{
+				{
+					Label: "Send back",
+					Kind:  "primary",
+					Action: ForYouCtaAction{
+						Type:         "send_kudos",
+						TargetUserID: d.Sender.ID.Hex(),
+					},
+				},
+			}
+		}
+		cards = append(cards, card)
+	}
+	return cards
+}
+
+func (s *Service) buildRingProgressCard(ctx context.Context, userID primitive.ObjectID, timezone string, exposures map[string]ExposureDoc) *ForYouCard {
+	if s.RingService == nil {
+		return nil
+	}
+	state, err := s.RingService.GetOrCreateToday(ctx, userID, timezone)
+	if err != nil {
+		slog.Warn("failed to fetch ring state for For You", "userId", userID.Hex(), "error", err)
+		return nil
+	}
+	if state == nil || state.AllClosed {
+		return nil
+	}
+
+	openCount := 0
+	if !state.Plan.Closed {
+		openCount += state.Plan.Target - state.Plan.Current
+	}
+	if !state.Do.Closed {
+		openCount += state.Do.Target - state.Do.Current
+	}
+	if !state.Share.Closed {
+		openCount += state.Share.Target - state.Share.Current
+	}
+	if openCount < 0 {
+		openCount = 0
+	}
+
+	mode := displayModeFor(exposures, CardRingProgress)
+	card := ForYouCard{
+		ID:          fmt.Sprintf("ring-%s", state.Date.Format("2006-01-02")),
+		Type:        CardRingProgress,
+		DisplayMode: mode,
+		IconKind:    IconRing,
+		Title:       ringTitle(openCount),
+		DeepLink:    "/(logged-in)/(tabs)/(task)/daily",
+		Priority:    90,
+		Ctas: []ForYouCta{
+			{
+				Label:  ringCtaLabel(mode),
+				Kind:   "primary",
+				Action: ForYouCtaAction{Type: "navigate", Href: "/(logged-in)/(tabs)/(task)/daily"},
+			},
+		},
+	}
+	if mode == DisplayModeFull {
+		card.Body = "Rings track how much of your day you've completed."
+	}
+	return &card
+}
+
+func (s *Service) buildPostPromptCard(ctx context.Context, userID primitive.ObjectID, exposures map[string]ExposureDoc) *ForYouCard {
+	if s.Posts == nil {
+		return nil
+	}
+
+	since := time.Now().Add(-24 * time.Hour)
+	filter := bson.M{
+		"user._id":           userID,
+		"metadata.isDeleted": false,
+		"metadata.createdAt": bson.M{"$gte": since},
+	}
+	count, err := s.Posts.CountDocuments(ctx, filter)
+	if err != nil {
+		slog.Warn("failed to count user posts for For You", "userId", userID.Hex(), "error", err)
+		return nil
+	}
+	if count > 0 {
+		return nil
+	}
+
+	mode := displayModeFor(exposures, CardPostPrompt)
+	card := ForYouCard{
+		ID:          "post-prompt-today",
+		Type:        CardPostPrompt,
+		DisplayMode: mode,
+		IconKind:    IconPost,
+		Title:       "Share something with your circle",
+		DeepLink:    "/(logged-in)/(tabs)/(feed)/feed",
+		Priority:    70,
+		Ctas: []ForYouCta{
+			{
+				Label:  "Share a post",
+				Kind:   "primary",
+				Action: ForYouCtaAction{Type: "navigate", Href: "/(logged-in)/(tabs)/(feed)/feed"},
+			},
+		},
+	}
+	if mode == DisplayModeFull {
+		card.Body = "Posts let your friends cheer you on."
+	}
+	return &card
+}
+
+// ---------- Exposure tracking ----------
+
+func (s *Service) loadExposures(ctx context.Context, userID primitive.ObjectID) (map[string]ExposureDoc, error) {
+	out := map[string]ExposureDoc{}
+	if s.Exposures == nil {
+		return out, nil
+	}
+	cursor, err := s.Exposures.Find(ctx, bson.M{"user_id": userID})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+	var docs []ExposureDoc
+	if err := cursor.All(ctx, &docs); err != nil {
+		return nil, err
+	}
+	for _, d := range docs {
+		out[d.CardType] = d
+	}
+	return out, nil
+}
+
+func (s *Service) recordViews(ctx context.Context, userID primitive.ObjectID, cardTypes []string) {
+	if s.Exposures == nil || len(cardTypes) == 0 {
+		return
+	}
+	now := time.Now()
+	for _, ct := range cardTypes {
+		_, err := s.Exposures.UpdateOne(
+			ctx,
+			bson.M{"user_id": userID, "card_type": ct},
+			bson.M{
+				"$inc": bson.M{"views": 1},
+				"$set": bson.M{"last_seen_at": now},
+				"$setOnInsert": bson.M{
+					"user_id":   userID,
+					"card_type": ct,
+				},
+			},
+			options.Update().SetUpsert(true),
+		)
+		if err != nil {
+			slog.Warn("failed to record For You view", "userId", userID.Hex(), "cardType", ct, "error", err)
+		}
+	}
+}
+
+// ---------- Helpers ----------
+
+func displayModeFor(exposures map[string]ExposureDoc, cardType ForYouCardType) DisplayMode {
+	e, ok := exposures[string(cardType)]
+	if !ok {
+		return DisplayModeFull
+	}
+	if e.Interactions >= CompactInteractionThreshold || e.Views >= CompactViewThreshold {
+		return DisplayModeCompact
+	}
+	return DisplayModeFull
+}
+
+func sortByPriority(cards []ForYouCard) {
+	sort.SliceStable(cards, func(i, j int) bool {
+		return cards[i].Priority > cards[j].Priority
+	})
+}
+
+func allCardTypes(sections ...[]ForYouCard) []string {
+	seen := map[string]struct{}{}
+	var out []string
+	for _, s := range sections {
+		for _, c := range s {
+			if _, ok := seen[string(c.Type)]; ok {
+				continue
+			}
+			seen[string(c.Type)] = struct{}{}
+			out = append(out, string(c.Type))
+		}
+	}
+	return out
+}
+
+func senderFirstName(displayName string) string {
+	for i, r := range displayName {
+		if r == ' ' {
+			return displayName[:i]
+		}
+	}
+	if displayName == "" {
+		return "Someone"
+	}
+	return displayName
+}
+
+func ringTitle(openCount int) string {
+	switch {
+	case openCount <= 1:
+		return "One task away from closing today's ring"
+	case openCount <= 3:
+		return fmt.Sprintf("%d tasks until you close today's ring", openCount)
+	default:
+		return "Keep going — your rings are still open"
+	}
+}
+
+func ringCtaLabel(mode DisplayMode) string {
+	if mode == DisplayModeCompact {
+		return "Open tasks"
+	}
+	return "Go to today's tasks"
+}

--- a/backend/internal/handlers/foryou/types.go
+++ b/backend/internal/handlers/foryou/types.go
@@ -1,0 +1,143 @@
+package foryou
+
+import (
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// ForYouCardType enumerates the kinds of cards the For You feed can surface.
+type ForYouCardType string
+
+const (
+	CardKudosReceived        ForYouCardType = "kudos_received"
+	CardCommentReply         ForYouCardType = "comment_reply"
+	CardReciprocityEncourage ForYouCardType = "reciprocity_encourage"
+	CardReciprocityReact     ForYouCardType = "reciprocity_react"
+	CardRingProgress         ForYouCardType = "ring_progress"
+	CardPostPrompt           ForYouCardType = "post_prompt"
+	CardBlueprintSuggestion  ForYouCardType = "blueprint_suggestion"
+)
+
+// ForYouIconKind controls the icon the client renders on a card.
+type ForYouIconKind string
+
+const (
+	IconKudos     ForYouIconKind = "kudos"
+	IconUsers     ForYouIconKind = "users"
+	IconRing      ForYouIconKind = "ring"
+	IconPost      ForYouIconKind = "post"
+	IconComment   ForYouIconKind = "comment"
+	IconBlueprint ForYouIconKind = "blueprint"
+)
+
+// DisplayMode is the layout the client should use for a card.
+type DisplayMode string
+
+const (
+	DisplayModeFull    DisplayMode = "full"
+	DisplayModeCompact DisplayMode = "compact"
+)
+
+// Thresholds at which the server switches a user's card from full to compact.
+// See docs/superpowers/specs/2026-05-31-for-you-tab-design.md.
+const (
+	CompactInteractionThreshold = 2
+	CompactViewThreshold        = 5
+)
+
+// ForYouSubject is the human-visible "who" a card is about (when applicable).
+type ForYouSubject struct {
+	UserID      string `json:"userId" example:"507f1f77bcf86cd799439011"`
+	DisplayName string `json:"displayName" example:"Sarah"`
+	AvatarURL   string `json:"avatarUrl,omitempty" example:"https://example.com/avatar.jpg"`
+}
+
+// ForYouCtaAction is a tagged-union describing what a CTA does. Exactly one of
+// the inner fields is non-zero for any given action.
+type ForYouCtaAction struct {
+	Type         string `json:"type" example:"navigate" doc:"navigate | send_kudos | send_encouragement | react"`
+	Href         string `json:"href,omitempty" example:"/(logged-in)/(tabs)/(task)/kudos"`
+	TargetUserID string `json:"targetUserId,omitempty"`
+	ReferenceID  string `json:"referenceId,omitempty"`
+	TaskID       string `json:"taskId,omitempty"`
+	PostID       string `json:"postId,omitempty"`
+	Reaction     string `json:"reaction,omitempty"`
+}
+
+// ForYouCta is a single button rendered on a card.
+type ForYouCta struct {
+	Label  string          `json:"label" example:"Send one back"`
+	Kind   string          `json:"kind" example:"primary" doc:"primary | secondary"`
+	Action ForYouCtaAction `json:"action"`
+}
+
+// ForYouCard is one row/card in the feed. The client never re-sorts; trust Priority.
+type ForYouCard struct {
+	ID          string         `json:"id"`
+	Type        ForYouCardType `json:"type"`
+	DisplayMode DisplayMode    `json:"displayMode"`
+	IconKind    ForYouIconKind `json:"iconKind"`
+	Title       string         `json:"title"`
+	Body        string         `json:"body,omitempty" doc:"Present iff displayMode == full"`
+	Subject     *ForYouSubject `json:"subject,omitempty"`
+	Ctas        []ForYouCta    `json:"ctas"`
+	DeepLink    string         `json:"deepLink" doc:"Tap-target for the entire card"`
+	Priority    int            `json:"priority"`
+}
+
+// ForYouSection groups cards under a heading.
+type ForYouSection struct {
+	ID    string       `json:"id" example:"catch_up" doc:"catch_up | suggested"`
+	Title string       `json:"title" example:"Catch up"`
+	Cards []ForYouCard `json:"cards"`
+}
+
+// ForYouFeed is the top-level response payload.
+type ForYouFeed struct {
+	Sections    []ForYouSection `json:"sections"`
+	UnreadCount int             `json:"unreadCount" doc:"Number of catch_up cards driving the tab dot"`
+}
+
+// ---------- Huma I/O types ----------
+
+type GetForYouInput struct {
+	Authorization string `header:"Authorization" required:"true" doc:"Bearer token"`
+	RefreshToken  string `header:"refresh_token" required:"true" doc:"Refresh token"`
+	Timezone      string `header:"X-Timezone" required:"false" doc:"IANA timezone, e.g. America/New_York"`
+}
+
+type GetForYouOutput struct {
+	Body ForYouFeed `json:"body"`
+}
+
+type RecordInteractionInput struct {
+	Authorization string                  `header:"Authorization" required:"true"`
+	RefreshToken  string                  `header:"refresh_token" required:"true"`
+	Body          RecordInteractionParams `json:"body"`
+}
+
+type RecordInteractionParams struct {
+	CardType string `json:"cardType" validate:"required" example:"kudos_received" doc:"Card type the user interacted with"`
+}
+
+type RecordInteractionOutput struct {
+	Body struct {
+		Message string `json:"message" example:"Interaction recorded"`
+	} `json:"body"`
+}
+
+// ---------- Internal storage types ----------
+
+// ExposureDoc tracks how many times a user has seen and interacted with a card
+// type. One document per (userID, cardType) — enforced by a unique compound
+// index defined in storage/xmongo/indexes.go.
+type ExposureDoc struct {
+	ID               primitive.ObjectID `bson:"_id,omitempty"`
+	UserID           primitive.ObjectID `bson:"user_id"`
+	CardType         string             `bson:"card_type"`
+	Views            int                `bson:"views"`
+	Interactions     int                `bson:"interactions"`
+	LastSeenAt       time.Time          `bson:"last_seen_at,omitempty"`
+	LastInteractedAt time.Time          `bson:"last_interacted_at,omitempty"`
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	congratulation "github.com/abhikaboy/Kindred/internal/handlers/congratulation"
 	connection "github.com/abhikaboy/Kindred/internal/handlers/connection"
 	encouragement "github.com/abhikaboy/Kindred/internal/handlers/encouragement"
+	"github.com/abhikaboy/Kindred/internal/handlers/foryou"
 	group "github.com/abhikaboy/Kindred/internal/handlers/group"
 	"github.com/abhikaboy/Kindred/internal/handlers/health"
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
@@ -168,6 +169,9 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 
 	// Register notification routes
 	notifications.Routes(api, collections)
+
+	// Register For You feed routes
+	foryou.Routes(api, collections, ringService)
 
 	// Register referral routes
 	referral.Routes(api, collections)

--- a/backend/internal/storage/xmongo/indexes.go
+++ b/backend/internal/storage/xmongo/indexes.go
@@ -108,6 +108,18 @@ var Indexes = []Index{
 			Keys: bson.D{{Key: "receiver", Value: 1}},
 		},
 	},
+	// For You exposure tracking — one document per (user_id, card_type). The
+	// unique compound index lets the service upsert exposure counts atomically.
+	{
+		Collection: "for_you_exposures",
+		Model: mongo.IndexModel{
+			Keys: bson.D{
+				{Key: "user_id", Value: 1},
+				{Key: "card_type", Value: 1},
+			},
+			Options: options.Index().SetName("user_card_unique").SetUnique(true),
+		},
+	},
 	// Calendar connections indexes
 	{
 		Collection: "calendar_connections",

--- a/frontend/api/forYou.ts
+++ b/frontend/api/forYou.ts
@@ -1,0 +1,55 @@
+// Typed contract for the /for-you endpoint.
+// Phase 1: backend isn't built yet; `fetchForYou` returns stub data from useForYou.
+
+export type ForYouCardType =
+    | "kudos_received"
+    | "comment_reply"
+    | "reciprocity_encourage"
+    | "reciprocity_react"
+    | "ring_progress"
+    | "post_prompt"
+    | "blueprint_suggestion";
+
+export type ForYouIconKind = "kudos" | "users" | "ring" | "post" | "comment" | "blueprint";
+
+export type ForYouSubject = {
+    userId: string;
+    displayName: string;
+    avatarUrl?: string;
+};
+
+export type ForYouCtaAction =
+    | { type: "navigate"; href: string }
+    | { type: "send_kudos"; targetUserId: string; referenceId?: string }
+    | { type: "send_encouragement"; targetUserId: string; taskId: string }
+    | { type: "react"; postId: string; reaction: string };
+
+export type ForYouCta = {
+    label: string;
+    kind: "primary" | "secondary";
+    action: ForYouCtaAction;
+};
+
+export type ForYouCard = {
+    id: string;
+    type: ForYouCardType;
+    displayMode: "full" | "compact";
+    iconKind: ForYouIconKind;
+    title: string;
+    body?: string;
+    subject?: ForYouSubject;
+    ctas: ForYouCta[];
+    deepLink: string;
+    priority: number;
+};
+
+export type ForYouSection = {
+    id: "catch_up" | "suggested";
+    title: string;
+    cards: ForYouCard[];
+};
+
+export type ForYouFeed = {
+    sections: ForYouSection[];
+    unreadCount: number;
+};

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -373,18 +373,24 @@ const Notifications = () => {
         }
     };
 
-    // Mark all notifications as read when the page is focused (only once per mount)
+    // Mark all notifications as read when the page is focused. Runs at most once
+    // per focus, only if there's something unread, and never re-fires on render
+    // (markAllAsRead is intentionally not in the deps — its identity changed
+    // every render in an earlier revision and triggered a request-spam loop).
+    const hasUnread = rawNotifications.some((n) => !n.read);
+    const markAllAsReadRef = useRef(markAllAsRead);
+    markAllAsReadRef.current = markAllAsRead;
     useFocusEffect(
         React.useCallback(() => {
-            if (!loading && rawNotifications.length > 0 && !hasMarkedAsRead.current) {
+            if (!loading && hasUnread && !hasMarkedAsRead.current) {
                 hasMarkedAsRead.current = true;
-                markAllAsRead();
+                markAllAsReadRef.current();
             }
 
             return () => {
                 hasMarkedAsRead.current = false;
             };
-        }, [loading, rawNotifications.length, markAllAsRead])
+        }, [loading, hasUnread])
     );
 
     const now = Date.now();

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -318,7 +318,7 @@ const Notifications = () => {
     const [activeTab, setActiveTab] = useState(ACTIVITY_TAB_INDEX);
     const [activeChip, setActiveChip] = useState<ActivityFilter>("all");
     const followRequestsRef = useRef<{ refresh: () => Promise<void> }>(null);
-    const { feed: forYouFeed, loading: forYouLoading, error: forYouError, refresh: refreshForYou } = useForYou();
+    const { feed: forYouFeed, loading: forYouLoading, error: forYouError, refresh: refreshForYou, recordInteraction: recordForYouInteraction } = useForYou();
     const forYouUnreadCount = forYouFeed?.unreadCount ?? 0;
     const tabBadges = [activeTab !== 0 && forYouUnreadCount > 0, false, false];
 
@@ -555,6 +555,7 @@ const Notifications = () => {
                     loading={forYouLoading}
                     error={forYouError}
                     refresh={refreshForYou}
+                    onInteraction={recordForYouInteraction}
                 />
                 <View style={{ flex: 1 }}>{activityTabContent}</View>
                 <TabPlaceholder label="Requests — coming soon" ThemedColor={ThemedColor} />

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -1,4 +1,4 @@
-import { Dimensions, StyleSheet, View, SectionList, TouchableOpacity, ActivityIndicator, Animated, InteractionManager, RefreshControl } from "react-native";
+import { Dimensions, StyleSheet, View, SectionList, TouchableOpacity, ActivityIndicator, Animated, InteractionManager, RefreshControl, ScrollView } from "react-native";
 import React, { useState, useEffect, useRef, useCallback } from "react";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
@@ -15,10 +15,16 @@ import { FollowRequestsSection } from "@/components/profile/FollowRequestsSectio
 import { useFocusEffect } from "@react-navigation/native";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
+import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
+import ForYouTab from "@/components/forYou/ForYouTab";
+import { useForYou } from "@/hooks/useForYou";
 
 const ONE_DAY = 24 * 60 * 60 * 1000;
 const ONE_WEEK = 7 * ONE_DAY;
 const ONE_MONTH = 30 * ONE_DAY;
+
+const NOTIFICATION_TABS = ["For You", "Activity", "Requests"];
+const ACTIVITY_TAB_INDEX = 1;
 
 type ProcessedNotification = {
     id: string;
@@ -34,6 +40,79 @@ type ProcessedNotification = {
     referenceId: string; // Post ID or Task ID that the notification references
     thumbnail?: string; // Optional thumbnail for friend notifications
 };
+
+type ActivityFilter = "all" | "encouragements" | "comments" | "social";
+
+const FILTER_CHIPS: { id: ActivityFilter; label: string }[] = [
+    { id: "all", label: "All" },
+    { id: "encouragements", label: "Encouragements" },
+    { id: "comments", label: "Comments" },
+    { id: "social", label: "Social" },
+];
+
+const filterByActivityType = (
+    notifications: ProcessedNotification[],
+    filter: ActivityFilter,
+): ProcessedNotification[] => {
+    switch (filter) {
+        case "all":
+            return notifications;
+        case "encouragements":
+            return notifications.filter((n) => n.type === "encouragement" || n.type === "congratulation");
+        case "comments":
+            return notifications.filter((n) => n.type === "comment");
+        case "social":
+            return notifications.filter((n) => n.type === "friend_request" || n.type === "friend_request_accepted");
+    }
+};
+
+const NotificationFilterChips = ({
+    active,
+    onChange,
+    ThemedColor,
+}: {
+    active: ActivityFilter;
+    onChange: (id: ActivityFilter) => void;
+    ThemedColor: any;
+}) => {
+    return (
+        <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={chipStyles.row}>
+            {FILTER_CHIPS.map((chip) => {
+                const isActive = active === chip.id;
+                return (
+                    <TouchableOpacity
+                        key={chip.id}
+                        onPress={() => onChange(chip.id)}
+                        activeOpacity={0.7}
+                        style={[
+                            chipStyles.chip,
+                            {
+                                backgroundColor: isActive ? ThemedColor.primary : "transparent",
+                                borderColor: isActive ? ThemedColor.primary : ThemedColor.tertiary,
+                            },
+                        ]}>
+                        <ThemedText
+                            style={[
+                                chipStyles.chipText,
+                                { color: isActive ? "#fff" : ThemedColor.text },
+                            ]}>
+                            {chip.label}
+                        </ThemedText>
+                    </TouchableOpacity>
+                );
+            })}
+        </ScrollView>
+    );
+};
+
+const TabPlaceholder = ({ label, ThemedColor }: { label: string; ThemedColor: any }) => (
+    <View style={placeholderStyles.container}>
+        <ThemedText style={{ color: ThemedColor.caption }}>{label}</ThemedText>
+    </View>
+);
 
 // Skeleton Component
 const NotificationsSkeleton = ({ ThemedColor }: { ThemedColor: any }) => {
@@ -236,7 +315,12 @@ const Notifications = () => {
     const { capture } = useAnalytics();
     const [ready, setReady] = useState(false);
     const [refreshing, setRefreshing] = useState(false);
+    const [activeTab, setActiveTab] = useState(ACTIVITY_TAB_INDEX);
+    const [activeChip, setActiveChip] = useState<ActivityFilter>("all");
     const followRequestsRef = useRef<{ refresh: () => Promise<void> }>(null);
+    const { feed: forYouFeed, loading: forYouLoading, error: forYouError, refresh: refreshForYou } = useForYou();
+    const forYouUnreadCount = forYouFeed?.unreadCount ?? 0;
+    const tabBadges = [activeTab !== 0 && forYouUnreadCount > 0, false, false];
 
     const onRefresh = useCallback(async () => {
         setRefreshing(true);
@@ -351,7 +435,8 @@ const Notifications = () => {
     };
 
     // Convert raw notifications to processed notifications
-    const notifications = rawNotifications.map(processNotification).filter((n): n is ProcessedNotification => n !== null);
+    const allNotifications = rawNotifications.map(processNotification).filter((n): n is ProcessedNotification => n !== null);
+    const notifications = filterByActivityType(allNotifications, activeChip);
 
     // Helper function to filter notifications by time period
     const filterByTimePeriod = (
@@ -374,63 +459,106 @@ const Notifications = () => {
         { title: "Older", data: olderNotifications },
     ].filter((s) => s.data.length > 0);
 
+    const activityHeader = (
+        <>
+            <NotificationFilterChips active={activeChip} onChange={setActiveChip} ThemedColor={ThemedColor} />
+            {activeChip === "all" && (
+                <FollowRequestsSection ref={followRequestsRef} styles={styles} maxVisible={4} />
+            )}
+        </>
+    );
+
+    const activityTabContent = !ready || loading ? (
+        <View style={styles.scrollViewContent}>
+            <NotificationsSkeleton ThemedColor={ThemedColor} />
+        </View>
+    ) : error ? (
+        <View style={[styles.scrollViewContent, styles.section]}>
+            <ThemedText style={{ textAlign: "center", color: "red" }}>{error}</ThemedText>
+            <TouchableOpacity
+                onPress={() => refreshNotifications()}
+                style={{ marginTop: 16, alignItems: "center" }}>
+                <ThemedText style={{ color: ThemedColor.text }}>Tap to retry</ThemedText>
+            </TouchableOpacity>
+        </View>
+    ) : allNotifications.length === 0 ? (
+        <View style={[styles.scrollViewContent, styles.section]}>
+            <ThemedText style={{ textAlign: "center" }}>No notifications yet</ThemedText>
+        </View>
+    ) : (
+        <SectionList
+            sections={sections}
+            keyExtractor={(item, index) => `${item.type}-${item.id}-${index}`}
+            renderItem={({ item, index }) => (
+                <NotificationItem
+                    notification={item}
+                    index={index}
+                    styles={styles}
+                    onNotificationPress={handleNotificationPress}
+                />
+            )}
+            renderSectionHeader={({ section: { title } }) => (
+                <View style={styles.sectionHeader}>
+                    <ThemedText type="defaultSemiBold">{title}</ThemedText>
+                </View>
+            )}
+            ListHeaderComponent={activityHeader}
+            ListEmptyComponent={
+                <View style={styles.emptyFilterState}>
+                    <ThemedText style={{ color: ThemedColor.caption, textAlign: "center" }}>
+                        No notifications match this filter
+                    </ThemedText>
+                </View>
+            }
+            contentContainerStyle={styles.scrollViewContent}
+            stickySectionHeadersEnabled={false}
+            initialNumToRender={10}
+            maxToRenderPerBatch={10}
+            windowSize={5}
+            refreshControl={
+                <RefreshControl
+                    refreshing={refreshing}
+                    onRefresh={onRefresh}
+                    tintColor={ThemedColor.text}
+                />
+            }
+        />
+    );
+
     return (
         <ThemedView style={styles.container}>
             <View style={styles.headerContainer}>
-                <TouchableOpacity onPress={() => router.back()}>
+                <TouchableOpacity onPress={() => router.back()} style={styles.headerSide}>
                     <Ionicons name="chevron-back" size={24} color={ThemedColor.text} />
                 </TouchableOpacity>
-                <ThemedText type="subtitle">Notifications</ThemedText>
+                <ThemedText type="subtitle" style={styles.headerTitle}>Notifications</ThemedText>
+                <TouchableOpacity
+                    onPress={() => router.push("/(logged-in)/(tabs)/(profile)/settings")}
+                    style={[styles.headerSide, styles.headerSideRight]}
+                    accessibilityRole="button"
+                    accessibilityLabel="Notification settings">
+                    <Ionicons name="settings-outline" size={24} color={ThemedColor.text} />
+                </TouchableOpacity>
             </View>
-            {!ready || loading ? (
-                <View style={styles.scrollViewContent}>
-                    <NotificationsSkeleton ThemedColor={ThemedColor} />
-                </View>
-            ) : error ? (
-                <View style={[styles.scrollViewContent, styles.section]}>
-                    <ThemedText style={{ textAlign: "center", color: "red" }}>{error}</ThemedText>
-                    <TouchableOpacity
-                        onPress={() => refreshNotifications()}
-                        style={{ marginTop: 16, alignItems: "center" }}>
-                        <ThemedText style={{ color: ThemedColor.text }}>Tap to retry</ThemedText>
-                    </TouchableOpacity>
-                </View>
-            ) : notifications.length === 0 ? (
-                <View style={[styles.scrollViewContent, styles.section]}>
-                    <ThemedText style={{ textAlign: "center" }}>No notifications yet</ThemedText>
-                </View>
-            ) : (
-                <SectionList
-                    sections={sections}
-                    keyExtractor={(item, index) => `${item.type}-${item.id}-${index}`}
-                    renderItem={({ item, index }) => (
-                        <NotificationItem
-                            notification={item}
-                            index={index}
-                            styles={styles}
-                            onNotificationPress={handleNotificationPress}
-                        />
-                    )}
-                    renderSectionHeader={({ section: { title } }) => (
-                        <View style={styles.sectionHeader}>
-                            <ThemedText type="defaultSemiBold">{title}</ThemedText>
-                        </View>
-                    )}
-                    ListHeaderComponent={<FollowRequestsSection ref={followRequestsRef} styles={styles} maxVisible={4} />}
-                    contentContainerStyle={styles.scrollViewContent}
-                    stickySectionHeadersEnabled={false}
-                    initialNumToRender={10}
-                    maxToRenderPerBatch={10}
-                    windowSize={5}
-                    refreshControl={
-                        <RefreshControl
-                            refreshing={refreshing}
-                            onRefresh={onRefresh}
-                            tintColor={ThemedColor.text}
-                        />
-                    }
+            <View style={styles.tabsWrapper}>
+                <AnimatedTabs
+                    tabs={NOTIFICATION_TABS}
+                    activeTab={activeTab}
+                    setActiveTab={setActiveTab}
+                    badges={tabBadges}
                 />
-            )}
+            </View>
+            <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab} flex lazy>
+                <ForYouTab
+                    horizontalPadding={Dimensions.get("window").width * 0.05}
+                    feed={forYouFeed}
+                    loading={forYouLoading}
+                    error={forYouError}
+                    refresh={refreshForYou}
+                />
+                <View style={{ flex: 1 }}>{activityTabContent}</View>
+                <TabPlaceholder label="Requests — coming soon" ThemedColor={ThemedColor} />
+            </AnimatedTabContent>
         </ThemedView>
     );
 };
@@ -446,10 +574,25 @@ const stylesheet = (ThemedColor: any) => {
             flexDirection: "row",
             alignItems: "center",
             paddingHorizontal: PADDING_HORIZTONAL,
-            paddingVertical: 32,
+            paddingVertical: 20,
+        },
+        headerSide: {
+            width: 32,
+            justifyContent: "center",
+        },
+        headerSideRight: {
+            alignItems: "flex-end",
+        },
+        headerTitle: {
+            flex: 1,
+            textAlign: "center",
+        },
+        tabsWrapper: {
+            paddingHorizontal: PADDING_HORIZTONAL,
         },
         scrollViewContent: {
             paddingHorizontal: PADDING_HORIZTONAL,
+            paddingTop: 16,
         },
         section: {
             marginBottom: 16,
@@ -461,8 +604,38 @@ const stylesheet = (ThemedColor: any) => {
             marginBottom: 4,
             marginTop: 12,
         },
+        emptyFilterState: {
+            paddingVertical: 32,
+        },
     });
 };
+
+const chipStyles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        gap: 8,
+        paddingVertical: 4,
+    },
+    chip: {
+        paddingHorizontal: 16,
+        paddingVertical: 8,
+        borderRadius: 999,
+        borderWidth: 1,
+    },
+    chipText: {
+        fontSize: 14,
+        fontFamily: "Outfit",
+    },
+});
+
+const placeholderStyles = StyleSheet.create({
+    container: {
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+        paddingHorizontal: 24,
+    },
+});
 
 // Skeleton Styles
 const skeletonStyles = StyleSheet.create({

--- a/frontend/components/forYou/ForYouCard.tsx
+++ b/frontend/components/forYou/ForYouCard.tsx
@@ -4,12 +4,12 @@ import { router } from "expo-router";
 import Ionicons from "@expo/vector-icons/Ionicons";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import type { ForYouCard as ForYouCardModel, ForYouCtaAction, ForYouIconKind } from "@/api/forYou";
+import type { ForYouCard as ForYouCardModel, ForYouCardType, ForYouCtaAction, ForYouIconKind } from "@/api/forYou";
 import { ForYouCtaRow } from "./ForYouCta";
 
 type Props = {
     card: ForYouCardModel;
-    onAction?: (action: ForYouCtaAction) => void;
+    onAction?: (action: ForYouCtaAction, cardType: ForYouCardType) => void;
 };
 
 const ICON_FOR_KIND: Record<ForYouIconKind, keyof typeof Ionicons.glyphMap> = {
@@ -25,8 +25,16 @@ export default function ForYouCard({ card, onAction }: Props) {
     const ThemedColor = useThemeColor();
     const styles = stylesheet(ThemedColor);
 
+    const dispatchAction = (action: ForYouCtaAction) => {
+        if (onAction) {
+            onAction(action, card.type);
+        } else if (action.type === "navigate" && action.href) {
+            router.push(action.href as never);
+        }
+    };
+
     const handleCardPress = () => {
-        router.push(card.deepLink as never);
+        dispatchAction({ type: "navigate", href: card.deepLink });
     };
 
     const iconName = ICON_FOR_KIND[card.iconKind];
@@ -43,21 +51,20 @@ export default function ForYouCard({ card, onAction }: Props) {
                 <View style={[styles.iconCircle, { backgroundColor: ThemedColor.primary + "20" }]}>
                     <Ionicons name={iconName} size={18} color={ThemedColor.primary} />
                 </View>
-                <ThemedText style={styles.compactTitle} numberOfLines={1}>
+                <ThemedText type="defaultSemiBold" style={styles.compactTitle} numberOfLines={1}>
                     {card.title}
                 </ThemedText>
                 {inlineCta ? (
                     <TouchableOpacity
                         onPress={(e) => {
                             e.stopPropagation();
-                            if (onAction) onAction(inlineCta.action);
-                            else if (inlineCta.action.type === "navigate") {
-                                router.push(inlineCta.action.href as never);
-                            }
+                            dispatchAction(inlineCta.action);
                         }}
                         style={[styles.compactCta, { backgroundColor: ThemedColor.primary }]}
                         accessibilityRole="button">
-                        <ThemedText style={styles.compactCtaLabel}>{inlineCta.label}</ThemedText>
+                        <ThemedText type="defaultSemiBold" style={styles.compactCtaLabel}>
+                            {inlineCta.label}
+                        </ThemedText>
                     </TouchableOpacity>
                 ) : null}
                 <Ionicons name="chevron-forward" size={18} color={ThemedColor.caption} />
@@ -65,7 +72,6 @@ export default function ForYouCard({ card, onAction }: Props) {
         );
     }
 
-    // Full layout
     return (
         <TouchableOpacity
             onPress={handleCardPress}
@@ -78,15 +84,11 @@ export default function ForYouCard({ card, onAction }: Props) {
                     <Ionicons name={iconName} size={20} color={ThemedColor.primary} />
                 </View>
                 <View style={styles.fullTextBlock}>
-                    <ThemedText style={styles.fullTitle}>{card.title}</ThemedText>
-                    {card.body ? (
-                        <ThemedText style={[styles.fullBody, { color: ThemedColor.caption }]}>
-                            {card.body}
-                        </ThemedText>
-                    ) : null}
+                    <ThemedText type="defaultSemiBold">{card.title}</ThemedText>
+                    {card.body ? <ThemedText type="caption">{card.body}</ThemedText> : null}
                 </View>
             </View>
-            <ForYouCtaRow ctas={card.ctas} onAction={onAction} />
+            <ForYouCtaRow ctas={card.ctas} onAction={dispatchAction} />
         </TouchableOpacity>
     );
 }
@@ -111,9 +113,6 @@ const stylesheet = (ThemedColor: any) =>
         },
         compactTitle: {
             flex: 1,
-            fontSize: 14,
-            fontFamily: "Outfit",
-            fontWeight: "500",
         },
         compactCta: {
             paddingHorizontal: 12,
@@ -122,9 +121,7 @@ const stylesheet = (ThemedColor: any) =>
         },
         compactCtaLabel: {
             color: "#fff",
-            fontSize: 12,
-            fontFamily: "Outfit",
-            fontWeight: "500",
+            fontSize: 13,
         },
         fullContainer: {
             padding: 16,
@@ -141,15 +138,5 @@ const stylesheet = (ThemedColor: any) =>
         fullTextBlock: {
             flex: 1,
             gap: 4,
-        },
-        fullTitle: {
-            fontSize: 16,
-            fontFamily: "Outfit",
-            fontWeight: "600",
-        },
-        fullBody: {
-            fontSize: 14,
-            fontFamily: "Outfit",
-            lineHeight: 19,
         },
     });

--- a/frontend/components/forYou/ForYouCard.tsx
+++ b/frontend/components/forYou/ForYouCard.tsx
@@ -1,0 +1,155 @@
+import React from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+import { router } from "expo-router";
+import Ionicons from "@expo/vector-icons/Ionicons";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { ForYouCard as ForYouCardModel, ForYouCtaAction, ForYouIconKind } from "@/api/forYou";
+import { ForYouCtaRow } from "./ForYouCta";
+
+type Props = {
+    card: ForYouCardModel;
+    onAction?: (action: ForYouCtaAction) => void;
+};
+
+const ICON_FOR_KIND: Record<ForYouIconKind, keyof typeof Ionicons.glyphMap> = {
+    kudos: "trophy",
+    users: "people",
+    ring: "ellipse",
+    post: "create",
+    comment: "chatbubble",
+    blueprint: "grid",
+};
+
+export default function ForYouCard({ card, onAction }: Props) {
+    const ThemedColor = useThemeColor();
+    const styles = stylesheet(ThemedColor);
+
+    const handleCardPress = () => {
+        router.push(card.deepLink as never);
+    };
+
+    const iconName = ICON_FOR_KIND[card.iconKind];
+
+    if (card.displayMode === "compact") {
+        const inlineCta = card.ctas[0];
+        return (
+            <TouchableOpacity
+                onPress={handleCardPress}
+                activeOpacity={0.7}
+                style={styles.compactContainer}
+                accessibilityRole="button"
+                accessibilityLabel={card.title}>
+                <View style={[styles.iconCircle, { backgroundColor: ThemedColor.primary + "20" }]}>
+                    <Ionicons name={iconName} size={18} color={ThemedColor.primary} />
+                </View>
+                <ThemedText style={styles.compactTitle} numberOfLines={1}>
+                    {card.title}
+                </ThemedText>
+                {inlineCta ? (
+                    <TouchableOpacity
+                        onPress={(e) => {
+                            e.stopPropagation();
+                            if (onAction) onAction(inlineCta.action);
+                            else if (inlineCta.action.type === "navigate") {
+                                router.push(inlineCta.action.href as never);
+                            }
+                        }}
+                        style={[styles.compactCta, { backgroundColor: ThemedColor.primary }]}
+                        accessibilityRole="button">
+                        <ThemedText style={styles.compactCtaLabel}>{inlineCta.label}</ThemedText>
+                    </TouchableOpacity>
+                ) : null}
+                <Ionicons name="chevron-forward" size={18} color={ThemedColor.caption} />
+            </TouchableOpacity>
+        );
+    }
+
+    // Full layout
+    return (
+        <TouchableOpacity
+            onPress={handleCardPress}
+            activeOpacity={0.8}
+            style={styles.fullContainer}
+            accessibilityRole="button"
+            accessibilityLabel={card.title}>
+            <View style={styles.fullHeader}>
+                <View style={[styles.iconCircle, { backgroundColor: ThemedColor.primary + "20" }]}>
+                    <Ionicons name={iconName} size={20} color={ThemedColor.primary} />
+                </View>
+                <View style={styles.fullTextBlock}>
+                    <ThemedText style={styles.fullTitle}>{card.title}</ThemedText>
+                    {card.body ? (
+                        <ThemedText style={[styles.fullBody, { color: ThemedColor.caption }]}>
+                            {card.body}
+                        </ThemedText>
+                    ) : null}
+                </View>
+            </View>
+            <ForYouCtaRow ctas={card.ctas} onAction={onAction} />
+        </TouchableOpacity>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        iconCircle: {
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        compactContainer: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 12,
+            paddingVertical: 12,
+            paddingHorizontal: 14,
+            borderRadius: 12,
+            backgroundColor: ThemedColor.lightened,
+        },
+        compactTitle: {
+            flex: 1,
+            fontSize: 14,
+            fontFamily: "Outfit",
+            fontWeight: "500",
+        },
+        compactCta: {
+            paddingHorizontal: 12,
+            paddingVertical: 6,
+            borderRadius: 999,
+        },
+        compactCtaLabel: {
+            color: "#fff",
+            fontSize: 12,
+            fontFamily: "Outfit",
+            fontWeight: "500",
+        },
+        fullContainer: {
+            padding: 16,
+            borderRadius: 14,
+            backgroundColor: ThemedColor.lightened,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+        },
+        fullHeader: {
+            flexDirection: "row",
+            gap: 12,
+            alignItems: "flex-start",
+        },
+        fullTextBlock: {
+            flex: 1,
+            gap: 4,
+        },
+        fullTitle: {
+            fontSize: 16,
+            fontFamily: "Outfit",
+            fontWeight: "600",
+        },
+        fullBody: {
+            fontSize: 14,
+            fontFamily: "Outfit",
+            lineHeight: 19,
+        },
+    });

--- a/frontend/components/forYou/ForYouCta.tsx
+++ b/frontend/components/forYou/ForYouCta.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { TouchableOpacity, StyleSheet, View } from "react-native";
+import { router } from "expo-router";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { ForYouCta as ForYouCtaModel, ForYouCtaAction } from "@/api/forYou";
+
+type Props = {
+    cta: ForYouCtaModel;
+    onAction?: (action: ForYouCtaAction) => void;
+};
+
+export default function ForYouCta({ cta, onAction }: Props) {
+    const ThemedColor = useThemeColor();
+
+    const handlePress = () => {
+        if (onAction) {
+            onAction(cta.action);
+            return;
+        }
+        // Default behavior — Phase 1 only navigation is fully wired;
+        // other action types fall through to console + deeplink navigation handled by the card.
+        if (cta.action.type === "navigate") {
+            router.push(cta.action.href as never);
+        } else {
+            console.log("[ForYouCta] stub action:", cta.action);
+        }
+    };
+
+    const isPrimary = cta.kind === "primary";
+    const bg = isPrimary ? ThemedColor.primary : "transparent";
+    const borderColor = isPrimary ? ThemedColor.primary : ThemedColor.tertiary;
+    const textColor = isPrimary ? "#fff" : ThemedColor.primary;
+
+    return (
+        <TouchableOpacity
+            onPress={handlePress}
+            activeOpacity={0.8}
+            style={[
+                styles.button,
+                isPrimary ? styles.buttonPrimary : styles.buttonSecondary,
+                { backgroundColor: bg, borderColor },
+            ]}
+            accessibilityRole="button">
+            <ThemedText style={[styles.label, { color: textColor }]}>{cta.label}</ThemedText>
+        </TouchableOpacity>
+    );
+}
+
+export function ForYouCtaRow({
+    ctas,
+    onAction,
+}: {
+    ctas: ForYouCtaModel[];
+    onAction?: (action: ForYouCtaAction) => void;
+}) {
+    if (ctas.length === 0) return null;
+    return (
+        <View style={styles.row}>
+            {ctas.map((cta, i) => (
+                <View key={`${cta.label}-${i}`} style={styles.cell}>
+                    <ForYouCta cta={cta} onAction={onAction} />
+                </View>
+            ))}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    button: {
+        paddingVertical: 10,
+        paddingHorizontal: 16,
+        borderRadius: 10,
+        borderWidth: 1,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    buttonPrimary: {},
+    buttonSecondary: {},
+    label: {
+        fontFamily: "Outfit",
+        fontWeight: "500",
+        fontSize: 14,
+    },
+    row: {
+        flexDirection: "row",
+        gap: 8,
+        marginTop: 12,
+    },
+    cell: {
+        flex: 1,
+    },
+});

--- a/frontend/components/forYou/ForYouCta.tsx
+++ b/frontend/components/forYou/ForYouCta.tsx
@@ -18,8 +18,6 @@ export default function ForYouCta({ cta, onAction }: Props) {
             onAction(cta.action);
             return;
         }
-        // Default behavior — Phase 1 only navigation is fully wired;
-        // other action types fall through to console + deeplink navigation handled by the card.
         if (cta.action.type === "navigate") {
             router.push(cta.action.href as never);
         } else {
@@ -36,13 +34,11 @@ export default function ForYouCta({ cta, onAction }: Props) {
         <TouchableOpacity
             onPress={handlePress}
             activeOpacity={0.8}
-            style={[
-                styles.button,
-                isPrimary ? styles.buttonPrimary : styles.buttonSecondary,
-                { backgroundColor: bg, borderColor },
-            ]}
+            style={[styles.button, { backgroundColor: bg, borderColor }]}
             accessibilityRole="button">
-            <ThemedText style={[styles.label, { color: textColor }]}>{cta.label}</ThemedText>
+            <ThemedText type="defaultSemiBold" style={{ color: textColor, fontSize: 14 }}>
+                {cta.label}
+            </ThemedText>
         </TouchableOpacity>
     );
 }
@@ -74,13 +70,6 @@ const styles = StyleSheet.create({
         borderWidth: 1,
         alignItems: "center",
         justifyContent: "center",
-    },
-    buttonPrimary: {},
-    buttonSecondary: {},
-    label: {
-        fontFamily: "Outfit",
-        fontWeight: "500",
-        fontSize: 14,
     },
     row: {
         flexDirection: "row",

--- a/frontend/components/forYou/ForYouSection.tsx
+++ b/frontend/components/forYou/ForYouSection.tsx
@@ -2,12 +2,12 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import type { ForYouCtaAction, ForYouSection as ForYouSectionModel } from "@/api/forYou";
+import type { ForYouCardType, ForYouCtaAction, ForYouSection as ForYouSectionModel } from "@/api/forYou";
 import ForYouCard from "./ForYouCard";
 
 type Props = {
     section: ForYouSectionModel;
-    onAction?: (action: ForYouCtaAction) => void;
+    onAction?: (action: ForYouCtaAction, cardType: ForYouCardType) => void;
 };
 
 export default function ForYouSection({ section, onAction }: Props) {
@@ -48,7 +48,6 @@ const styles = StyleSheet.create({
     },
     heading: {
         marginBottom: 12,
-        fontSize: 16,
     },
     cardList: {
         gap: 10,

--- a/frontend/components/forYou/ForYouSection.tsx
+++ b/frontend/components/forYou/ForYouSection.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { ForYouCtaAction, ForYouSection as ForYouSectionModel } from "@/api/forYou";
+import ForYouCard from "./ForYouCard";
+
+type Props = {
+    section: ForYouSectionModel;
+    onAction?: (action: ForYouCtaAction) => void;
+};
+
+export default function ForYouSection({ section, onAction }: Props) {
+    const ThemedColor = useThemeColor();
+    const isEmpty = section.cards.length === 0;
+
+    return (
+        <View style={styles.container}>
+            <ThemedText type="defaultSemiBold" style={styles.heading}>
+                {section.title}
+            </ThemedText>
+            {isEmpty ? (
+                <View
+                    style={[
+                        styles.emptyState,
+                        { backgroundColor: ThemedColor.tertiary + "30" },
+                    ]}>
+                    <ThemedText style={{ color: ThemedColor.caption }}>
+                        {section.id === "catch_up"
+                            ? "You're all caught up \u{1F44B}"
+                            : "Nothing suggested right now."}
+                    </ThemedText>
+                </View>
+            ) : (
+                <View style={styles.cardList}>
+                    {section.cards.map((card) => (
+                        <ForYouCard key={card.id} card={card} onAction={onAction} />
+                    ))}
+                </View>
+            )}
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        marginTop: 20,
+    },
+    heading: {
+        marginBottom: 12,
+        fontSize: 16,
+    },
+    cardList: {
+        gap: 10,
+    },
+    emptyState: {
+        paddingVertical: 20,
+        paddingHorizontal: 16,
+        borderRadius: 12,
+        alignItems: "center",
+    },
+});

--- a/frontend/components/forYou/ForYouTab.tsx
+++ b/frontend/components/forYou/ForYouTab.tsx
@@ -1,0 +1,89 @@
+import React, { useCallback } from "react";
+import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { ForYouCtaAction, ForYouFeed } from "@/api/forYou";
+import { router } from "expo-router";
+import ForYouSection from "./ForYouSection";
+
+type Props = {
+    horizontalPadding: number;
+    feed: ForYouFeed | null;
+    loading: boolean;
+    error: string | null;
+    refresh: () => Promise<void>;
+};
+
+export default function ForYouTab({ horizontalPadding, feed, loading, error, refresh }: Props) {
+    const ThemedColor = useThemeColor();
+    const [refreshing, setRefreshing] = React.useState(false);
+
+    const onRefresh = useCallback(async () => {
+        setRefreshing(true);
+        await refresh();
+        setRefreshing(false);
+    }, [refresh]);
+
+    const handleAction = useCallback((action: ForYouCtaAction) => {
+        // Phase 1: only `navigate` is wired end-to-end. Other action types
+        // log and fall back to a sensible navigation target so the user lands somewhere.
+        // Phase 3 will wire send_kudos / send_encouragement / react inline.
+        switch (action.type) {
+            case "navigate":
+                router.push(action.href as never);
+                return;
+            case "send_kudos":
+            case "send_encouragement":
+                router.push("/(logged-in)/(tabs)/(task)/kudos" as never);
+                return;
+            case "react":
+                router.push(`/(logged-in)/posting/${action.postId}` as never);
+                return;
+        }
+    }, []);
+
+    if (loading && !feed) {
+        return (
+            <View style={[styles.center, { paddingHorizontal: horizontalPadding }]}>
+                <ActivityIndicator color={ThemedColor.text} />
+            </View>
+        );
+    }
+
+    if (error) {
+        return (
+            <View style={[styles.center, { paddingHorizontal: horizontalPadding }]}>
+                <ThemedText style={{ color: "red", textAlign: "center" }}>{error}</ThemedText>
+                <TouchableOpacity onPress={refresh} style={{ marginTop: 16 }}>
+                    <ThemedText style={{ color: ThemedColor.text }}>Tap to retry</ThemedText>
+                </TouchableOpacity>
+            </View>
+        );
+    }
+
+    if (!feed) return null;
+
+    return (
+        <ScrollView
+            contentContainerStyle={[styles.scrollContent, { paddingHorizontal: horizontalPadding }]}
+            refreshControl={
+                <RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={ThemedColor.text} />
+            }>
+            {feed.sections.map((section) => (
+                <ForYouSection key={section.id} section={section} onAction={handleAction} />
+            ))}
+            <View style={{ height: 40 }} />
+        </ScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    center: {
+        flex: 1,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    scrollContent: {
+        paddingBottom: 16,
+    },
+});

--- a/frontend/components/forYou/ForYouTab.tsx
+++ b/frontend/components/forYou/ForYouTab.tsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { ActivityIndicator, RefreshControl, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import type { ForYouCtaAction, ForYouFeed } from "@/api/forYou";
+import type { ForYouCardType, ForYouCtaAction, ForYouFeed } from "@/api/forYou";
 import { router } from "expo-router";
 import ForYouSection from "./ForYouSection";
 
@@ -12,9 +12,10 @@ type Props = {
     loading: boolean;
     error: string | null;
     refresh: () => Promise<void>;
+    onInteraction?: (cardType: ForYouCardType) => void;
 };
 
-export default function ForYouTab({ horizontalPadding, feed, loading, error, refresh }: Props) {
+export default function ForYouTab({ horizontalPadding, feed, loading, error, refresh, onInteraction }: Props) {
     const ThemedColor = useThemeColor();
     const [refreshing, setRefreshing] = React.useState(false);
 
@@ -24,23 +25,27 @@ export default function ForYouTab({ horizontalPadding, feed, loading, error, ref
         setRefreshing(false);
     }, [refresh]);
 
-    const handleAction = useCallback((action: ForYouCtaAction) => {
-        // Phase 1: only `navigate` is wired end-to-end. Other action types
-        // log and fall back to a sensible navigation target so the user lands somewhere.
-        // Phase 3 will wire send_kudos / send_encouragement / react inline.
-        switch (action.type) {
-            case "navigate":
-                router.push(action.href as never);
-                return;
-            case "send_kudos":
-            case "send_encouragement":
-                router.push("/(logged-in)/(tabs)/(task)/kudos" as never);
-                return;
-            case "react":
-                router.push(`/(logged-in)/posting/${action.postId}` as never);
-                return;
-        }
-    }, []);
+    const handleAction = useCallback(
+        (action: ForYouCtaAction, cardType: ForYouCardType) => {
+            onInteraction?.(cardType);
+            // Phase 2 only fully wires `navigate`. Other action types fall through to a
+            // sensible navigation target so the user lands somewhere; inline CTA execution
+            // (send kudos / react) lands in Phase 3.
+            switch (action.type) {
+                case "navigate":
+                    if (action.href) router.push(action.href as never);
+                    return;
+                case "send_kudos":
+                case "send_encouragement":
+                    router.push("/(logged-in)/(tabs)/(task)/kudos" as never);
+                    return;
+                case "react":
+                    if (action.postId) router.push(`/(logged-in)/posting/${action.postId}` as never);
+                    return;
+            }
+        },
+        [onInteraction],
+    );
 
     if (loading && !feed) {
         return (

--- a/frontend/components/inputs/AnimatedTabs.tsx
+++ b/frontend/components/inputs/AnimatedTabs.tsx
@@ -20,9 +20,11 @@ type AnimatedTabBarProps = {
     tabs: string[];
     activeTab: number;
     setActiveTab: (index: number) => void;
+    /** When provided, shows a small dot next to the tab label at indices where badges[i] is true. */
+    badges?: boolean[];
 };
 
-export default function AnimatedTabs({ tabs, activeTab, setActiveTab }: AnimatedTabBarProps) {
+export default function AnimatedTabs({ tabs, activeTab, setActiveTab, badges }: AnimatedTabBarProps) {
     const ThemedColor = useThemeColor();
     const indicatorX = useSharedValue(0);
     const indicatorWidth = useSharedValue(0);
@@ -64,16 +66,21 @@ export default function AnimatedTabs({ tabs, activeTab, setActiveTab }: Animated
                     style={styles.tab}
                     onLayout={(e) => handleTabLayout(index, e)}
                     onPress={() => setActiveTab(index)}>
-                    <ThemedText
-                        style={[
-                            styles.tabText,
-                            {
-                                color: activeTab === index ? ThemedColor.text : ThemedColor.caption,
-                                fontWeight: activeTab === index ? "600" : "500",
-                            },
-                        ]}>
-                        {tab}
-                    </ThemedText>
+                    <View style={styles.tabLabelRow}>
+                        <ThemedText
+                            style={[
+                                styles.tabText,
+                                {
+                                    color: activeTab === index ? ThemedColor.text : ThemedColor.caption,
+                                    fontWeight: activeTab === index ? "600" : "500",
+                                },
+                            ]}>
+                            {tab}
+                        </ThemedText>
+                        {badges?.[index] ? (
+                            <View style={[styles.badgeDot, { backgroundColor: ThemedColor.primary }]} />
+                        ) : null}
+                    </View>
                 </Pressable>
             ))}
             <Animated.View
@@ -200,10 +207,20 @@ const styles = StyleSheet.create({
         paddingTop: 4,
         alignItems: "center",
     },
+    tabLabelRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 6,
+    },
     tabText: {
         fontSize: 16,
         fontFamily: "Outfit",
         textAlign: "center",
+    },
+    badgeDot: {
+        width: 6,
+        height: 6,
+        borderRadius: 3,
     },
     indicator: {
         position: "absolute",

--- a/frontend/hooks/useForYou.ts
+++ b/frontend/hooks/useForYou.ts
@@ -1,0 +1,151 @@
+import { useEffect, useState, useCallback } from "react";
+import type { ForYouFeed } from "@/api/forYou";
+
+// TODO(backend Phase 2): replace stub with real `GET /for-you` call.
+// Backend contract is documented in docs/superpowers/specs/2026-05-31-for-you-tab-design.md.
+const STUB_FEED: ForYouFeed = {
+    unreadCount: 3,
+    sections: [
+        {
+            id: "catch_up",
+            title: "Catch up",
+            cards: [
+                {
+                    id: "stub-kudos-1",
+                    type: "kudos_received",
+                    displayMode: "full",
+                    iconKind: "kudos",
+                    title: "Sarah sent you a kudos!",
+                    body: "Kudos are a quick way to celebrate friends' wins.",
+                    subject: { userId: "stub-user-sarah", displayName: "Sarah" },
+                    ctas: [
+                        {
+                            label: "Send one back",
+                            kind: "primary",
+                            action: { type: "send_kudos", targetUserId: "stub-user-sarah" },
+                        },
+                        {
+                            label: "Reply",
+                            kind: "secondary",
+                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(task)/kudos" },
+                        },
+                    ],
+                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
+                    priority: 100,
+                },
+                {
+                    id: "stub-reciprocity-1",
+                    type: "reciprocity_encourage",
+                    displayMode: "full",
+                    iconKind: "users",
+                    title: "Mike just finished his morning routine",
+                    body: "Encourage him?",
+                    subject: { userId: "stub-user-mike", displayName: "Mike" },
+                    ctas: [
+                        {
+                            label: "Send encouragement",
+                            kind: "primary",
+                            action: {
+                                type: "send_encouragement",
+                                targetUserId: "stub-user-mike",
+                                taskId: "stub-task-routine",
+                            },
+                        },
+                    ],
+                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
+                    priority: 80,
+                },
+                {
+                    id: "stub-kudos-2",
+                    type: "kudos_received",
+                    displayMode: "compact",
+                    iconKind: "kudos",
+                    title: "Jordan sent you a kudos",
+                    subject: { userId: "stub-user-jordan", displayName: "Jordan" },
+                    ctas: [
+                        {
+                            label: "Send back",
+                            kind: "primary",
+                            action: { type: "send_kudos", targetUserId: "stub-user-jordan" },
+                        },
+                    ],
+                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
+                    priority: 60,
+                },
+            ],
+        },
+        {
+            id: "suggested",
+            title: "Suggested for you",
+            cards: [
+                {
+                    id: "stub-ring-1",
+                    type: "ring_progress",
+                    displayMode: "full",
+                    iconKind: "ring",
+                    title: "One task away from closing today's ring",
+                    body: "Rings track how much of your day you've completed.",
+                    ctas: [
+                        {
+                            label: "Go to today's tasks",
+                            kind: "primary",
+                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(task)/daily" },
+                        },
+                    ],
+                    deepLink: "/(logged-in)/(tabs)/(task)/daily",
+                    priority: 90,
+                },
+                {
+                    id: "stub-post-1",
+                    type: "post_prompt",
+                    displayMode: "full",
+                    iconKind: "post",
+                    title: "Share something with your circle",
+                    body: "Posts let your friends cheer you on.",
+                    ctas: [
+                        {
+                            label: "Share a post",
+                            kind: "primary",
+                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(feed)/feed" },
+                        },
+                    ],
+                    deepLink: "/(logged-in)/(tabs)/(feed)/feed",
+                    priority: 70,
+                },
+            ],
+        },
+    ],
+};
+
+export type UseForYouResult = {
+    feed: ForYouFeed | null;
+    loading: boolean;
+    error: string | null;
+    refresh: () => Promise<void>;
+};
+
+export function useForYou(): UseForYouResult {
+    const [feed, setFeed] = useState<ForYouFeed | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const load = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            // TODO(backend Phase 2): swap for real fetch.
+            await new Promise((r) => setTimeout(r, 150));
+            setFeed(STUB_FEED);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "Failed to load For You");
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    return { feed, loading, error, refresh: load };
+}

--- a/frontend/hooks/useForYou.ts
+++ b/frontend/hooks/useForYou.ts
@@ -1,127 +1,16 @@
 import { useEffect, useState, useCallback } from "react";
-import type { ForYouFeed } from "@/api/forYou";
+import { request } from "@/hooks/useRequest";
+import { createLogger } from "@/utils/logger";
+import type { ForYouFeed, ForYouCardType } from "@/api/forYou";
 
-// TODO(backend Phase 2): replace stub with real `GET /for-you` call.
-// Backend contract is documented in docs/superpowers/specs/2026-05-31-for-you-tab-design.md.
-const STUB_FEED: ForYouFeed = {
-    unreadCount: 3,
-    sections: [
-        {
-            id: "catch_up",
-            title: "Catch up",
-            cards: [
-                {
-                    id: "stub-kudos-1",
-                    type: "kudos_received",
-                    displayMode: "full",
-                    iconKind: "kudos",
-                    title: "Sarah sent you a kudos!",
-                    body: "Kudos are a quick way to celebrate friends' wins.",
-                    subject: { userId: "stub-user-sarah", displayName: "Sarah" },
-                    ctas: [
-                        {
-                            label: "Send one back",
-                            kind: "primary",
-                            action: { type: "send_kudos", targetUserId: "stub-user-sarah" },
-                        },
-                        {
-                            label: "Reply",
-                            kind: "secondary",
-                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(task)/kudos" },
-                        },
-                    ],
-                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
-                    priority: 100,
-                },
-                {
-                    id: "stub-reciprocity-1",
-                    type: "reciprocity_encourage",
-                    displayMode: "full",
-                    iconKind: "users",
-                    title: "Mike just finished his morning routine",
-                    body: "Encourage him?",
-                    subject: { userId: "stub-user-mike", displayName: "Mike" },
-                    ctas: [
-                        {
-                            label: "Send encouragement",
-                            kind: "primary",
-                            action: {
-                                type: "send_encouragement",
-                                targetUserId: "stub-user-mike",
-                                taskId: "stub-task-routine",
-                            },
-                        },
-                    ],
-                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
-                    priority: 80,
-                },
-                {
-                    id: "stub-kudos-2",
-                    type: "kudos_received",
-                    displayMode: "compact",
-                    iconKind: "kudos",
-                    title: "Jordan sent you a kudos",
-                    subject: { userId: "stub-user-jordan", displayName: "Jordan" },
-                    ctas: [
-                        {
-                            label: "Send back",
-                            kind: "primary",
-                            action: { type: "send_kudos", targetUserId: "stub-user-jordan" },
-                        },
-                    ],
-                    deepLink: "/(logged-in)/(tabs)/(task)/kudos",
-                    priority: 60,
-                },
-            ],
-        },
-        {
-            id: "suggested",
-            title: "Suggested for you",
-            cards: [
-                {
-                    id: "stub-ring-1",
-                    type: "ring_progress",
-                    displayMode: "full",
-                    iconKind: "ring",
-                    title: "One task away from closing today's ring",
-                    body: "Rings track how much of your day you've completed.",
-                    ctas: [
-                        {
-                            label: "Go to today's tasks",
-                            kind: "primary",
-                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(task)/daily" },
-                        },
-                    ],
-                    deepLink: "/(logged-in)/(tabs)/(task)/daily",
-                    priority: 90,
-                },
-                {
-                    id: "stub-post-1",
-                    type: "post_prompt",
-                    displayMode: "full",
-                    iconKind: "post",
-                    title: "Share something with your circle",
-                    body: "Posts let your friends cheer you on.",
-                    ctas: [
-                        {
-                            label: "Share a post",
-                            kind: "primary",
-                            action: { type: "navigate", href: "/(logged-in)/(tabs)/(feed)/feed" },
-                        },
-                    ],
-                    deepLink: "/(logged-in)/(tabs)/(feed)/feed",
-                    priority: 70,
-                },
-            ],
-        },
-    ],
-};
+const logger = createLogger("ForYou");
 
 export type UseForYouResult = {
     feed: ForYouFeed | null;
     loading: boolean;
     error: string | null;
     refresh: () => Promise<void>;
+    recordInteraction: (cardType: ForYouCardType) => Promise<void>;
 };
 
 export function useForYou(): UseForYouResult {
@@ -133,13 +22,21 @@ export function useForYou(): UseForYouResult {
         setLoading(true);
         setError(null);
         try {
-            // TODO(backend Phase 2): swap for real fetch.
-            await new Promise((r) => setTimeout(r, 150));
-            setFeed(STUB_FEED);
+            const response = await request("GET", "/user/for-you");
+            setFeed(response as ForYouFeed);
         } catch (e) {
+            logger.error("Failed to load For You feed", e);
             setError(e instanceof Error ? e.message : "Failed to load For You");
         } finally {
             setLoading(false);
+        }
+    }, []);
+
+    const recordInteraction = useCallback(async (cardType: ForYouCardType) => {
+        try {
+            await request("POST", "/user/for-you/interactions", { cardType });
+        } catch (e) {
+            logger.warn("Failed to record For You interaction", e);
         }
     }, []);
 
@@ -147,5 +44,5 @@ export function useForYou(): UseForYouResult {
         load();
     }, [load]);
 
-    return { feed, loading, error, refresh: load };
+    return { feed, loading, error, refresh: load, recordInteraction };
 }

--- a/frontend/hooks/useNotifications.tsx
+++ b/frontend/hooks/useNotifications.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { getNotifications, markNotificationsAsRead, markAllNotificationsAsRead } from '@/api/notifications';
 import type { components } from '@/api/generated/types';
@@ -32,9 +32,14 @@ export const useNotifications = (): UseNotificationsReturn => {
         gcTime: 5 * 60 * 1000, // 5 minutes
     });
 
+    // Exponential backoff up to ~30s, capped at 3 retries. Mutations default to no retries.
+    const retryDelay = (attempt: number) => Math.min(1000 * 2 ** attempt, 30_000);
+
     // Mutation for marking notifications as read
     const markAsReadMutation = useMutation({
         mutationFn: markNotificationsAsRead,
+        retry: 3,
+        retryDelay,
         onSuccess: (_, notificationIds) => {
             // Optimistically update the cache
             queryClient.setQueryData(['notifications'], (oldData: any) => {
@@ -60,6 +65,8 @@ export const useNotifications = (): UseNotificationsReturn => {
     // Mutation for marking all notifications as read
     const markAllAsReadMutation = useMutation({
         mutationFn: markAllNotificationsAsRead,
+        retry: 3,
+        retryDelay,
         onSuccess: () => {
             // Optimistically update the cache
             queryClient.setQueryData(['notifications'], (oldData: any) => {
@@ -76,6 +83,7 @@ export const useNotifications = (): UseNotificationsReturn => {
             });
         },
         onError: (err) => {
+            // Only fires after retries are exhausted; surface to the user once.
             console.error('Failed to mark all notifications as read:', err);
             showToast('Failed to mark all notifications as read', 'danger');
         },
@@ -85,13 +93,21 @@ export const useNotifications = (): UseNotificationsReturn => {
     const unreadCount = notificationsData?.unread_count || 0;
     const error = queryError ? 'Failed to load notifications' : null;
 
+    // `mutate` is stable across renders; capture it in refs so the wrappers we
+    // return don't change identity each render (otherwise consumers that depend
+    // on these in effects re-fire constantly).
+    const markAsReadMutateRef = useRef(markAsReadMutation.mutate);
+    markAsReadMutateRef.current = markAsReadMutation.mutate;
+    const markAllAsReadMutateRef = useRef(markAllAsReadMutation.mutate);
+    markAllAsReadMutateRef.current = markAllAsReadMutation.mutate;
+
     const markAsRead = useCallback((notificationIds: string[]) => {
-        markAsReadMutation.mutate(notificationIds);
-    }, [markAsReadMutation]);
+        markAsReadMutateRef.current(notificationIds);
+    }, []);
 
     const markAllAsRead = useCallback(() => {
-        markAllAsReadMutation.mutate();
-    }, [markAllAsReadMutation]);
+        markAllAsReadMutateRef.current();
+    }, []);
 
     return {
         notifications,


### PR DESCRIPTION
## Summary

Redesigns the Notifications page with a three-tab layout, introduces a personalized **For You** feed end-to-end (frontend + backend), and lands the celebration moment on the onboarding checklist.

**Notifications page**
- New header: back / centered title / settings gear
- Three tabs (For You / Activity / Requests) via the existing `AnimatedTabs`, with a tab-level unread dot
- Activity tab keeps the existing notification list behind a new filter-chip row (All / Encouragements / Comments / Social); chips filter before time-bucketing and `FollowRequestsSection` is hidden when a non-default chip is active
- Requests tab is a placeholder for now (follow-up work)

**For You — backend (`GET /v1/user/for-you`)**
- New handler package `backend/internal/handlers/foryou/` (types, service, handlers, operations, routes)
- Assembles three card types from existing data:
  - `kudos_received` — recent encouragements addressed to the user
  - `ring_progress` — open rings via `RingService.GetOrCreateToday`
  - `post_prompt` — surfaces when the user hasn't posted in the last 24h
- Server-side ranking by priority; client never re-sorts
- Adaptive education: per-(user, card_type) exposure tracked in a new `for_you_exposures` Mongo collection (unique compound index on `(user_id, card_type)`). Cards switch from `full` (with body copy + multi-CTA) to `compact` once `interactions ≥ 2` OR `views ≥ 5`
- `POST /v1/user/for-you/interactions` records CTA taps

**For You — frontend**
- New `components/forYou/` (`ForYouTab`, `ForYouSection`, `ForYouCard`, `ForYouCta`) rendering both `full` and `compact` modes off the server contract in `api/forYou.ts`
- `useForYou` hook handles fetch + refresh + interaction recording
- All typography on `ThemedText` semantic types (`defaultSemiBold`, `caption`) — no hardcoded `fontFamily`/`fontWeight`

**Onboarding checklist — completion celebration**
- When the final checklist item lands, the card holds a "you're all set" moment for ~2.5s with a confetti burst and a success haptic, then fades out — distinct from the per-item toasts so the finish has its own payoff
- New `computeCompletedItems` helper (priority-ordered, no overlap with the visible rotation) + tests
- App version bumped to 1.0.2 / build 99

**Notification spam fix (bonus)**
Root-caused a request-spam loop on the mark-all-as-read flow:
- `useNotifications` returned `markAllAsRead` wrapped in a `useCallback` whose dep was the mutation result object — identity changed every render
- The page's `useFocusEffect` listed it in deps, so each render re-ran the effect's cleanup (resetting the "already marked" ref) and re-fired the request
- A failing endpoint then logged + toasted on every render

Fix: stable refs around `mutate`, drop the unstable dep from the focus effect, guard on `hasUnread` so a fully-read inbox doesn't fire it at all, and add retry+exponential backoff (1s, 2s, 4s, … capped at 30s) to the read mutations so transient failures don't immediately surface.

## Test plan

- [ ] Open Notifications page → header layout matches the mock (back / Notifications / gear)
- [ ] Activity tab is the default; existing list renders with filter chips above it
- [ ] Each chip filters by notification type; `FollowRequestsSection` hides on non-All chips
- [ ] Settings gear navigates to `/(profile)/settings`
- [ ] For You tab loads; cards render in `full` mode for users with low feature exposure and `compact` after threshold
- [ ] Tap a CTA → navigates AND `POST /for-you/interactions` fires (verify in logs)
- [ ] Refresh control reloads the feed
- [ ] Onboarding checklist: complete the last item → confetti + haptic fire, card fades after ~2.5s, no per-item toast on the finishing item
- [ ] Mark-all-as-read no longer spams: with a failing notification endpoint, only one toast appears (after retries exhausted), not one per render
- [ ] Fully-read inbox does not fire mark-all-as-read at all
- [ ] Run the `cmd/db/create_collections` script in non-prod environments so the new `for_you_exposures` collection + index is bootstrapped before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)