### PR TITLE
feat: drag a task between categories (long-hold + drag)

### DIFF
--- a/backend/internal/handlers/task/move_test.go
+++ b/backend/internal/handlers/task/move_test.go
@@ -1,0 +1,135 @@
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/abhikaboy/Kindred/xutils"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type MoveTaskTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+}
+
+func (s *MoveTaskTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+}
+
+func TestMoveTaskService(t *testing.T) {
+	suite.Run(t, new(MoveTaskTestSuite))
+}
+
+func (s *MoveTaskTestSuite) insertCategory(userID primitive.ObjectID, name string, tasks []TaskDocument) primitive.ObjectID {
+	cat := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          name,
+		User:          userID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         tasks,
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, cat)
+	s.NoError(err)
+	return cat.ID
+}
+
+func (s *MoveTaskTestSuite) loadTasks(categoryID primitive.ObjectID) []TaskDocument {
+	var cat types.CategoryDocument
+	err := s.Collections["categories"].FindOne(s.Ctx, bson.M{"_id": categoryID}).Decode(&cat)
+	s.NoError(err)
+	return cat.Tasks
+}
+
+func (s *MoveTaskTestSuite) TestMoveTask_MovesToTopOfTarget() {
+	user := s.GetUser(0)
+	taskID := primitive.NewObjectID()
+	movingTask := TaskDocument{ID: taskID, UserID: user.ID, Content: "Move me", Priority: 1, Active: true, Timestamp: xutils.NowUTC()}
+	existingTarget := TaskDocument{ID: primitive.NewObjectID(), UserID: user.ID, Content: "Already here", Priority: 1, Active: true, Timestamp: xutils.NowUTC()}
+
+	sourceID := s.insertCategory(user.ID, "Source", []TaskDocument{movingTask})
+	movingTask.CategoryID = sourceID
+	targetID := s.insertCategory(user.ID, "Target", []TaskDocument{existingTarget})
+
+	moved, err := s.service.MoveTask(user.ID, sourceID, taskID, targetID)
+	s.NoError(err)
+	s.NotNil(moved)
+	s.Equal(targetID, moved.CategoryID)
+
+	s.Len(s.loadTasks(sourceID), 0)
+
+	targetTasks := s.loadTasks(targetID)
+	s.Len(targetTasks, 2)
+	s.Equal(taskID, targetTasks[0].ID)
+	s.Equal(targetID, targetTasks[0].CategoryID)
+}
+
+func (s *MoveTaskTestSuite) TestMoveTask_RepointsTemplate() {
+	user := s.GetUser(0)
+	templateID := primitive.NewObjectID()
+	taskID := primitive.NewObjectID()
+	movingTask := TaskDocument{ID: taskID, UserID: user.ID, Content: "Recurring", Priority: 1, Active: true, Timestamp: xutils.NowUTC(), TemplateID: &templateID}
+
+	sourceID := s.insertCategory(user.ID, "Source", []TaskDocument{movingTask})
+	targetID := s.insertCategory(user.ID, "Target", []TaskDocument{})
+
+	template := &TemplateTaskDocument{
+		ID: templateID, UserID: user.ID, CategoryID: sourceID,
+		Content: "Recurring", Priority: 1, Value: 5,
+		RecurFrequency: "daily", RecurType: "OCCURRENCE",
+		RecurDetails: &RecurDetails{Every: 1}, LastEdited: xutils.NowUTC(),
+	}
+	_, err := s.Collections["template-tasks"].InsertOne(s.Ctx, template)
+	s.NoError(err)
+
+	_, err = s.service.MoveTask(user.ID, sourceID, taskID, targetID)
+	s.NoError(err)
+
+	var updated TemplateTaskDocument
+	err = s.Collections["template-tasks"].FindOne(s.Ctx, bson.M{"_id": templateID}).Decode(&updated)
+	s.NoError(err)
+	s.Equal(targetID, updated.CategoryID, "template should re-point to the target category")
+}
+
+func (s *MoveTaskTestSuite) TestMoveTask_SameCategoryIsNoop() {
+	user := s.GetUser(0)
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{ID: taskID, UserID: user.ID, Content: "Stay", Priority: 1, Active: true, Timestamp: xutils.NowUTC()}
+	catID := s.insertCategory(user.ID, "Cat", []TaskDocument{task})
+
+	moved, err := s.service.MoveTask(user.ID, catID, taskID, catID)
+	s.NoError(err)
+	s.NotNil(moved)
+	s.Equal(taskID, moved.ID)
+	s.Len(s.loadTasks(catID), 1)
+}
+
+func (s *MoveTaskTestSuite) TestMoveTask_TargetOwnedByOtherUserRejected() {
+	user := s.GetUser(0)
+	other := s.GetUser(1)
+	taskID := primitive.NewObjectID()
+	task := TaskDocument{ID: taskID, UserID: user.ID, Content: "Move me", Priority: 1, Active: true, Timestamp: xutils.NowUTC()}
+	sourceID := s.insertCategory(user.ID, "Source", []TaskDocument{task})
+	foreignTargetID := s.insertCategory(other.ID, "Foreign", []TaskDocument{})
+
+	_, err := s.service.MoveTask(user.ID, sourceID, taskID, foreignTargetID)
+	s.ErrorIs(err, ErrNotCategoryOwner)
+
+	s.Len(s.loadTasks(sourceID), 1)
+}
+
+func (s *MoveTaskTestSuite) TestMoveTask_TaskNotFound() {
+	user := s.GetUser(0)
+	sourceID := s.insertCategory(user.ID, "Source", []TaskDocument{})
+	targetID := s.insertCategory(user.ID, "Target", []TaskDocument{})
+
+	_, err := s.service.MoveTask(user.ID, sourceID, primitive.NewObjectID(), targetID)
+	s.ErrorIs(err, ErrTaskNotFound)
+}
+
+var _ = time.Second

--- a/backend/internal/handlers/task/move_test.go
+++ b/backend/internal/handlers/task/move_test.go
@@ -20,6 +20,31 @@ type MoveTaskTestSuite struct {
 func (s *MoveTaskTestSuite) SetupTest() {
 	s.BaseSuite.SetupTest()
 	s.service = NewService(s.Collections)
+
+	// MoveTask performs a multi-document transaction, which MongoDB only allows
+	// on a replica set or mongos. Local and CI test databases are frequently
+	// standalone mongod instances, so skip these cases there rather than failing.
+	if !s.supportsTransactions() {
+		s.T().Skip("MoveTask requires a replica set for transactions; skipping on standalone mongod")
+	}
+}
+
+// supportsTransactions reports whether the connected MongoDB deployment can run
+// multi-document transactions (replica set or sharded cluster).
+func (s *MoveTaskTestSuite) supportsTransactions() bool {
+	var res bson.M
+	err := s.Collections["categories"].Database().
+		RunCommand(s.Ctx, bson.D{{Key: "hello", Value: 1}}).Decode(&res)
+	if err != nil {
+		return false
+	}
+	if _, ok := res["setName"]; ok { // replica set member
+		return true
+	}
+	if msg, ok := res["msg"]; ok && msg == "isdbgrid" { // mongos (sharded cluster)
+		return true
+	}
+	return false
 }
 
 func TestMoveTaskService(t *testing.T) {

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -49,6 +49,7 @@ func RegisterTaskOperations(api huma.API, handler *Handler) {
 	RegisterUpdateTaskDeadlineOperation(api, handler)
 	RegisterUpdateTaskStartOperation(api, handler)
 	RegisterUpdateTaskReminderOperation(api, handler)
+	RegisterMoveTaskOperation(api, handler)
 	RegisterGetTemplateByIDOperation(api, handler)
 	RegisterUpdateTemplateOperation(api, handler)
 	RegisterResetTemplateMetricsOperation(api, handler)

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -881,5 +882,57 @@ func (h *Handler) UpdateTaskReminders(ctx context.Context, input *UpdateTaskRemi
 
 	resp := &UpdateTaskReminderOutput{}
 	resp.Body.Message = "Task reminders updated successfully"
+	return resp, nil
+}
+
+// MoveTask moves a task from its current category to a different category.
+func (h *Handler) MoveTask(ctx context.Context, input *MoveTaskInput) (*MoveTaskOutput, error) {
+	id, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid task ID format", err)
+	}
+
+	sourceCategoryID, err := primitive.ObjectIDFromHex(input.Category)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid category ID format", err)
+	}
+
+	targetCategoryID, err := primitive.ObjectIDFromHex(input.Body.TargetCategoryID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid target category ID format", err)
+	}
+
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+
+	userID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	_, err = h.service.MoveTask(userID, sourceCategoryID, id, targetCategoryID)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrTaskNotFound):
+			return nil, huma.Error404NotFound("Task not found in the source category", err)
+		case errors.Is(err, ErrCategoryNotFound):
+			return nil, huma.Error404NotFound("Category not found", err)
+		case errors.Is(err, ErrNotCategoryOwner):
+			return nil, huma.Error403Forbidden("You do not have access to this category", err)
+		default:
+			slog.Error("Failed to move task",
+				"taskId", id.Hex(),
+				"sourceCategoryId", sourceCategoryID.Hex(),
+				"targetCategoryId", targetCategoryID.Hex(),
+				"userId", userID.Hex(),
+				"error", err)
+			return nil, huma.Error500InternalServerError("Unable to move task due to a database error. Please try again.", err)
+		}
+	}
+
+	resp := &MoveTaskOutput{}
+	resp.Body.Message = "Task moved successfully"
 	return resp, nil
 }

--- a/backend/internal/handlers/task/task_operations.go
+++ b/backend/internal/handlers/task/task_operations.go
@@ -462,3 +462,30 @@ func RegisterUpdateTaskReminderOperation(api huma.API, handler *Handler) {
 		Tags:        []string{"tasks"},
 	}, handler.UpdateTaskReminders)
 }
+
+// Move Task
+type MoveTaskInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Category      string `path:"category" example:"507f1f77bcf86cd799439011" doc:"Source category ID"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011" doc:"Task ID"`
+	Body          struct {
+		TargetCategoryID string `json:"targetCategoryID" example:"507f1f77bcf86cd799439012" doc:"Destination category ID"`
+	} `json:"body"`
+}
+
+type MoveTaskOutput struct {
+	Body struct {
+		Message string `json:"message" example:"Task moved successfully"`
+	}
+}
+
+func RegisterMoveTaskOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "move-task",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/tasks/{category}/{id}/move",
+		Summary:     "Move task to another category",
+		Description: "Move a task from its current category to a different category. The task lands at the top of the target category, and any recurring template is re-pointed so future instances generate in the target.",
+		Tags:        []string{"tasks"},
+	}, handler.MoveTask)
+}

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -1419,6 +1419,118 @@ func (s *Service) UpdateTaskReminders(id primitive.ObjectID, categoryID primitiv
 	return handleMongoError(ctx, "update task reminders", err)
 }
 
+var (
+	ErrTaskNotFound     = errors.New("task not found in source category")
+	ErrCategoryNotFound = errors.New("category not found")
+	ErrNotCategoryOwner = errors.New("user does not own the category")
+)
+
+// MoveTask atomically moves a task from sourceCategoryID to the top of
+// targetCategoryID. If the task has a recurring template, the template's
+// categoryID is re-pointed so future instances generate into the target.
+// A same-category move is a no-op that returns the task unchanged.
+func (s *Service) MoveTask(userID, sourceCategoryID, taskID, targetCategoryID primitive.ObjectID) (*TaskDocument, error) {
+	ctx := context.Background()
+
+	if sourceCategoryID == targetCategoryID {
+		return s.findTaskInCategory(ctx, sourceCategoryID, taskID)
+	}
+
+	client := s.Tasks.Database().Client()
+	session, err := client.StartSession()
+	if err != nil {
+		return nil, err
+	}
+	defer session.EndSession(ctx)
+
+	var moved *TaskDocument
+	_, err = session.WithTransaction(ctx, func(sessCtx mongo.SessionContext) (interface{}, error) {
+		var sourceCat types.CategoryDocument
+		if err := s.Tasks.FindOne(sessCtx, bson.M{"_id": sourceCategoryID}).Decode(&sourceCat); err != nil {
+			if err == mongo.ErrNoDocuments {
+				return nil, ErrCategoryNotFound
+			}
+			return nil, err
+		}
+		if sourceCat.User != userID {
+			return nil, ErrNotCategoryOwner
+		}
+
+		var task *TaskDocument
+		for i := range sourceCat.Tasks {
+			if sourceCat.Tasks[i].ID == taskID {
+				t := sourceCat.Tasks[i]
+				task = &t
+				break
+			}
+		}
+		if task == nil {
+			return nil, ErrTaskNotFound
+		}
+
+		var targetCat types.CategoryDocument
+		if err := s.Tasks.FindOne(sessCtx, bson.M{"_id": targetCategoryID}).Decode(&targetCat); err != nil {
+			if err == mongo.ErrNoDocuments {
+				return nil, ErrCategoryNotFound
+			}
+			return nil, err
+		}
+		if targetCat.User != userID {
+			return nil, ErrNotCategoryOwner
+		}
+
+		if _, err := s.Tasks.UpdateOne(sessCtx,
+			bson.M{"_id": sourceCategoryID},
+			bson.M{"$pull": bson.M{"tasks": bson.M{"_id": taskID}}},
+		); err != nil {
+			return nil, err
+		}
+
+		task.CategoryID = targetCategoryID
+		if _, err := s.Tasks.UpdateOne(sessCtx,
+			bson.M{"_id": targetCategoryID},
+			bson.M{"$push": bson.M{"tasks": bson.M{"$each": bson.A{task}, "$position": 0}}},
+		); err != nil {
+			return nil, err
+		}
+
+		if task.TemplateID != nil {
+			if _, err := s.TemplateTasks.UpdateOne(sessCtx,
+				bson.M{"_id": *task.TemplateID},
+				bson.M{"$set": bson.M{"categoryID": targetCategoryID}},
+			); err != nil {
+				return nil, err
+			}
+		}
+
+		moved = task
+		return nil, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.enqueuePushUpsertIfEnabled(context.Background(), taskID, targetCategoryID, userID)
+	return moved, nil
+}
+
+func (s *Service) findTaskInCategory(ctx context.Context, categoryID, taskID primitive.ObjectID) (*TaskDocument, error) {
+	var cat types.CategoryDocument
+	if err := s.Tasks.FindOne(ctx, bson.M{"_id": categoryID}).Decode(&cat); err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, ErrCategoryNotFound
+		}
+		return nil, err
+	}
+	for i := range cat.Tasks {
+		if cat.Tasks[i].ID == taskID {
+			t := cat.Tasks[i]
+			return &t, nil
+		}
+	}
+	return nil, ErrTaskNotFound
+}
+
 // recalculateFollowUp removes any existing FOLLOW_UP reminder and injects a new one based on the new deadline.
 func (s *Service) recalculateFollowUp(ctx context.Context, taskID primitive.ObjectID, categoryID primitive.ObjectID, deadline *time.Time) error {
 	// Remove existing FOLLOW_UP reminders

--- a/frontend/__tests__/dragHitTest.test.ts
+++ b/frontend/__tests__/dragHitTest.test.ts
@@ -1,0 +1,26 @@
+import { categoryAtPoint, CategoryRect } from "@/utils/dragHitTest";
+
+const rects: CategoryRect[] = [
+    { categoryId: "a", x: 0, y: 0, width: 100, height: 50 },
+    { categoryId: "b", x: 0, y: 60, width: 100, height: 50 },
+];
+
+describe("categoryAtPoint", () => {
+    it("returns the category whose rect contains the point", () => {
+        expect(categoryAtPoint(rects, 10, 10)).toBe("a");
+        expect(categoryAtPoint(rects, 10, 80)).toBe("b");
+    });
+
+    it("returns null when the point is outside every rect", () => {
+        expect(categoryAtPoint(rects, 10, 55)).toBeNull();
+        expect(categoryAtPoint(rects, 200, 10)).toBeNull();
+    });
+
+    it("returns the first matching rect when rects overlap", () => {
+        const overlapping: CategoryRect[] = [
+            { categoryId: "first", x: 0, y: 0, width: 100, height: 100 },
+            { categoryId: "second", x: 0, y: 0, width: 100, height: 100 },
+        ];
+        expect(categoryAtPoint(overlapping, 50, 50)).toBe("first");
+    });
+});

--- a/frontend/__tests__/moveTask.test.ts
+++ b/frontend/__tests__/moveTask.test.ts
@@ -1,0 +1,46 @@
+import { moveTaskInWorkspaces } from "@/utils/moveTask";
+import { Workspace, Task, Categories } from "@/api/types";
+
+const task = (id: string, content = ""): Task =>
+    ({ id, content, priority: 1 } as Task);
+
+const cat = (id: string, name: string, tasks: Task[]): Categories =>
+    ({ id, name, tags: [], tasks });
+
+const ws = (categories: Categories[]): Workspace =>
+    ({ name: "W", categories, isBlueprint: false } as Workspace);
+
+describe("moveTaskInWorkspaces", () => {
+    it("removes the task from source and puts it at the top of target", () => {
+        const input = [
+            ws([
+                cat("src", "Source", [task("t1", "move me"), task("t2")]),
+                cat("dst", "Target", [task("t3")]),
+            ]),
+        ];
+        const out = moveTaskInWorkspaces(input, "src", "t1", "dst");
+        const src = out[0].categories.find((c) => c.id === "src")!;
+        const dst = out[0].categories.find((c) => c.id === "dst")!;
+        expect(src.tasks.map((t) => t.id)).toEqual(["t2"]);
+        expect(dst.tasks.map((t) => t.id)).toEqual(["t1", "t3"]);
+    });
+
+    it("does not mutate the input", () => {
+        const input = [ws([cat("src", "S", [task("t1")]), cat("dst", "D", [])])];
+        const snapshot = JSON.stringify(input);
+        moveTaskInWorkspaces(input, "src", "t1", "dst");
+        expect(JSON.stringify(input)).toEqual(snapshot);
+    });
+
+    it("is a no-op when source and target are the same", () => {
+        const input = [ws([cat("src", "S", [task("t1")])])];
+        const out = moveTaskInWorkspaces(input, "src", "t1", "src");
+        expect(out).toBe(input);
+    });
+
+    it("returns the input unchanged when the task is not found", () => {
+        const input = [ws([cat("src", "S", []), cat("dst", "D", [])])];
+        const out = moveTaskInWorkspaces(input, "src", "missing", "dst");
+        expect(out).toBe(input);
+    });
+});

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -3627,6 +3627,84 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/for-you:
+        get:
+            tags:
+                - for-you
+            summary: Get the For You feed
+            description: Returns the curated For You feed for the authenticated user, organized into Catch up and Suggested for you sections.
+            operationId: get-for-you
+            parameters:
+                - name: Authorization
+                  in: header
+                  description: Bearer token
+                  required: true
+                  schema:
+                    type: string
+                    description: Bearer token
+                - name: refresh_token
+                  in: header
+                  description: Refresh token
+                  required: true
+                  schema:
+                    type: string
+                    description: Refresh token
+                - name: X-Timezone
+                  in: header
+                  description: IANA timezone, e.g. America/New_York
+                  schema:
+                    type: string
+                    description: IANA timezone, e.g. America/New_York
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ForYouFeed'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/user/for-you/interactions:
+        post:
+            tags:
+                - for-you
+            summary: Record a For You CTA interaction
+            description: Increments the interaction counter for a card type, counting toward the threshold that switches the card to compact display mode.
+            operationId: record-for-you-interaction
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: refresh_token
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RecordInteractionParams'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/RecordInteractionOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/groups:
         get:
             tags:
@@ -5070,6 +5148,32 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tags:
+        get:
+            tags:
+                - categories
+            summary: Get user tags
+            description: Retrieve the distinct list of category tags for the authenticated user
+            operationId: get-user-tags
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetUserTagsOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/tasks/:
         get:
             tags:
@@ -5302,6 +5406,58 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/UpdateTaskChecklistOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tasks/{category}/{id}/move:
+        post:
+            tags:
+                - tasks
+            summary: Move task to another category
+            description: Move a task from its current category to a different category. The task lands at the top of the target category, and any recurring template is re-pointed so future instances generate in the target.
+            operationId: move-task
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: category
+                  in: path
+                  description: Source category ID
+                  required: true
+                  schema:
+                    type: string
+                    description: Source category ID
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                  example: 507f1f77bcf86cd799439011
+                - name: id
+                  in: path
+                  description: Task ID
+                  required: true
+                  schema:
+                    type: string
+                    description: Task ID
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                  example: 507f1f77bcf86cd799439011
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/MoveTaskInputBody'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/MoveTaskOutputBody'
                 default:
                     description: Error
                     content:
@@ -6302,32 +6458,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/DeleteWaitlistOutputBody'
-                default:
-                    description: Error
-                    content:
-                        application/problem+json:
-                            schema:
-                                $ref: '#/components/schemas/ErrorModel'
-    /v1/user/tags:
-        get:
-            tags:
-                - categories
-            summary: Get user tags
-            description: Retrieve the distinct list of category tags for the authenticated user
-            operationId: get-user-tags
-            parameters:
-                - name: Authorization
-                  in: header
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/GetUserTagsOutputBody'
                 default:
                     description: Error
                     content:
@@ -9190,6 +9320,150 @@ components:
                 - target
                 - period
                 - completedInPeriod
+        ForYouCard:
+            type: object
+            additionalProperties: false
+            properties:
+                body:
+                    type: string
+                    description: Present iff displayMode == full
+                ctas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouCta'
+                deepLink:
+                    type: string
+                    description: Tap-target for the entire card
+                displayMode:
+                    type: string
+                iconKind:
+                    type: string
+                id:
+                    type: string
+                priority:
+                    type: integer
+                    format: int64
+                subject:
+                    $ref: '#/components/schemas/ForYouSubject'
+                title:
+                    type: string
+                type:
+                    type: string
+            required:
+                - id
+                - type
+                - displayMode
+                - iconKind
+                - title
+                - ctas
+                - deepLink
+                - priority
+        ForYouCta:
+            type: object
+            additionalProperties: false
+            properties:
+                action:
+                    $ref: '#/components/schemas/ForYouCtaAction'
+                kind:
+                    type: string
+                    description: primary | secondary
+                    examples:
+                        - primary
+                label:
+                    type: string
+                    examples:
+                        - Send one back
+            required:
+                - label
+                - kind
+                - action
+        ForYouCtaAction:
+            type: object
+            additionalProperties: false
+            properties:
+                href:
+                    type: string
+                    examples:
+                        - /(logged-in)/(tabs)/(task)/kudos
+                postId:
+                    type: string
+                reaction:
+                    type: string
+                referenceId:
+                    type: string
+                targetUserId:
+                    type: string
+                taskId:
+                    type: string
+                type:
+                    type: string
+                    description: navigate | send_kudos | send_encouragement | react
+                    examples:
+                        - navigate
+            required:
+                - type
+        ForYouFeed:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/ForYouFeed.json
+                    readOnly: true
+                sections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouSection'
+                unreadCount:
+                    type: integer
+                    description: Number of catch_up cards driving the tab dot
+                    format: int64
+            required:
+                - sections
+                - unreadCount
+        ForYouSection:
+            type: object
+            additionalProperties: false
+            properties:
+                cards:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouCard'
+                id:
+                    type: string
+                    description: catch_up | suggested
+                    examples:
+                        - catch_up
+                title:
+                    type: string
+                    examples:
+                        - Catch up
+            required:
+                - id
+                - title
+                - cards
+        ForYouSubject:
+            type: object
+            additionalProperties: false
+            properties:
+                avatarUrl:
+                    type: string
+                    examples:
+                        - https://example.com/avatar.jpg
+                displayName:
+                    type: string
+                    examples:
+                        - Sarah
+                userId:
+                    type: string
+                    examples:
+                        - 507f1f77bcf86cd799439011
+            required:
+                - userId
+                - displayName
         FriendReference:
             type: object
             additionalProperties: false
@@ -10190,6 +10464,41 @@ components:
             required:
                 - id
                 - handle
+        MoveTaskInputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/MoveTaskInputBody.json
+                    readOnly: true
+                targetCategoryID:
+                    type: string
+                    description: Destination category ID
+                    examples:
+                        - 507f1f77bcf86cd799439012
+            required:
+                - targetCategoryID
+        MoveTaskOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/MoveTaskOutputBody.json
+                    readOnly: true
+                message:
+                    type: string
+                    examples:
+                        - Task moved successfully
+            required:
+                - message
         MultiTaskOutputLocal:
             type: object
             additionalProperties: false
@@ -10617,6 +10926,41 @@ components:
             required:
                 - tasks
                 - query
+        RecordInteractionOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RecordInteractionOutputBody.json
+                    readOnly: true
+                message:
+                    type: string
+                    examples:
+                        - Interaction recorded
+            required:
+                - message
+        RecordInteractionParams:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RecordInteractionParams.json
+                    readOnly: true
+                cardType:
+                    type: string
+                    description: Card type the user interacted with
+                    examples:
+                        - kudos_received
+            required:
+                - cardType
         RecurDetails:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -1780,6 +1780,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/for-you": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the For You feed
+         * @description Returns the curated For You feed for the authenticated user, organized into Catch up and Suggested for you sections.
+         */
+        get: operations["get-for-you"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/user/for-you/interactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record a For You CTA interaction
+         * @description Increments the interaction counter for a card type, counting toward the threshold that switches the card to compact display mode.
+         */
+        post: operations["record-for-you-interaction"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/groups": {
         parameters: {
             query?: never;
@@ -2472,6 +2512,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user tags
+         * @description Retrieve the distinct list of category tags for the authenticated user
+         */
+        get: operations["get-user-tags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/tasks/": {
         parameters: {
             query?: never;
@@ -2550,6 +2610,26 @@ export interface paths {
          * @description Update the checklist field of a task
          */
         post: operations["update-task-checklist"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/user/tasks/{category}/{id}/move": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Move task to another category
+         * @description Move a task from its current category to a different category. The task lands at the top of the target category, and any recurring template is re-pointed so future instances generate in the target.
+         */
+        post: operations["move-task"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3043,26 +3123,6 @@ export interface paths {
          * @description Remove a waitlist entry by its ID
          */
         delete: operations["delete-waitlist"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/user/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get user tags
-         * @description Retrieve the distinct list of category tags for the authenticated user
-         */
-        get: operations["get-user-tags"];
-        put?: never;
-        post?: never;
-        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -4837,6 +4897,77 @@ export interface components {
             /** Format: int64 */
             target: number;
         };
+        ForYouCard: {
+            /** @description Present iff displayMode == full */
+            body?: string;
+            ctas: components["schemas"]["ForYouCta"][];
+            /** @description Tap-target for the entire card */
+            deepLink: string;
+            displayMode: string;
+            iconKind: string;
+            id: string;
+            /** Format: int64 */
+            priority: number;
+            subject?: components["schemas"]["ForYouSubject"];
+            title: string;
+            type: string;
+        };
+        ForYouCta: {
+            action: components["schemas"]["ForYouCtaAction"];
+            /**
+             * @description primary | secondary
+             * @example primary
+             */
+            kind: string;
+            /** @example Send one back */
+            label: string;
+        };
+        ForYouCtaAction: {
+            /** @example /(logged-in)/(tabs)/(task)/kudos */
+            href?: string;
+            postId?: string;
+            reaction?: string;
+            referenceId?: string;
+            targetUserId?: string;
+            taskId?: string;
+            /**
+             * @description navigate | send_kudos | send_encouragement | react
+             * @example navigate
+             */
+            type: string;
+        };
+        ForYouFeed: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/ForYouFeed.json
+             */
+            readonly $schema?: string;
+            sections: components["schemas"]["ForYouSection"][];
+            /**
+             * Format: int64
+             * @description Number of catch_up cards driving the tab dot
+             */
+            unreadCount: number;
+        };
+        ForYouSection: {
+            cards: components["schemas"]["ForYouCard"][];
+            /**
+             * @description catch_up | suggested
+             * @example catch_up
+             */
+            id: string;
+            /** @example Catch up */
+            title: string;
+        };
+        ForYouSubject: {
+            /** @example https://example.com/avatar.jpg */
+            avatarUrl?: string;
+            /** @example Sarah */
+            displayName: string;
+            /** @example 507f1f77bcf86cd799439011 */
+            userId: string;
+        };
         FriendReference: {
             /**
              * @description User ID
@@ -5429,6 +5560,29 @@ export interface components {
             handle: string;
             id: string;
         };
+        MoveTaskInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/MoveTaskInputBody.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Destination category ID
+             * @example 507f1f77bcf86cd799439012
+             */
+            targetCategoryID: string;
+        };
+        MoveTaskOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/MoveTaskOutputBody.json
+             */
+            readonly $schema?: string;
+            /** @example Task moved successfully */
+            message: string;
+        };
         MultiTaskOutputLocal: {
             categories: components["schemas"]["NewCategoryWithTasksLocal"][];
             tasks: components["schemas"]["CategoryTaskPairLocal"][];
@@ -5632,6 +5786,29 @@ export interface components {
             query: components["schemas"]["TaskQueryFilters"];
             /** @description Matching tasks */
             tasks: components["schemas"]["TaskDocument"][];
+        };
+        RecordInteractionOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RecordInteractionOutputBody.json
+             */
+            readonly $schema?: string;
+            /** @example Interaction recorded */
+            message: string;
+        };
+        RecordInteractionParams: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RecordInteractionParams.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Card type the user interacted with
+             * @example kudos_received
+             */
+            cardType: string;
         };
         RecurDetails: {
             behavior?: string;
@@ -10681,6 +10858,78 @@ export interface operations {
             };
         };
     };
+    "get-for-you": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Bearer token */
+                Authorization: string;
+                /** @description Refresh token */
+                refresh_token: string;
+                /** @description IANA timezone, e.g. America/New_York */
+                "X-Timezone"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForYouFeed"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "record-for-you-interaction": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+                refresh_token: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordInteractionParams"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordInteractionOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-groups": {
         parameters: {
             query?: never;
@@ -12121,6 +12370,37 @@ export interface operations {
             };
         };
     };
+    "get-user-tags": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetUserTagsOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-tasks-by-user": {
         parameters: {
             query?: {
@@ -12305,6 +12585,52 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UpdateTaskChecklistOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "move-task": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path: {
+                /**
+                 * @description Source category ID
+                 * @example 507f1f77bcf86cd799439011
+                 */
+                category: string;
+                /**
+                 * @description Task ID
+                 * @example 507f1f77bcf86cd799439011
+                 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["MoveTaskInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MoveTaskOutputBody"];
                 };
             };
             /** @description Error */
@@ -13268,37 +13594,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeleteWaitlistOutputBody"];
-                };
-            };
-            /** @description Error */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
-                };
-            };
-        };
-    };
-    "get-user-tags": {
-        parameters: {
-            query?: never;
-            header: {
-                Authorization: string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetUserTagsOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/api/task.ts
+++ b/frontend/api/task.ts
@@ -745,3 +745,26 @@ export const confirmTasksFromNaturalLanguageAPI = async (
     const responsePayload = (data as any)?.body ?? data;
     return responsePayload as NaturalLanguageTaskCreationResponse;
 };
+
+/**
+ * Move a task to a different category.
+ * API: POST /v1/user/tasks/{category}/{id}/move
+ * The task lands at the top of the target category; recurring templates re-point.
+ * @param sourceCategoryId - The category the task currently lives in
+ * @param taskId - The task to move
+ * @param targetCategoryId - The destination category
+ */
+export const moveTaskAPI = async (
+    sourceCategoryId: string,
+    taskId: string,
+    targetCategoryId: string
+): Promise<void> => {
+    const { error } = await client.POST("/v1/user/tasks/{category}/{id}/move", {
+        params: withAuthHeaders({ path: { category: sourceCategoryId, id: taskId } }),
+        body: { targetCategoryID: targetCategoryId },
+    });
+
+    if (error) {
+        throw new Error(`Failed to move task: ${JSON.stringify(error)}`);
+    }
+};

--- a/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/workspace.tsx
@@ -28,8 +28,40 @@ import { UpcomingCategory } from "@/components/UpcomingCategory";
 import { OpenTasksCategory } from "@/components/OpenTasksCategory";
 import { FunnelSimple, SortAscending, CalendarBlank } from "phosphor-react-native";
 import * as PhosphorIcons from "phosphor-react-native";
+import { DragProvider, useDrag } from "@/contexts/dragContext";
 
 type Props = {};
+
+/**
+ * While a task is being dragged, scroll the workspace when the finger nears the
+ * top/bottom edge so off-screen categories can be reached. EDGE/STEP are tuned
+ * for feel during QA. Mounted inside DragProvider so it can read drag state.
+ */
+const DragAutoScroll = ({
+    scrollViewRef,
+    scrollOffsetRef,
+}: {
+    scrollViewRef: React.RefObject<ScrollView>;
+    scrollOffsetRef: React.MutableRefObject<number>;
+}) => {
+    const { isDragging, fingerY } = useDrag();
+    useEffect(() => {
+        if (!isDragging) return;
+        const screenH = Dimensions.get("window").height;
+        const EDGE = 120;
+        const STEP = 24;
+        const interval = setInterval(() => {
+            const y = fingerY.value;
+            if (y < EDGE) {
+                scrollViewRef.current?.scrollTo({ y: Math.max(0, scrollOffsetRef.current - STEP), animated: false });
+            } else if (y > screenH - EDGE) {
+                scrollViewRef.current?.scrollTo({ y: scrollOffsetRef.current + STEP, animated: false });
+            }
+        }, 16);
+        return () => clearInterval(interval);
+    }, [isDragging, fingerY, scrollViewRef, scrollOffsetRef]);
+    return null;
+};
 
 const Workspace = (props: Props) => {
     let ThemedColor = useThemeColor();
@@ -64,11 +96,13 @@ const Workspace = (props: Props) => {
 
     const drawerRef = useRef<DrawerLayout>(null);
     const scrollViewRef = useRef<ScrollView>(null);
+    const scrollOffsetRef = useRef(0);
     const noCategories = categories.filter((category) => category.name !== "!-proxy-!").length == 0;
     const { setIsDrawerOpen } = useDrawer();
 
     const handleScroll = (event: any) => {
         const scrollY = event.nativeEvent.contentOffset.y;
+        scrollOffsetRef.current = scrollY;
         // Adjust this threshold based on when you want the header to become sticky
         const stickyThreshold = 100; // Adjust this value as needed
         setIsHeaderSticky(scrollY > stickyThreshold);
@@ -79,7 +113,8 @@ const Workspace = (props: Props) => {
     const workspaceColor = currentWorkspace?.color ?? undefined;
 
     return (
-        <WorkspaceContent
+        <DragProvider>
+            <WorkspaceContent
             drawerRef={drawerRef}
             scrollViewRef={scrollViewRef}
             ThemedColor={ThemedColor}
@@ -107,7 +142,9 @@ const Workspace = (props: Props) => {
             requestWorkspaceAction={requestWorkspaceAction}
             workspaceAction={workspaceAction}
             setWorkspaceAction={setWorkspaceAction}
-        />
+            />
+            <DragAutoScroll scrollViewRef={scrollViewRef} scrollOffsetRef={scrollOffsetRef} />
+        </DragProvider>
     );
 };
 

--- a/frontend/components/cards/TaskCard.tsx
+++ b/frontend/components/cards/TaskCard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useState, useRef } from "react";
 import { TouchableOpacity, View, StyleSheet, Dimensions, Platform } from "react-native";
 import { ThemedText } from "../ThemedText";
 import { useRouter } from "expo-router";
@@ -22,6 +22,9 @@ import { showToastable } from "react-native-toastable";
 import DefaultToast from "@/components/ui/DefaultToast";
 import { setWorkingAPI } from "@/api/task";
 import * as Haptics from "expo-haptics";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import { runOnJS } from "react-native-reanimated";
+import { useDragOptional } from "@/contexts/dragContext";
 
 export const PRIORITY_MAP = {
     0: "none",
@@ -349,109 +352,171 @@ const TaskCard = ({
         setEditing(true);
     };
 
+    // ── Drag-and-drop gesture (only active when DragProvider is present) ──
+    const drag = useDragOptional();
+    const draggable = Boolean(drag) && Boolean(redirect) && !task?.isPhantom && Boolean(task);
+    const liftedRef = useRef(false);
+
+    const onLift = useCallback((absX: number, absY: number) => {
+        if (Platform.OS === "ios") {
+            Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        }
+        liftedRef.current = true;
+        if (task && drag) drag.beginDrag(task, categoryId, absX, absY);
+    }, [task, categoryId, drag]);
+
+    const onReleaseInPlaceOpenMenu = useCallback(() => {
+        drag?.endDrag();
+        liftedRef.current = false;
+        setEditing(true);
+    }, [drag]);
+
+    const dragGesture = useMemo(() => {
+        const longPress = Gesture.LongPress()
+            .minDuration(350)
+            .onStart((e) => {
+                runOnJS(onLift)(e.absoluteX, e.absoluteY);
+            });
+
+        const longPressMenu = Gesture.LongPress()
+            .minDuration(350)
+            .onEnd((_e, success) => {
+                if (success && liftedRef.current) {
+                    runOnJS(onReleaseInPlaceOpenMenu)();
+                }
+            });
+
+        const pan = Gesture.Pan()
+            .manualActivation(true)
+            .onTouchesMove((_e, state) => {
+                if (liftedRef.current) {
+                    state.activate();
+                }
+            })
+            .onUpdate((e) => {
+                runOnJS((x: number, y: number) => drag?.updateDrag(x, y))(e.absoluteX, e.absoluteY);
+            })
+            .onEnd(() => {
+                runOnJS(() => {
+                    drag?.endDrag();
+                    liftedRef.current = false;
+                })();
+            });
+
+        return Gesture.Simultaneous(Gesture.Race(longPress, longPressMenu), pan);
+    }, [onLift, onReleaseInPlaceOpenMenu, drag]);
+
+    const cardBody = (
+        <TouchableOpacity
+            style={[
+                styles.container,
+                {
+                    backgroundColor: ThemedColor.lightenedCard,
+                    borderWidth: 1,
+                    borderColor: ThemedColor.tertiary,
+                    ...(task?.isPhantom
+                        ? { opacity: 0.45, borderStyle: "dashed" as const }
+                        : null),
+                },
+            ]}
+            disabled={
+                Boolean(task?.isPhantom) ||
+                (!redirect && !encourage && !congratulate)
+            }
+            onPress={handlePress}
+            onLongPress={draggable ? undefined : handleLongPress}>
+            {editing && (
+                <EditPost
+                    visible={editing}
+                    setVisible={setEditing}
+                    id={{ id, category: categoryId }}
+                    task={task}
+                    onStartWorking={task && !task.isPhantom ? startWorking : undefined}
+                />
+            )}
+
+            <View style={styles.row}>
+                <View style={styles.contentContainer}>
+                    {highlightContent ? (
+                        <ThemedText numberOfLines={2} ellipsizeMode="tail" style={styles.content} type="default">
+                            {content}
+                            {dateDisplay && (
+                                <ThemedText type="default" style={{ color: ThemedColor[dateDisplay.color] }}>
+                                    {" "}{dateDisplay.text}
+                                </ThemedText>
+                            )}
+                        </ThemedText>
+                    ) : (
+                        <ThemedText numberOfLines={2} ellipsizeMode="tail" style={styles.content} type="default">
+                            {content}
+                            {task?.workingOnSince && (
+                                <ThemedText type="default" style={{ color: ThemedColor.primary }}>
+                                    {" "}(active)
+                                </ThemedText>
+                            )}
+                            {dateDisplay && (
+                                <ThemedText type="default" style={{ color: ThemedColor[dateDisplay.color] }}>
+                                    {" "}{dateDisplay.text}
+                                </ThemedText>
+                            )}
+                        </ThemedText>
+                    )}
+                    {inlineComponent && <View style={styles.inlineWrapper}>{inlineComponent}</View>}
+                </View>
+                <View style={styles.iconRow}>
+                    <ConditionalView condition={!encourage}>
+                        <ConditionalView condition={isRunningState}>
+                            <Timer size={20} color={ThemedColor.caption} weight="regular" />
+                        </ConditionalView>
+                        <ConditionalView condition={task?.recurring}>
+                            <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
+                                <Repeat size={20} color={ThemedColor.caption} weight="regular" />
+                                {task?.flexInfo && (
+                                    <ThemedText type="caption" style={{ color: ThemedColor.primary, fontWeight: "600", fontSize: 12 }}>
+                                        {task.flexInfo.instanceNumber}/{task.flexInfo.target}
+                                    </ThemedText>
+                                )}
+                            </View>
+                        </ConditionalView>
+                        <ConditionalView condition={!!task?.integration}>
+                            {getIntegrationIcon(task?.integration, ThemedColor.caption)}
+                        </ConditionalView>
+                        {/* <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                        {value}
+                    </ThemedText> */}
+
+                        {/* Show priority dot — purple when actively working */}
+                        <View
+                            style={[styles.circle, { backgroundColor: task?.workingOnSince ? ThemedColor.primary : getPriorityColor(PRIORITY_MAP[priority]) }]}
+                        />
+                    </ConditionalView>
+                    <ConditionalView condition={encourage}>
+                        <Sparkle
+                            size={24}
+                            color="#9333EA"
+                            weight="regular"
+                        />
+                    </ConditionalView>
+                    <ConditionalView condition={congratulate}>
+                        <Svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+                            <Path
+                                d="M12 2L13.09 8.26L20 9L13.09 9.74L12 16L10.91 9.74L4 9L10.91 8.26L12 2Z"
+                                fill="#FFD700"
+                            />
+                        </Svg>
+                    </ConditionalView>
+                </View>
+            </View>
+        </TouchableOpacity>
+    );
+
     return (
         <>
-            <TouchableOpacity
-                style={[
-                    styles.container,
-                    {
-                        backgroundColor: ThemedColor.lightenedCard,
-                        borderWidth: 1,
-                        borderColor: ThemedColor.tertiary,
-                        ...(task?.isPhantom
-                            ? { opacity: 0.45, borderStyle: "dashed" as const }
-                            : null),
-                    },
-                ]}
-                disabled={
-                    Boolean(task?.isPhantom) ||
-                    (!redirect && !encourage && !congratulate)
-                }
-                onPress={handlePress}
-                onLongPress={handleLongPress}>
-                {editing && (
-                    <EditPost
-                        visible={editing}
-                        setVisible={setEditing}
-                        id={{ id, category: categoryId }}
-                        task={task}
-                        onStartWorking={task && !task.isPhantom ? startWorking : undefined}
-                    />
-                )}
-
-                <View style={styles.row}>
-                    <View style={styles.contentContainer}>
-                        {highlightContent ? (
-                            <ThemedText numberOfLines={2} ellipsizeMode="tail" style={styles.content} type="default">
-                                {content}
-                                {dateDisplay && (
-                                    <ThemedText type="default" style={{ color: ThemedColor[dateDisplay.color] }}>
-                                        {" "}{dateDisplay.text}
-                                    </ThemedText>
-                                )}
-                            </ThemedText>
-                        ) : (
-                            <ThemedText numberOfLines={2} ellipsizeMode="tail" style={styles.content} type="default">
-                                {content}
-                                {task?.workingOnSince && (
-                                    <ThemedText type="default" style={{ color: ThemedColor.primary }}>
-                                        {" "}(active)
-                                    </ThemedText>
-                                )}
-                                {dateDisplay && (
-                                    <ThemedText type="default" style={{ color: ThemedColor[dateDisplay.color] }}>
-                                        {" "}{dateDisplay.text}
-                                    </ThemedText>
-                                )}
-                            </ThemedText>
-                        )}
-                        {inlineComponent && <View style={styles.inlineWrapper}>{inlineComponent}</View>}
-                    </View>
-                    <View style={styles.iconRow}>
-                        <ConditionalView condition={!encourage}>
-                            <ConditionalView condition={isRunningState}>
-                                <Timer size={20} color={ThemedColor.caption} weight="regular" />
-                            </ConditionalView>
-                            <ConditionalView condition={task?.recurring}>
-                                <View style={{ flexDirection: "row", alignItems: "center", gap: 4 }}>
-                                    <Repeat size={20} color={ThemedColor.caption} weight="regular" />
-                                    {task?.flexInfo && (
-                                        <ThemedText type="caption" style={{ color: ThemedColor.primary, fontWeight: "600", fontSize: 12 }}>
-                                            {task.flexInfo.instanceNumber}/{task.flexInfo.target}
-                                        </ThemedText>
-                                    )}
-                                </View>
-                            </ConditionalView>
-                            <ConditionalView condition={!!task?.integration}>
-                                {getIntegrationIcon(task?.integration, ThemedColor.caption)}
-                            </ConditionalView>
-                            {/* <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
-                            {value}
-                        </ThemedText> */}
-
-                            {/* Show priority dot — purple when actively working */}
-                            <View
-                                style={[styles.circle, { backgroundColor: task?.workingOnSince ? ThemedColor.primary : getPriorityColor(PRIORITY_MAP[priority]) }]}
-                            />
-                        </ConditionalView>
-                        <ConditionalView condition={encourage}>
-                            <Sparkle
-                                size={24}
-                                color="#9333EA"
-                                weight="regular"
-                            />
-                        </ConditionalView>
-                        <ConditionalView condition={congratulate}>
-                            <Svg width="24" height="24" viewBox="0 0 24 24" fill="none">
-                                <Path
-                                    d="M12 2L13.09 8.26L20 9L13.09 9.74L12 16L10.91 9.74L4 9L10.91 8.26L12 2Z"
-                                    fill="#FFD700"
-                                />
-                            </Svg>
-                        </ConditionalView>
-                    </View>
-                </View>
-            </TouchableOpacity>
+            {draggable ? (
+                <GestureDetector gesture={dragGesture}>{cardBody}</GestureDetector>
+            ) : (
+                cardBody
+            )}
 
             {/* Lazy load modals - only render when needed */}
             {showEncourageModal && (

--- a/frontend/components/category.tsx
+++ b/frontend/components/category.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useRef, useCallback, useEffect } from "react";
 import { StyleSheet, View, TouchableOpacity, ScrollView } from "react-native";
+import { useDragOptional } from "@/contexts/dragContext";
 import { ThemedText } from "./ThemedText";
 import TaskCard from "./cards/TaskCard";
 import { Task } from "../api/types";
@@ -37,12 +38,39 @@ export const Category: React.FC<CategoryProps> = ({
     const ThemedColor = useThemeColor();
     const router = useRouter();
 
+    const drag = useDragOptional();
+    const containerRef = useRef<View>(null);
+    const isDropTarget = drag?.hoveredCategoryId === id;
+
+    const measure = useCallback(() => {
+        if (!drag) return;
+        containerRef.current?.measureInWindow((x, y, width, height) => {
+            drag.setCategoryRect({ categoryId: id, x, y, width, height });
+        });
+    }, [drag, id]);
+
+    useEffect(() => {
+        return () => {
+            drag?.removeCategoryRect(id);
+        };
+    }, [drag, id]);
+
     const categoryNameText = (
         <ThemedText type={tasks.length > 0 ? "subtitle" : "disabledTitle"}>{name}</ThemedText>
     );
 
     return (
-        <View style={styles.container}>
+        <View
+            style={[
+                styles.container,
+                isDropTarget && {
+                    backgroundColor: ThemedColor.lightenedCard,
+                    borderRadius: 12,
+                },
+            ]}
+            ref={containerRef}
+            onLayout={measure}
+            collapsable={false}>
             <View style={{ flexDirection: "row", justifyContent: "space-between", alignItems: "center", gap: 8 }}>
                 <TouchableOpacity
                     style={{ flexDirection: "row", alignItems: "center", gap: 8, flexShrink: 1 }}

--- a/frontend/contexts/dragContext.tsx
+++ b/frontend/contexts/dragContext.tsx
@@ -1,0 +1,137 @@
+import React, { createContext, useCallback, useContext, useRef, useState } from "react";
+import { StyleSheet, View } from "react-native";
+import Reanimated, {
+    useSharedValue,
+    useAnimatedStyle,
+    SharedValue,
+} from "react-native-reanimated";
+import { Task } from "@/api/types";
+import { CategoryRect, categoryAtPoint } from "@/utils/dragHitTest";
+import { useTasks } from "@/contexts/tasksContext";
+import TaskCard from "@/components/cards/TaskCard";
+
+type DragContextValue = {
+    fingerX: SharedValue<number>;
+    fingerY: SharedValue<number>;
+    hoveredCategoryId: string | null;
+    isDragging: boolean;
+    setCategoryRect: (rect: CategoryRect) => void;
+    removeCategoryRect: (categoryId: string) => void;
+    beginDrag: (task: Task, sourceCategoryId: string, startX: number, startY: number) => void;
+    updateDrag: (x: number, y: number) => void;
+    endDrag: () => void;
+};
+
+const DragContext = createContext<DragContextValue | null>(null);
+
+export const useDrag = () => {
+    const ctx = useContext(DragContext);
+    if (!ctx) throw new Error("useDrag must be used within DragProvider");
+    return ctx;
+};
+
+/**
+ * Like useDrag but returns null when there is no DragProvider above (e.g. a
+ * Category or TaskCard rendered in a view-only / encourage / congratulate
+ * context). Lets drag-aware components degrade gracefully instead of throwing.
+ */
+export const useDragOptional = (): DragContextValue | null => useContext(DragContext);
+
+export const DragProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const { moveTask } = useTasks();
+
+    const fingerX = useSharedValue(0);
+    const fingerY = useSharedValue(0);
+
+    const rectsRef = useRef<Map<string, CategoryRect>>(new Map());
+    const draggingRef = useRef<{ task: Task; sourceCategoryId: string } | null>(null);
+
+    const [isDragging, setIsDragging] = useState(false);
+    const [hoveredCategoryId, setHoveredCategoryId] = useState<string | null>(null);
+    const [draggedTask, setDraggedTask] = useState<Task | null>(null);
+
+    const setCategoryRect = useCallback((rect: CategoryRect) => {
+        rectsRef.current.set(rect.categoryId, rect);
+    }, []);
+
+    const removeCategoryRect = useCallback((categoryId: string) => {
+        rectsRef.current.delete(categoryId);
+    }, []);
+
+    const beginDrag = useCallback((task: Task, sourceCategoryId: string, startX: number, startY: number) => {
+        draggingRef.current = { task, sourceCategoryId };
+        fingerX.value = startX;
+        fingerY.value = startY;
+        setDraggedTask(task);
+        setIsDragging(true);
+    }, [fingerX, fingerY]);
+
+    const updateDrag = useCallback((x: number, y: number) => {
+        fingerX.value = x;
+        fingerY.value = y;
+        const hit = categoryAtPoint(Array.from(rectsRef.current.values()), x, y);
+        setHoveredCategoryId((prev) => (prev === hit ? prev : hit));
+    }, [fingerX, fingerY]);
+
+    const endDrag = useCallback(() => {
+        const dragging = draggingRef.current;
+        const target = categoryAtPoint(Array.from(rectsRef.current.values()), fingerX.value, fingerY.value);
+        if (dragging && target && target !== dragging.sourceCategoryId) {
+            void moveTask(dragging.sourceCategoryId, dragging.task.id, target);
+        }
+        draggingRef.current = null;
+        setDraggedTask(null);
+        setHoveredCategoryId(null);
+        setIsDragging(false);
+    }, [fingerX, fingerY, moveTask]);
+
+    const ghostStyle = useAnimatedStyle(() => ({
+        position: "absolute",
+        left: 0,
+        top: 0,
+        transform: [{ translateX: fingerX.value - 24 }, { translateY: fingerY.value - 24 }],
+        opacity: 0.92,
+    }));
+
+    return (
+        <DragContext.Provider
+            value={{
+                fingerX,
+                fingerY,
+                hoveredCategoryId,
+                isDragging,
+                setCategoryRect,
+                removeCategoryRect,
+                beginDrag,
+                updateDrag,
+                endDrag,
+            }}>
+            {children}
+            {isDragging && draggedTask && (
+                <View style={StyleSheet.absoluteFill} pointerEvents="none">
+                    <Reanimated.View style={[styles.ghost, ghostStyle]}>
+                        <TaskCard
+                            content={draggedTask.content}
+                            value={draggedTask.value}
+                            priority={draggedTask.priority as 0 | 1 | 2 | 3}
+                            id={draggedTask.id}
+                            categoryId={draggedTask.categoryID ?? ""}
+                            task={{ ...draggedTask }}
+                        />
+                    </Reanimated.View>
+                </View>
+            )}
+        </DragContext.Provider>
+    );
+};
+
+const styles = StyleSheet.create({
+    ghost: {
+        width: "90%",
+        shadowColor: "#000",
+        shadowOpacity: 0.25,
+        shadowRadius: 12,
+        shadowOffset: { width: 0, height: 6 },
+        elevation: 8,
+    },
+});

--- a/frontend/contexts/tasksContext.tsx
+++ b/frontend/contexts/tasksContext.tsx
@@ -2,7 +2,10 @@ import { useAuth } from "@/hooks/useAuth";
 import React, { useEffect, useMemo, useCallback, startTransition } from "react";
 import { createContext, useState, useContext } from "react";
 import { Task, Workspace, Categories, BlueprintWorkspace } from "../api/types";
-import { getUserTemplatesAPI } from "@/api/task";
+import { getUserTemplatesAPI, moveTaskAPI } from "@/api/task";
+import { moveTaskInWorkspaces } from "@/utils/moveTask";
+import { showToastable } from "react-native-toastable";
+import DefaultToast from "@/components/ui/DefaultToast";
 import { computePhantomTasks } from "@/utils/phantomTasks";
 import { fetchUserWorkspaces, createWorkspace } from "@/api/workspace";
 import { renameWorkspace as renameWorkspaceAPI, renameCategory as renameCategoryAPI, updateWorkspaceMeta } from "@/api/category";
@@ -34,6 +37,7 @@ type TaskContextType = {
     addToWorkspace: (name: string, category: Categories) => void;
     addWorkspace: (name: string, category: Categories, icon?: string | null, color?: string | null) => void;
     updateTask: (categoryId: string, taskId: string, updates: Partial<Task>) => void;
+    moveTask: (sourceCategoryId: string, taskId: string, targetCategoryId: string) => Promise<void>;
     removeFromCategory: (categoryId: string, taskId: string) => void;
     removeFromWorkspace: (name: string, categoryId: string) => void;
     removeWorkspace: (name: string) => void;
@@ -295,6 +299,36 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
 
         invalidateWorkspacesCache();
     }, [invalidateWorkspacesCache]);
+
+    const moveTask = useCallback(
+        async (sourceCategoryId: string, taskId: string, targetCategoryId: string) => {
+            if (sourceCategoryId === targetCategoryId) return;
+
+            let snapshot: Workspace[] = [];
+            setRawWorkspaces((prev) => {
+                snapshot = prev;
+                return moveTaskInWorkspaces(prev, sourceCategoryId, taskId, targetCategoryId);
+            });
+            invalidateWorkspacesCache();
+
+            try {
+                await moveTaskAPI(sourceCategoryId, taskId, targetCategoryId);
+            } catch (error) {
+                logger.error("Failed to move task, rolling back", error);
+                setRawWorkspaces(snapshot);
+                invalidateWorkspacesCache();
+                showToastable({
+                    title: "Couldn't move task",
+                    status: "danger",
+                    position: "top",
+                    message: "Something went wrong. Please try again.",
+                    swipeDirection: "up",
+                    renderContent: (props) => <DefaultToast {...props} />,
+                });
+            }
+        },
+        [invalidateWorkspacesCache]
+    );
 
     const addToWorkspace = useCallback((name: string, category: Categories) => {
         setRawWorkspaces(prev => prev.map(workspace => {
@@ -581,6 +615,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
         categories,
         addToCategory,
         updateTask,
+        moveTask,
         addToWorkspace,
         addWorkspace,
         removeFromCategory,
@@ -614,7 +649,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
         clearRecentWorkspaces,
     }), [
         workspaces, getWorkspace, fetchWorkspaces, selected, handleSetSelected,
-        categories, addToCategory, updateTask, addToWorkspace, addWorkspace,
+        categories, addToCategory, updateTask, moveTask, addToWorkspace, addWorkspace,
         removeFromCategory, removeFromWorkspace, removeWorkspace, restoreWorkspace,
         renameWorkspace, renameCategory, getCategoriesByTag, updateCategoryTags, updateWorkspaceIconColor, setCreateCategory,
         selectedCategory, showConfetti, task, getTaskById, doesWorkspaceExist,

--- a/frontend/utils/dragHitTest.ts
+++ b/frontend/utils/dragHitTest.ts
@@ -1,0 +1,29 @@
+export interface CategoryRect {
+    categoryId: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+/**
+ * Returns the categoryId of the first rect that contains (pointX, pointY),
+ * or null if the point is outside every rect. Coordinates are in window space.
+ */
+export function categoryAtPoint(
+    rects: CategoryRect[],
+    pointX: number,
+    pointY: number
+): string | null {
+    for (const r of rects) {
+        if (
+            pointX >= r.x &&
+            pointX <= r.x + r.width &&
+            pointY >= r.y &&
+            pointY <= r.y + r.height
+        ) {
+            return r.categoryId;
+        }
+    }
+    return null;
+}

--- a/frontend/utils/moveTask.ts
+++ b/frontend/utils/moveTask.ts
@@ -1,0 +1,40 @@
+import { Workspace, Task } from "@/api/types";
+
+/**
+ * Pure reducer: move a task from one category to the TOP of another, across the
+ * workspace tree. Returns a new array (no mutation). No-op (returns the same
+ * reference) when source === target or when the task cannot be located.
+ */
+export function moveTaskInWorkspaces(
+    workspaces: Workspace[],
+    sourceCategoryId: string,
+    taskId: string,
+    targetCategoryId: string
+): Workspace[] {
+    if (sourceCategoryId === targetCategoryId) return workspaces;
+
+    let moving: Task | undefined;
+    for (const ws of workspaces) {
+        for (const category of ws.categories) {
+            if (category.id === sourceCategoryId) {
+                moving = category.tasks.find((t) => t.id === taskId);
+            }
+        }
+    }
+    if (!moving) return workspaces;
+    const movingTask = moving;
+
+    return workspaces.map((ws) => ({
+        ...ws,
+        categories: ws.categories.map((category) => {
+            if (category.id === sourceCategoryId) {
+                return { ...category, tasks: category.tasks.filter((t) => t.id !== taskId) };
+            }
+            if (category.id === targetCategoryId) {
+                const placed: Task = { ...movingTask, categoryName: category.name };
+                return { ...category, tasks: [placed, ...category.tasks] };
+            }
+            return category;
+        }),
+    }));
+}


### PR DESCRIPTION
## Summary
Long-press a task to lift it, drag it onto another category, and drop to move it to the **top** of that category. If the task is recurring, its template re-points so future instances generate in the new category.

- **Backend:** new atomic `POST /v1/user/tasks/{category}/{id}/move` endpoint. Pulls the task from the source category, pushes it to the top of the target (`$position: 0`), and re-points the recurring template — all inside a **MongoDB transaction** (the first in this codebase; requires the replica set we run). Validates task existence and category ownership (403/404 mapping).
- **Frontend:** custom Reanimated drag layer (`DragProvider`) — a ghost follows the finger, categories register their on-screen rects, and the hovered category highlights. Drop fires an **optimistic** `moveTask` with rollback + toast on failure. Lift-on-hold gesture: hold → lift (haptic), move → drag, release-in-place → the existing Edit/Delete bottom menu (preserved). Edge auto-scroll while dragging.
- Pure logic (`moveTaskInWorkspaces` reducer, `categoryAtPoint` hit-test) and the backend service are covered by tests.

Design + plan: `docs/superpowers/specs/2026-06-01-drag-task-between-categories-design.md` (local).

## Scope notes
- Cross-category move only — no within-category reorder and no new ordering field (task order stays implicit array order).
- The regen commit also syncs pre-existing spec drift on main (`for-you`, `for-you/interactions`, `tags`); no behavior change.

## Test plan
Automated:
- [x] Backend `MoveTaskTestSuite` (top-of-target, template re-point, same-category no-op, cross-user rejection, task-not-found) — green
- [x] `moveTaskInWorkspaces` + `categoryAtPoint` unit tests — green
- [x] `tsc --noEmit` clean (excluding pre-existing `DatePager.tsx`)

Manual QA (device — gesture/animation can't be unit-tested):
- [ ] Hold ~350ms → haptic + card lifts (ghost appears)
- [ ] Drag over another category → it highlights; release → task moves to its top; reload confirms persistence
- [ ] Release in place (no movement) → Edit/Delete/Start-Working menu opens (unchanged)
- [ ] Horizontal swipe still completes/deletes (not hijacked by the drag)
- [ ] Recurring task: template `categoryID` re-points (next generated instance lands in the new category)
- [ ] Airplane mode → move snaps back with "Couldn't move task" toast (rollback)
- [ ] Drag near top/bottom edge auto-scrolls

## Known risk to validate on device
The gesture composition uses `Gesture.Simultaneous(Gesture.Race(longPress, longPressMenu), pan)`. The two 350ms long-press recognizers racing may, on some platforms, cancel the menu recognizer when the lift recognizer wins — which could suppress the **release-in-place → menu** path. This needs device verification; if it misfires, fold the lift + menu-open into a single LongPress (`onStart` lifts, `onEnd(success)` opens the menu only when the pan never activated) instead of racing two recognizers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)