### PR TITLE
feat: user tagging in posts

### DIFF
--- a/backend/internal/handlers/notifications/types.go
+++ b/backend/internal/handlers/notifications/types.go
@@ -29,6 +29,7 @@ const (
 	NotificationTypeFriendRequestAccepted NotificationType = "FRIEND_REQUEST_ACCEPTED"
 	NotificationTypePost                  NotificationType = "POST"
 	NotificationTypeRingsClosed           NotificationType = "RINGS_CLOSED"
+	NotificationTypePostTag               NotificationType = "POST_TAG"
 )
 
 // NotificationDocument represents a notification stored in the database

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/internal/xvalidator"
@@ -140,6 +141,24 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 			if delta.JustClosedAll {
 				h.service.RingService.NotifyAllRingsClosed(userObjID)
 			}
+		}
+	}
+
+	// Fan out tag notifications.
+	var thumbnail string
+	if len(createdPost.Images) > 0 {
+		thumbnail = createdPost.Images[0]
+	}
+	for _, tagged := range createdPost.TaggedUsers {
+		if tagged.ID == userObjID {
+			continue
+		}
+		content := fmt.Sprintf("%s tagged you in a post", createdPost.User.DisplayName)
+		if err := h.service.NotificationService.CreateNotification(userObjID, tagged.ID, content, notifications.NotificationTypePostTag, createdPost.ID, thumbnail); err != nil {
+			slog.Error("Failed to create tag notification", "tagged_user_id", tagged.ID, "err", err)
+		}
+		if err := h.service.sendTagPushNotification(tagged.ID, createdPost.ID, createdPost.User.DisplayName); err != nil {
+			slog.Error("Failed to send tag push notification", "tagged_user_id", tagged.ID, "err", err)
 		}
 	}
 

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -94,6 +94,33 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 
 	doc.Metadata.IsPublic = input.Body.IsPublic
 
+	// Collect tag candidates: explicit + encourager auto-tag.
+	var tagCandidates []primitive.ObjectID
+	for _, m := range input.Body.TaggedUsers {
+		if objID, err := primitive.ObjectIDFromHex(m.ID); err == nil {
+			tagCandidates = append(tagCandidates, objID)
+		}
+	}
+	if input.Body.Task != nil && h.service.EncouragementService != nil {
+		taskID := input.Body.Task.ID
+		encs, encErr := h.service.EncouragementService.GetEncouragementsByTaskAndReceiver(taskID, userObjID)
+		if encErr != nil {
+			slog.Warn("Failed to fetch encouragements for auto-tag", "task_id", taskID, "err", encErr)
+		} else {
+			for _, e := range encs {
+				tagCandidates = append(tagCandidates, e.Sender.ID)
+			}
+		}
+	}
+	if len(tagCandidates) > 0 {
+		resolved, resolveErr := h.service.ResolveTaggedUsers(ctx, userObjID, tagCandidates)
+		if resolveErr != nil {
+			slog.Warn("Failed to resolve tagged users", "err", resolveErr)
+		} else {
+			doc.TaggedUsers = resolved
+		}
+	}
+
 	createdPost, userStats, err := h.service.CreatePost(&doc)
 	if err != nil {
 		slog.Error("failed to create post", "userId", user_id, "error", err)

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -630,7 +630,7 @@ func (h *Handler) UpdatePostHuma(ctx context.Context, input *UpdatePostInput) (*
 		return nil, huma.Error403Forbidden("You can only edit your own posts")
 	}
 
-	if err := h.service.UpdatePartialPost(id, input.Body); err != nil {
+	if err := h.service.UpdatePartialPost(ctx, id, input.Body); err != nil {
 		slog.Error("failed to update post", "userId", user_id, "postId", input.ID, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to update post. Please try again.", err)
 	}

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
@@ -26,15 +27,16 @@ type UserStatsUpdate struct {
 // newService receives the map of collections and picks out Jobs
 func newService(collections map[string]*mongo.Collection, ringService *rings.RingService) *Service {
 	return &Service{
-		Posts:               collections["posts"],
-		Users:               collections["users"],
-		Blueprints:          collections["blueprints"],
-		Categories:          collections["categories"],
-		Groups:              collections["groups"],
-		Connections:         collections["friend-requests"],
-		Reports:             collections["reports"],
-		NotificationService: notifications.NewNotificationService(collections),
-		RingService:         ringService,
+		Posts:                collections["posts"],
+		Users:                collections["users"],
+		Blueprints:           collections["blueprints"],
+		Categories:           collections["categories"],
+		Groups:               collections["groups"],
+		Connections:          collections["friend-requests"],
+		Reports:              collections["reports"],
+		NotificationService:  notifications.NewNotificationService(collections),
+		RingService:          ringService,
+		EncouragementService: encouragement.NewEncouragementService(collections),
 	}
 }
 

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -1287,3 +1287,93 @@ func (s *Service) GetFriendsRingClosures(userID primitive.ObjectID, limit, offse
 
 	return results, int(total), nil
 }
+
+// ResolveTaggedUsers validates a candidate set of user IDs against the
+// author's friends list and returns canonical MentionReferences in the
+// original insertion order, deduped, with self excluded.
+func (s *Service) ResolveTaggedUsers(ctx context.Context, authorID primitive.ObjectID, candidates []primitive.ObjectID) ([]types.MentionReference, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	// 1. Load the author's accepted friend IDs.
+	cursor, err := s.Connections.Find(ctx, bson.M{
+		"users":  authorID,
+		"status": "friends",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to query author's friends: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var connections []struct {
+		Users []primitive.ObjectID `bson:"users"`
+	}
+	if err := cursor.All(ctx, &connections); err != nil {
+		return nil, fmt.Errorf("failed to decode friends: %w", err)
+	}
+
+	friends := make(map[primitive.ObjectID]struct{}, len(connections))
+	for _, c := range connections {
+		for _, uid := range c.Users {
+			if uid != authorID {
+				friends[uid] = struct{}{}
+			}
+		}
+	}
+
+	// 2. Walk candidates in order, keeping the first occurrence of each
+	//    candidate that is a friend (and not the author themselves).
+	seen := make(map[primitive.ObjectID]struct{}, len(candidates))
+	var validIDs []primitive.ObjectID
+	for _, cid := range candidates {
+		if cid == authorID {
+			continue
+		}
+		if _, ok := friends[cid]; !ok {
+			continue
+		}
+		if _, dup := seen[cid]; dup {
+			continue
+		}
+		seen[cid] = struct{}{}
+		validIDs = append(validIDs, cid)
+	}
+
+	if len(validIDs) == 0 {
+		return nil, nil
+	}
+
+	// 3. Fetch canonical handles in one query.
+	userCursor, err := s.Users.Find(ctx, bson.M{"_id": bson.M{"$in": validIDs}}, options.Find().SetProjection(bson.M{"_id": 1, "handle": 1}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch user handles: %w", err)
+	}
+	defer userCursor.Close(ctx)
+
+	var users []struct {
+		ID     primitive.ObjectID `bson:"_id"`
+		Handle string             `bson:"handle"`
+	}
+	if err := userCursor.All(ctx, &users); err != nil {
+		return nil, fmt.Errorf("failed to decode users: %w", err)
+	}
+
+	handleByID := make(map[primitive.ObjectID]string, len(users))
+	for _, u := range users {
+		handleByID[u.ID] = u.Handle
+	}
+
+	// 4. Build result in the order of validIDs.
+	result := make([]types.MentionReference, 0, len(validIDs))
+	for _, id := range validIDs {
+		handle, ok := handleByID[id]
+		if !ok {
+			// User was a friend but doesn't exist anymore — skip.
+			continue
+		}
+		result = append(result, types.MentionReference{ID: id, Handle: handle})
+	}
+
+	return result, nil
+}

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -272,8 +272,7 @@ func (s *Service) updateUserPostStats(ctx context.Context, userID primitive.Obje
 }
 
 // UpdatePartialPost updates only specified fields of a Post document by ObjectID.
-func (s *Service) UpdatePartialPost(id primitive.ObjectID, updated UpdatePostParams) error {
-	ctx := context.Background()
+func (s *Service) UpdatePartialPost(ctx context.Context, id primitive.ObjectID, updated UpdatePostParams) error {
 	filter := bson.M{"_id": id}
 
 	updateDoc := bson.M{
@@ -297,6 +296,54 @@ func (s *Service) UpdatePartialPost(id primitive.ObjectID, updated UpdatePostPar
 
 	if updated.Size != nil {
 		setMap["size"] = *updated.Size
+	}
+
+	if updated.TaggedUsers != nil {
+		// Fetch the existing post to diff against.
+		var existing types.PostDocument
+		if err := s.Posts.FindOne(ctx, bson.M{"_id": id, "metadata.isDeleted": false}).Decode(&existing); err != nil {
+			return fmt.Errorf("failed to fetch existing post for tag diff: %w", err)
+		}
+
+		var candidates []primitive.ObjectID
+		for _, m := range *updated.TaggedUsers {
+			if objID, err := primitive.ObjectIDFromHex(m.ID); err == nil {
+				candidates = append(candidates, objID)
+			}
+		}
+
+		resolved, err := s.ResolveTaggedUsers(ctx, existing.User.ID, candidates)
+		if err != nil {
+			return fmt.Errorf("failed to resolve tagged users: %w", err)
+		}
+
+		// Diff against the existing list.
+		prevSet := make(map[primitive.ObjectID]struct{}, len(existing.TaggedUsers))
+		for _, t := range existing.TaggedUsers {
+			prevSet[t.ID] = struct{}{}
+		}
+		var newlyAdded []types.MentionReference
+		for _, t := range resolved {
+			if _, found := prevSet[t.ID]; !found {
+				newlyAdded = append(newlyAdded, t)
+			}
+		}
+
+		setMap["taggedUsers"] = resolved
+
+		// Fan out notifications only to the newly added users.
+		var thumbnail string
+		if len(existing.Images) > 0 {
+			thumbnail = existing.Images[0]
+		}
+		for _, t := range newlyAdded {
+			if t.ID == existing.User.ID {
+				continue
+			}
+			content := fmt.Sprintf("%s tagged you in a post", existing.User.DisplayName)
+			_ = s.NotificationService.CreateNotification(existing.User.ID, t.ID, content, notifications.NotificationTypePostTag, existing.ID, thumbnail)
+			_ = s.sendTagPushNotification(t.ID, existing.ID, existing.User.DisplayName)
+		}
 	}
 
 	_, err := s.Posts.UpdateOne(ctx, filter, updateDoc)

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -1007,6 +1007,43 @@ func (s *Service) sendCommentNotification(postOwnerID, postID primitive.ObjectID
 	return xutils.SendNotification(notification)
 }
 
+// sendTagPushNotification sends a push notification when a user is tagged in a post.
+func (s *Service) sendTagPushNotification(taggedUserID, postID primitive.ObjectID, taggerName string) error {
+	if s.Users == nil {
+		return fmt.Errorf("users collection not available")
+	}
+
+	ctx := context.Background()
+
+	var taggedUser types.User
+	err := s.Users.FindOne(ctx, bson.M{"_id": taggedUserID}).Decode(&taggedUser)
+	if err != nil {
+		return fmt.Errorf("failed to get tagged user: %w", err)
+	}
+
+	if taggedUser.PushToken == "" {
+		slog.Warn("Tagged user has no push token", "tagged_user_id", taggedUserID)
+		return nil
+	}
+
+	data := map[string]string{
+		"type":        "post_tag",
+		"tagger_name": taggerName,
+	}
+	if !postID.IsZero() {
+		data["post_id"] = postID.Hex()
+	}
+
+	notification := xutils.Notification{
+		Token:   taggedUser.PushToken,
+		Title:   "You were tagged in a post",
+		Message: fmt.Sprintf("%s tagged you in a post", taggerName),
+		Data:    data,
+	}
+
+	return xutils.SendNotification(notification)
+}
+
 // CheckRelationship checks the relationship between two users
 // Returns true if they are friends or if it's the same user
 func (s *Service) CheckRelationship(viewerID, profileUserID primitive.ObjectID) (bool, error) {

--- a/backend/internal/handlers/post/service_test.go
+++ b/backend/internal/handlers/post/service_test.go
@@ -1467,3 +1467,69 @@ func (s *PostServiceTestSuite) TestToggleReaction_PostNotFound() {
 	// Should return error
 	s.Error(err)
 }
+
+// ========================================
+// resolveTaggedUsers Tests
+// ========================================
+
+func (s *PostServiceTestSuite) TestResolveTaggedUsers_FiltersNonFriends() {
+	author := s.GetUser(0)
+	friend := s.GetUser(1)
+	stranger := s.GetUser(2)
+
+	// Seed a "friends" connection between author and friend (sorted users array).
+	sortedIDs := []primitive.ObjectID{author.ID, friend.ID}
+	if author.ID.Hex() > friend.ID.Hex() {
+		sortedIDs = []primitive.ObjectID{friend.ID, author.ID}
+	}
+	_, err := s.Collections["friend-requests"].InsertOne(s.Ctx, bson.M{
+		"users":  sortedIDs,
+		"status": "friends",
+	})
+	s.Require().NoError(err)
+
+	// Candidate set includes friend and stranger; only friend should survive.
+	candidates := []primitive.ObjectID{friend.ID, stranger.ID}
+	result, err := s.service.ResolveTaggedUsers(s.Ctx, author.ID, candidates)
+
+	s.NoError(err)
+	s.Len(result, 1)
+	s.Equal(friend.ID, result[0].ID)
+	s.Equal(friend.Handle, result[0].Handle) // canonical handle from users collection
+}
+
+func (s *PostServiceTestSuite) TestResolveTaggedUsers_DedupesAndPreservesOrder() {
+	author := s.GetUser(0)
+	f1 := s.GetUser(1)
+	f2 := s.GetUser(2)
+
+	for _, friendID := range []primitive.ObjectID{f1.ID, f2.ID} {
+		sortedIDs := []primitive.ObjectID{author.ID, friendID}
+		if author.ID.Hex() > friendID.Hex() {
+			sortedIDs = []primitive.ObjectID{friendID, author.ID}
+		}
+		_, err := s.Collections["friend-requests"].InsertOne(s.Ctx, bson.M{
+			"users":  sortedIDs,
+			"status": "friends",
+		})
+		s.Require().NoError(err)
+	}
+
+	candidates := []primitive.ObjectID{f2.ID, f1.ID, f2.ID} // f2 duplicated
+	result, err := s.service.ResolveTaggedUsers(s.Ctx, author.ID, candidates)
+
+	s.NoError(err)
+	s.Len(result, 2)
+	s.Equal(f2.ID, result[0].ID) // insertion order preserved
+	s.Equal(f1.ID, result[1].ID)
+}
+
+func (s *PostServiceTestSuite) TestResolveTaggedUsers_DropsAuthorSelf() {
+	author := s.GetUser(0)
+
+	candidates := []primitive.ObjectID{author.ID}
+	result, err := s.service.ResolveTaggedUsers(s.Ctx, author.ID, candidates)
+
+	s.NoError(err)
+	s.Empty(result)
+}

--- a/backend/internal/handlers/post/service_test.go
+++ b/backend/internal/handlers/post/service_test.go
@@ -322,7 +322,7 @@ func (s *PostServiceTestSuite) TestUpdatePartialPost_Caption() {
 
 	// Update caption
 	newCaption := "Updated caption"
-	err = s.service.UpdatePartialPost(created.ID, Post.UpdatePostParams{
+	err = s.service.UpdatePartialPost(s.Ctx, created.ID, Post.UpdatePostParams{
 		Caption: &newCaption,
 	})
 	s.NoError(err)
@@ -348,7 +348,7 @@ func (s *PostServiceTestSuite) TestUpdatePartialPost_IsPublic() {
 
 	// Update to public
 	isPublic := true
-	err = s.service.UpdatePartialPost(created.ID, Post.UpdatePostParams{
+	err = s.service.UpdatePartialPost(s.Ctx, created.ID, Post.UpdatePostParams{
 		IsPublic: &isPublic,
 	})
 	s.NoError(err)
@@ -372,7 +372,7 @@ func (s *PostServiceTestSuite) TestUpdatePartialPost_Size() {
 
 	// Update size
 	newSize := types.ImageSize{Width: 1920, Height: 1080}
-	err = s.service.UpdatePartialPost(created.ID, Post.UpdatePostParams{
+	err = s.service.UpdatePartialPost(s.Ctx, created.ID, Post.UpdatePostParams{
 		Size: &newSize,
 	})
 	s.NoError(err)
@@ -399,7 +399,7 @@ func (s *PostServiceTestSuite) TestUpdatePartialPost_MultipleFields() {
 	// Update multiple fields
 	newCaption := "Updated"
 	isPublic := true
-	err = s.service.UpdatePartialPost(created.ID, Post.UpdatePostParams{
+	err = s.service.UpdatePartialPost(s.Ctx, created.ID, Post.UpdatePostParams{
 		Caption:  &newCaption,
 		IsPublic: &isPublic,
 	})
@@ -1532,6 +1532,71 @@ func (s *PostServiceTestSuite) TestResolveTaggedUsers_DropsAuthorSelf() {
 
 	s.NoError(err)
 	s.Empty(result)
+}
+
+// ========================================
+// CreatePost auto-tag Tests
+// ========================================
+
+// ========================================
+// UpdatePartialPost tag diff Tests
+// ========================================
+
+func (s *PostServiceTestSuite) TestUpdatePost_NotifiesOnlyNewlyAddedTags() {
+	author := s.GetUser(0)
+	f1 := s.GetUser(1)
+	f2 := s.GetUser(2)
+
+	// Seed both friendships.
+	for _, friend := range []primitive.ObjectID{f1.ID, f2.ID} {
+		sortedIDs := []primitive.ObjectID{author.ID, friend}
+		if author.ID.Hex() > friend.Hex() {
+			sortedIDs = []primitive.ObjectID{friend, author.ID}
+		}
+		_, err := s.Collections["friend-requests"].InsertOne(s.Ctx, bson.M{
+			"users":  sortedIDs,
+			"status": "friends",
+		})
+		s.Require().NoError(err)
+	}
+
+	// Create post with f1 already tagged.
+	post := s.GetPost(0) // fixture post owned by author (users[0])
+	_, err := s.Collections["posts"].UpdateOne(s.Ctx,
+		bson.M{"_id": post.ID},
+		bson.M{"$set": bson.M{
+			"taggedUsers": []bson.M{{"_id": f1.ID, "handle": f1.Handle}},
+			"user._id":    author.ID,
+		}})
+	s.Require().NoError(err)
+
+	// Snapshot notification count before.
+	countBefore, _ := s.Collections["notifications"].CountDocuments(s.Ctx, bson.M{
+		"notificationType": "POST_TAG",
+		"receiver":         f2.ID,
+	})
+
+	// Update with both f1 and f2.
+	newTags := []Post.MentionInput{
+		{ID: f1.ID.Hex(), Handle: f1.Handle},
+		{ID: f2.ID.Hex(), Handle: f2.Handle},
+	}
+	params := Post.UpdatePostParams{TaggedUsers: &newTags}
+	err = s.service.UpdatePartialPost(s.Ctx, post.ID, params)
+	s.Require().NoError(err)
+
+	// f2 (newly added) should have a new notification; f1 should NOT.
+	countAfter, _ := s.Collections["notifications"].CountDocuments(s.Ctx, bson.M{
+		"notificationType": "POST_TAG",
+		"receiver":         f2.ID,
+	})
+	s.Equal(int64(1), countAfter-countBefore)
+
+	f1Notifs, _ := s.Collections["notifications"].CountDocuments(s.Ctx, bson.M{
+		"notificationType": "POST_TAG",
+		"receiver":         f1.ID,
+	})
+	s.Equal(int64(0), f1Notifs)
 }
 
 // ========================================

--- a/backend/internal/handlers/post/service_test.go
+++ b/backend/internal/handlers/post/service_test.go
@@ -1533,3 +1533,75 @@ func (s *PostServiceTestSuite) TestResolveTaggedUsers_DropsAuthorSelf() {
 	s.NoError(err)
 	s.Empty(result)
 }
+
+// ========================================
+// CreatePost auto-tag Tests
+// ========================================
+
+func (s *PostServiceTestSuite) TestCreatePost_AutoTagsEncouragers() {
+	author := s.GetUser(0)
+	encourager := s.GetUser(1)
+
+	// Seed friendship author <-> encourager
+	sortedIDs := []primitive.ObjectID{author.ID, encourager.ID}
+	if author.ID.Hex() > encourager.ID.Hex() {
+		sortedIDs = []primitive.ObjectID{encourager.ID, author.ID}
+	}
+	_, err := s.Collections["friend-requests"].InsertOne(s.Ctx, bson.M{
+		"users":  sortedIDs,
+		"status": "friends",
+	})
+	s.Require().NoError(err)
+
+	// Seed an encouragement from encourager → author on some task
+	taskID := primitive.NewObjectID()
+	_, err = s.Collections["encouragements"].InsertOne(s.Ctx, bson.M{
+		"taskId":   taskID,
+		"receiver": author.ID,
+		"sender": bson.M{
+			"id":      encourager.ID,
+			"name":    encourager.DisplayName,
+			"picture": encourager.ProfilePicture,
+		},
+		"type":  "encouragement",
+		"scope": "task",
+	})
+	s.Require().NoError(err)
+
+	// Simulate what the handler does: build candidates from encouragements + resolve.
+	encs, err := s.service.EncouragementService.GetEncouragementsByTaskAndReceiver(taskID, author.ID)
+	s.Require().NoError(err)
+
+	var candidates []primitive.ObjectID
+	for _, e := range encs {
+		candidates = append(candidates, e.Sender.ID)
+	}
+
+	resolved, err := s.service.ResolveTaggedUsers(s.Ctx, author.ID, candidates)
+	s.Require().NoError(err)
+
+	// Create the post with the resolved tags already applied (mirrors handler logic).
+	newPost := &types.PostDocument{
+		ID:      primitive.NewObjectID(),
+		Caption: "Did it!",
+		User: types.UserExtendedReferenceInternal{
+			ID:             author.ID,
+			DisplayName:    author.DisplayName,
+			Handle:         author.Handle,
+			ProfilePicture: author.ProfilePicture,
+		},
+		Task: &types.PostTaskExtendedReference{
+			ID:      taskID,
+			Content: "Some task",
+		},
+		TaggedUsers: resolved,
+		Reactions:   map[string][]primitive.ObjectID{},
+		Comments:    []types.CommentDocument{},
+		Metadata:    types.PostMetadata{IsDeleted: false},
+	}
+	post, _, err := s.service.CreatePost(newPost)
+	s.Require().NoError(err)
+
+	s.Len(post.TaggedUsers, 1)
+	s.Equal(encourager.ID, post.TaggedUsers[0].ID)
+}

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -1,6 +1,7 @@
 package Post
 
 import (
+	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
@@ -254,13 +255,14 @@ Database layer of the application
 */
 
 type Service struct {
-	Posts               *mongo.Collection
-	Users               *mongo.Collection
-	Categories          *mongo.Collection
-	Blueprints          *mongo.Collection
-	Groups              *mongo.Collection
-	Connections         *mongo.Collection
-	Reports             *mongo.Collection
-	NotificationService *notifications.Service
-	RingService         *rings.RingService
+	Posts                *mongo.Collection
+	Users                *mongo.Collection
+	Categories           *mongo.Collection
+	Blueprints           *mongo.Collection
+	Groups               *mongo.Collection
+	Connections          *mongo.Collection
+	Reports              *mongo.Collection
+	NotificationService  *notifications.Service
+	RingService          *rings.RingService
+	EncouragementService *encouragement.Service
 }

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -34,6 +34,7 @@ type CreatePostParams struct {
 	BlueprintIsPublic *bool                            `json:"blueprintIsPublic,omitempty"`
 	Groups            []string                         `json:"groups,omitempty" validate:"omitempty,dive,len=24"`
 	IsPublic          bool                             `json:"isPublic"`
+	TaggedUsers       []MentionInput                   `json:"taggedUsers,omitempty" validate:"omitempty,max=20,dive"`
 }
 
 // Get Posts (all)
@@ -152,9 +153,10 @@ type UpdatePostOutput struct {
 }
 
 type UpdatePostParams struct {
-	Caption  *string          `json:"caption,omitempty"`
-	IsPublic *bool            `json:"isPublic,omitempty"`
-	Size     *types.ImageSize `json:"size,omitempty"`
+	Caption     *string          `json:"caption,omitempty"`
+	IsPublic    *bool            `json:"isPublic,omitempty"`
+	Size        *types.ImageSize `json:"size,omitempty"`
+	TaggedUsers *[]MentionInput  `json:"taggedUsers,omitempty" validate:"omitempty,max=20,dive"`
 }
 
 // Get User Groups (for posts)

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -400,10 +400,11 @@ type PostDocument struct {
 	Caption string     `bson:"caption" json:"caption"`
 	Size    *ImageSize `bson:"size,omitempty" json:"size,omitempty"`
 
-	Category  *CategoryExtendedReference  `bson:"category,omitempty" json:"category,omitempty"`
-	Task      *PostTaskExtendedReference  `bson:"task,omitempty" json:"task,omitempty"`
-	Blueprint *EnhancedBlueprintReference `bson:"blueprint,omitempty" json:"blueprint,omitempty"`
-	Groups    []primitive.ObjectID        `bson:"groups,omitempty" json:"groups,omitempty"`
+	Category    *CategoryExtendedReference  `bson:"category,omitempty" json:"category,omitempty"`
+	Task        *PostTaskExtendedReference  `bson:"task,omitempty" json:"task,omitempty"`
+	Blueprint   *EnhancedBlueprintReference `bson:"blueprint,omitempty" json:"blueprint,omitempty"`
+	Groups      []primitive.ObjectID        `bson:"groups,omitempty" json:"groups,omitempty"`
+	TaggedUsers []MentionReference          `bson:"taggedUsers,omitempty" json:"taggedUsers,omitempty"`
 
 	Reactions map[string][]primitive.ObjectID `bson:"reactions" json:"reactions"`
 	Comments  []CommentDocument               `bson:"comments" json:"comments"`
@@ -605,14 +606,15 @@ type PostDocumentAPI struct {
 	ID   primitive.ObjectID    `json:"_id"`
 	User UserExtendedReference `json:"user"`
 
-	Images    []string                    `json:"images"`
-	Dual      *string                     `json:"dual,omitempty"`
-	Caption   string                      `json:"caption"`
-	Size      *ImageSize                  `json:"size,omitempty"`
-	Category  *CategoryExtendedReference  `json:"category,omitempty"`
-	Task      *PostTaskExtendedReference  `json:"task,omitempty"`
-	Blueprint *EnhancedBlueprintReference `json:"blueprint,omitempty"`
-	Groups    []string                    `json:"groups,omitempty"`
+	Images      []string                    `json:"images"`
+	Dual        *string                     `json:"dual,omitempty"`
+	Caption     string                      `json:"caption"`
+	Size        *ImageSize                  `json:"size,omitempty"`
+	Category    *CategoryExtendedReference  `json:"category,omitempty"`
+	Task        *PostTaskExtendedReference  `json:"task,omitempty"`
+	Blueprint   *EnhancedBlueprintReference `json:"blueprint,omitempty"`
+	Groups      []string                    `json:"groups,omitempty"`
+	TaggedUsers []MentionReference          `json:"taggedUsers,omitempty"`
 
 	Reactions map[string][]string  `json:"reactions"`
 	Comments  []CommentDocumentAPI `json:"comments"`
@@ -642,19 +644,20 @@ func (p *PostDocument) ToAPI() *PostDocumentAPI {
 	}
 
 	return &PostDocumentAPI{
-		ID:        p.ID,
-		User:      *p.User.ToAPI(),
-		Images:    p.Images,
-		Dual:      p.Dual,
-		Caption:   p.Caption,
-		Size:      p.Size,
-		Category:  p.Category,
-		Task:      p.Task,
-		Blueprint: p.Blueprint,
-		Groups:    groupStrings,
-		Reactions: apiReactions,
-		Comments:  apiComments,
-		Metadata:  p.Metadata,
+		ID:          p.ID,
+		User:        *p.User.ToAPI(),
+		Images:      p.Images,
+		Dual:        p.Dual,
+		Caption:     p.Caption,
+		Size:        p.Size,
+		Category:    p.Category,
+		Task:        p.Task,
+		Blueprint:   p.Blueprint,
+		Groups:      groupStrings,
+		TaggedUsers: p.TaggedUsers,
+		Reactions:   apiReactions,
+		Comments:    apiComments,
+		Metadata:    p.Metadata,
 	}
 }
 

--- a/backend/internal/storage/xmongo/indexes.go
+++ b/backend/internal/storage/xmongo/indexes.go
@@ -243,6 +243,13 @@ var Indexes = []Index{
 			},
 		},
 	},
+	// Supports future 'posts that tagged user X' query (e.g., profile "Tagged" tab)
+	{
+		Collection: "posts",
+		Model: mongo.IndexModel{
+			Keys: bson.D{{Key: "taggedUsers._id", Value: 1}},
+		},
+	},
 
 	// Friend-requests (connections) collection indexes
 	// Covers GetRelationship, IsBlocked, AcceptConnection lookups by user pair

--- a/frontend/__tests__/PostCardCaption.test.tsx
+++ b/frontend/__tests__/PostCardCaption.test.tsx
@@ -1,0 +1,18 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import PostCardCaption from "@/components/cards/PostCardCaption";
+
+jest.mock("expo-router", () => ({ router: { push: jest.fn() } }));
+
+describe("PostCardCaption", () => {
+    it("links @handle runs that match taggedUsers", () => {
+        const { getByText } = render(
+            <PostCardCaption
+                caption="hi @sarah and @notreal"
+                taggedUsers={[{ id: "u1", handle: "sarah" }]}
+            />
+        );
+        expect(getByText("@sarah")).toBeTruthy();
+        expect(getByText("@notreal")).toBeTruthy(); // rendered, but as plain text
+    });
+});

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -3627,6 +3627,84 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/for-you:
+        get:
+            tags:
+                - for-you
+            summary: Get the For You feed
+            description: Returns the curated For You feed for the authenticated user, organized into Catch up and Suggested for you sections.
+            operationId: get-for-you
+            parameters:
+                - name: Authorization
+                  in: header
+                  description: Bearer token
+                  required: true
+                  schema:
+                    type: string
+                    description: Bearer token
+                - name: refresh_token
+                  in: header
+                  description: Refresh token
+                  required: true
+                  schema:
+                    type: string
+                    description: Refresh token
+                - name: X-Timezone
+                  in: header
+                  description: IANA timezone, e.g. America/New_York
+                  schema:
+                    type: string
+                    description: IANA timezone, e.g. America/New_York
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/ForYouFeed'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/user/for-you/interactions:
+        post:
+            tags:
+                - for-you
+            summary: Record a For You CTA interaction
+            description: Increments the interaction counter for a card type, counting toward the threshold that switches the card to compact display mode.
+            operationId: record-for-you-interaction
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: refresh_token
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RecordInteractionParams'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/RecordInteractionOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/groups:
         get:
             tags:
@@ -5070,6 +5148,32 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tags:
+        get:
+            tags:
+                - categories
+            summary: Get user tags
+            description: Retrieve the distinct list of category tags for the authenticated user
+            operationId: get-user-tags
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/GetUserTagsOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/tasks/:
         get:
             tags:
@@ -6302,32 +6406,6 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/DeleteWaitlistOutputBody'
-                default:
-                    description: Error
-                    content:
-                        application/problem+json:
-                            schema:
-                                $ref: '#/components/schemas/ErrorModel'
-    /v1/user/tags:
-        get:
-            tags:
-                - categories
-            summary: Get user tags
-            description: Retrieve the distinct list of category tags for the authenticated user
-            operationId: get-user-tags
-            parameters:
-                - name: Authorization
-                  in: header
-                  required: true
-                  schema:
-                    type: string
-            responses:
-                "200":
-                    description: OK
-                    content:
-                        application/json:
-                            schema:
-                                $ref: '#/components/schemas/GetUserTagsOutputBody'
                 default:
                     description: Error
                     content:
@@ -8168,6 +8246,10 @@ components:
                     $ref: '#/components/schemas/RingDelta'
                 size:
                     $ref: '#/components/schemas/ImageSize'
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MentionReference'
                 task:
                     $ref: '#/components/schemas/PostTaskExtendedReference'
                 user:
@@ -8224,6 +8306,10 @@ components:
                     type: boolean
                 size:
                     $ref: '#/components/schemas/ImageSize'
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MentionInput'
                 task:
                     $ref: '#/components/schemas/PostTaskExtendedReference'
             required:
@@ -9190,6 +9276,150 @@ components:
                 - target
                 - period
                 - completedInPeriod
+        ForYouCard:
+            type: object
+            additionalProperties: false
+            properties:
+                body:
+                    type: string
+                    description: Present iff displayMode == full
+                ctas:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouCta'
+                deepLink:
+                    type: string
+                    description: Tap-target for the entire card
+                displayMode:
+                    type: string
+                iconKind:
+                    type: string
+                id:
+                    type: string
+                priority:
+                    type: integer
+                    format: int64
+                subject:
+                    $ref: '#/components/schemas/ForYouSubject'
+                title:
+                    type: string
+                type:
+                    type: string
+            required:
+                - id
+                - type
+                - displayMode
+                - iconKind
+                - title
+                - ctas
+                - deepLink
+                - priority
+        ForYouCta:
+            type: object
+            additionalProperties: false
+            properties:
+                action:
+                    $ref: '#/components/schemas/ForYouCtaAction'
+                kind:
+                    type: string
+                    description: primary | secondary
+                    examples:
+                        - primary
+                label:
+                    type: string
+                    examples:
+                        - Send one back
+            required:
+                - label
+                - kind
+                - action
+        ForYouCtaAction:
+            type: object
+            additionalProperties: false
+            properties:
+                href:
+                    type: string
+                    examples:
+                        - /(logged-in)/(tabs)/(task)/kudos
+                postId:
+                    type: string
+                reaction:
+                    type: string
+                referenceId:
+                    type: string
+                targetUserId:
+                    type: string
+                taskId:
+                    type: string
+                type:
+                    type: string
+                    description: navigate | send_kudos | send_encouragement | react
+                    examples:
+                        - navigate
+            required:
+                - type
+        ForYouFeed:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/ForYouFeed.json
+                    readOnly: true
+                sections:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouSection'
+                unreadCount:
+                    type: integer
+                    description: Number of catch_up cards driving the tab dot
+                    format: int64
+            required:
+                - sections
+                - unreadCount
+        ForYouSection:
+            type: object
+            additionalProperties: false
+            properties:
+                cards:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ForYouCard'
+                id:
+                    type: string
+                    description: catch_up | suggested
+                    examples:
+                        - catch_up
+                title:
+                    type: string
+                    examples:
+                        - Catch up
+            required:
+                - id
+                - title
+                - cards
+        ForYouSubject:
+            type: object
+            additionalProperties: false
+            properties:
+                avatarUrl:
+                    type: string
+                    examples:
+                        - https://example.com/avatar.jpg
+                displayName:
+                    type: string
+                    examples:
+                        - Sarah
+                userId:
+                    type: string
+                    examples:
+                        - 507f1f77bcf86cd799439011
+            required:
+                - userId
+                - displayName
         FriendReference:
             type: object
             additionalProperties: false
@@ -10340,6 +10570,10 @@ components:
                             type: string
                 size:
                     $ref: '#/components/schemas/ImageSize'
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MentionReference'
                 task:
                     $ref: '#/components/schemas/PostTaskExtendedReference'
                 user:
@@ -10617,6 +10851,41 @@ components:
             required:
                 - tasks
                 - query
+        RecordInteractionOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RecordInteractionOutputBody.json
+                    readOnly: true
+                message:
+                    type: string
+                    examples:
+                        - Interaction recorded
+            required:
+                - message
+        RecordInteractionParams:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RecordInteractionParams.json
+                    readOnly: true
+                cardType:
+                    type: string
+                    description: Card type the user interacted with
+                    examples:
+                        - kudos_received
+            required:
+                - cardType
         RecurDetails:
             type: object
             additionalProperties: false
@@ -12516,6 +12785,10 @@ components:
                     type: boolean
                 size:
                     $ref: '#/components/schemas/ImageSize'
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/MentionInput'
         UpdateProfileDocument:
             type: object
             additionalProperties: false

--- a/frontend/api/encouragement.ts
+++ b/frontend/api/encouragement.ts
@@ -139,6 +139,17 @@ export const updateEncouragementAPI = async (id: string, message: string): Promi
 };
 
 /**
+ * Get encouragements received by the current user that are scoped to a specific task.
+ * Filters the full encouragements list client-side since the backend endpoint doesn't
+ * support task-scoped queries from the frontend.
+ * @param taskId - The task ID to filter by
+ */
+export const getEncouragementsByTask = async (taskId: string): Promise<EncouragementDocument[]> => {
+    const all = await getEncouragementsAPI();
+    return all.filter((e) => e.taskId === taskId);
+};
+
+/**
  * Delete an encouragement message
  * API: Makes DELETE request to remove the encouragement
  * Frontend: Used to delete encouragement messages

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -1780,6 +1780,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/for-you": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the For You feed
+         * @description Returns the curated For You feed for the authenticated user, organized into Catch up and Suggested for you sections.
+         */
+        get: operations["get-for-you"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/user/for-you/interactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Record a For You CTA interaction
+         * @description Increments the interaction counter for a card type, counting toward the threshold that switches the card to compact display mode.
+         */
+        post: operations["record-for-you-interaction"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/groups": {
         parameters: {
             query?: never;
@@ -2472,6 +2512,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get user tags
+         * @description Retrieve the distinct list of category tags for the authenticated user
+         */
+        get: operations["get-user-tags"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/tasks/": {
         parameters: {
             query?: never;
@@ -3043,26 +3103,6 @@ export interface paths {
          * @description Remove a waitlist entry by its ID
          */
         delete: operations["delete-waitlist"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/v1/user/tags": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get user tags
-         * @description Retrieve the distinct list of category tags for the authenticated user
-         */
-        get: operations["get-user-tags"];
-        put?: never;
-        post?: never;
-        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -4256,6 +4296,7 @@ export interface components {
             /** @description Describes the Share ring increment triggered by this post so the client can render feedback */
             ringDelta?: components["schemas"]["RingDelta"];
             size?: components["schemas"]["ImageSize"];
+            taggedUsers?: components["schemas"]["MentionReference"][];
             task?: components["schemas"]["PostTaskExtendedReference"];
             user: components["schemas"]["UserExtendedReference"];
         };
@@ -4280,6 +4321,7 @@ export interface components {
             images: string[];
             isPublic: boolean;
             size?: components["schemas"]["ImageSize"];
+            taggedUsers?: components["schemas"]["MentionInput"][];
             task?: components["schemas"]["PostTaskExtendedReference"];
         };
         CreateTaskNaturalLanguageInputBody: {
@@ -4836,6 +4878,77 @@ export interface components {
             periodStart?: string;
             /** Format: int64 */
             target: number;
+        };
+        ForYouCard: {
+            /** @description Present iff displayMode == full */
+            body?: string;
+            ctas: components["schemas"]["ForYouCta"][];
+            /** @description Tap-target for the entire card */
+            deepLink: string;
+            displayMode: string;
+            iconKind: string;
+            id: string;
+            /** Format: int64 */
+            priority: number;
+            subject?: components["schemas"]["ForYouSubject"];
+            title: string;
+            type: string;
+        };
+        ForYouCta: {
+            action: components["schemas"]["ForYouCtaAction"];
+            /**
+             * @description primary | secondary
+             * @example primary
+             */
+            kind: string;
+            /** @example Send one back */
+            label: string;
+        };
+        ForYouCtaAction: {
+            /** @example /(logged-in)/(tabs)/(task)/kudos */
+            href?: string;
+            postId?: string;
+            reaction?: string;
+            referenceId?: string;
+            targetUserId?: string;
+            taskId?: string;
+            /**
+             * @description navigate | send_kudos | send_encouragement | react
+             * @example navigate
+             */
+            type: string;
+        };
+        ForYouFeed: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/ForYouFeed.json
+             */
+            readonly $schema?: string;
+            sections: components["schemas"]["ForYouSection"][];
+            /**
+             * Format: int64
+             * @description Number of catch_up cards driving the tab dot
+             */
+            unreadCount: number;
+        };
+        ForYouSection: {
+            cards: components["schemas"]["ForYouCard"][];
+            /**
+             * @description catch_up | suggested
+             * @example catch_up
+             */
+            id: string;
+            /** @example Catch up */
+            title: string;
+        };
+        ForYouSubject: {
+            /** @example https://example.com/avatar.jpg */
+            avatarUrl?: string;
+            /** @example Sarah */
+            displayName: string;
+            /** @example 507f1f77bcf86cd799439011 */
+            userId: string;
         };
         FriendReference: {
             /**
@@ -5486,6 +5599,7 @@ export interface components {
                 [key: string]: string[];
             };
             size?: components["schemas"]["ImageSize"];
+            taggedUsers?: components["schemas"]["MentionReference"][];
             task?: components["schemas"]["PostTaskExtendedReference"];
             user: components["schemas"]["UserExtendedReference"];
         };
@@ -5632,6 +5746,29 @@ export interface components {
             query: components["schemas"]["TaskQueryFilters"];
             /** @description Matching tasks */
             tasks: components["schemas"]["TaskDocument"][];
+        };
+        RecordInteractionOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RecordInteractionOutputBody.json
+             */
+            readonly $schema?: string;
+            /** @example Interaction recorded */
+            message: string;
+        };
+        RecordInteractionParams: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RecordInteractionParams.json
+             */
+            readonly $schema?: string;
+            /**
+             * @description Card type the user interacted with
+             * @example kudos_received
+             */
+            cardType: string;
         };
         RecurDetails: {
             behavior?: string;
@@ -6704,6 +6841,7 @@ export interface components {
             caption?: string;
             isPublic?: boolean;
             size?: components["schemas"]["ImageSize"];
+            taggedUsers?: components["schemas"]["MentionInput"][];
         };
         UpdateProfileDocument: {
             /**
@@ -10681,6 +10819,78 @@ export interface operations {
             };
         };
     };
+    "get-for-you": {
+        parameters: {
+            query?: never;
+            header: {
+                /** @description Bearer token */
+                Authorization: string;
+                /** @description Refresh token */
+                refresh_token: string;
+                /** @description IANA timezone, e.g. America/New_York */
+                "X-Timezone"?: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForYouFeed"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "record-for-you-interaction": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+                refresh_token: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RecordInteractionParams"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecordInteractionOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-groups": {
         parameters: {
             query?: never;
@@ -12121,6 +12331,37 @@ export interface operations {
             };
         };
     };
+    "get-user-tags": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GetUserTagsOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-tasks-by-user": {
         parameters: {
             query?: {
@@ -13268,37 +13509,6 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeleteWaitlistOutputBody"];
-                };
-            };
-            /** @description Error */
-            default: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/problem+json": components["schemas"]["ErrorModel"];
-                };
-            };
-        };
-    };
-    "get-user-tags": {
-        parameters: {
-            query?: never;
-            header: {
-                Authorization: string;
-            };
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["GetUserTagsOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/api/post.ts
+++ b/frontend/api/post.ts
@@ -35,7 +35,8 @@ export const createPost = async (
     isPublic: boolean = true,
     size?: { width: number; height: number; bytes: number },
     groups?: string[],
-    dual?: string
+    dual?: string,
+    taggedUsers?: Array<{ id: string; handle: string }>,
 ): Promise<{
     post: PostDocumentAPI;
     userStats: { posts_made: number; points: number } | null;
@@ -51,7 +52,8 @@ export const createPost = async (
             isPublic,
             size,
             groups,
-            dual
+            dual,
+            taggedUsers,
         },
     });
 
@@ -431,11 +433,12 @@ export const updatePost = async (
     postId: string,
     caption?: string,
     isPublic?: boolean,
-    size?: { width: number; height: number; bytes: number }
+    size?: { width: number; height: number; bytes: number },
+    taggedUsers?: Array<{ id: string; handle: string }>,
 ): Promise<void> => {
     const { error } = await client.PATCH("/v1/user/posts/{id}", {
         params: withAuthHeaders({ path: { id: postId } }),
-        body: { caption, isPublic, size },
+        body: { caption, isPublic, size, taggedUsers },
     });
 
     if (error) {
@@ -452,14 +455,15 @@ export const createPostToBackend = async (
     isPublic: boolean = false,
     size?: { width: number; height: number; bytes: number },
     groups?: string[],
-    dual?: string
+    dual?: string,
+    taggedUsers?: Array<{ id: string; handle: string }>,
 ): Promise<{
     post: PostDocumentAPI;
     userStats: { posts_made: number; points: number } | null;
     ringDelta?: RingDelta;
 }> => {
     try {
-        const result = await createPost(images, caption, taskReference, blueprintId, isPublic, size, groups, dual);
+        const result = await createPost(images, caption, taskReference, blueprintId, isPublic, size, groups, dual, taggedUsers);
         return result;
     } catch (error) {
         logger.error("Failed to create post to backend", error);

--- a/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/Notifications.tsx
@@ -30,7 +30,7 @@ const ACTIVITY_TAB_INDEX = 1;
 
 type ProcessedNotification = {
     id: string;
-    type: "comment" | "encouragement" | "congratulation" | "friend_request" | "friend_request_accepted" | "rings_closed";
+    type: "comment" | "encouragement" | "congratulation" | "friend_request" | "friend_request_accepted" | "rings_closed" | "post_tag";
     name: string;
     handle: string;
     userId: string;
@@ -381,6 +381,7 @@ const Notifications = () => {
                 // Already on the notifications page which shows friend requests
                 break;
             case "comment":
+            case "post_tag":
                 if (notification.referenceId) {
                     router.push(`/(logged-in)/posting/${notification.referenceId}`);
                 }
@@ -430,6 +431,7 @@ const Notifications = () => {
         "friend_request",
         "friend_request_accepted",
         "rings_closed",
+        "post_tag",
     ]);
 
     const processNotification = (notification: NotificationDocument): ProcessedNotification | null => {
@@ -473,7 +475,8 @@ const Notifications = () => {
                     | "encouragement"
                     | "congratulation"
                     | "friend_request"
-                    | "friend_request_accepted",
+                    | "friend_request_accepted"
+                    | "post_tag",
                 name: notification.user.display_name,
                 handle: notification.user.handle ?? "",
                 userId: notification.user.id,

--- a/frontend/app/(logged-in)/_layout.tsx
+++ b/frontend/app/(logged-in)/_layout.tsx
@@ -52,6 +52,7 @@ type NotificationType =
     | "friend_request_accepted"
     | "new_post"
     | "comment"
+    | "post_tag"
     | "rings_closed"
     | "TASK_MISSED"
     | "TASK_REGENERATED"
@@ -120,6 +121,11 @@ function getNotificationRoute(data: NotificationData | undefined): string | null
             }
             return "/(logged-in)/(tabs)/(feed)/feed";
         case "comment":
+            if (data.post_id) {
+                return `/(logged-in)/posting/${data.post_id}`;
+            }
+            return "/(logged-in)/(tabs)/(feed)/feed";
+        case "post_tag":
             if (data.post_id) {
                 return `/(logged-in)/posting/${data.post_id}`;
             }

--- a/frontend/app/(logged-in)/posting/_layout.tsx
+++ b/frontend/app/(logged-in)/posting/_layout.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Stack } from "expo-router";
+import { Dimensions } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { PostComposerProvider } from "@/contexts/PostComposerContext";
+
+export default function PostingLayout() {
+    const ThemedColor = useThemeColor();
+    return (
+        <PostComposerProvider>
+            <Stack
+                screenOptions={{
+                    headerShown: false,
+                    navigationBarHidden: true,
+                    contentStyle: {
+                        backgroundColor: ThemedColor.background,
+                        minHeight: Dimensions.get("screen").height,
+                    },
+                }}>
+                <Stack.Screen name="caption" />
+                <Stack.Screen name="groups" />
+                <Stack.Screen name="tag-people" options={{ presentation: "modal" }} />
+            </Stack>
+        </PostComposerProvider>
+    );
+}

--- a/frontend/app/(logged-in)/posting/caption.tsx
+++ b/frontend/app/(logged-in)/posting/caption.tsx
@@ -1,12 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { useLocalSearchParams, router } from "expo-router";
 import { View, TouchableOpacity, ScrollView, KeyboardAvoidingView, Platform } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedView } from "@/components/ThemedView";
-import LongTextInput from "@/components/inputs/LongTextInput";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import PrimaryButton from "@/components/inputs/PrimaryButton";
+import MentionTextInput from "@/components/inputs/MentionTextInput";
+import TaggedUsersChips, { TaggedUser } from "@/components/inputs/TaggedUsersChips";
 import { createPostToBackend } from "@/api/post";
 import { uploadImageSmart, ImageUploadResult } from "@/api/upload";
 import { ObjectId } from "bson";
@@ -20,6 +21,10 @@ import { Ionicons } from "@expo/vector-icons";
 import PostCardHeader from "@/components/cards/PostCardHeader";
 import PostCardMedia from "@/components/cards/PostCardMedia";
 import PostCardFooter from "@/components/cards/PostCardFooter";
+import { usePostComposer } from "@/contexts/PostComposerContext";
+import { getEncouragementsByTask } from "@/api/encouragement";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
+import type { Href } from "expo-router";
 
 export default function Caption() {
     const insets = useSafeAreaInsets();
@@ -41,9 +46,36 @@ export default function Caption() {
     const { capture } = useAnalytics();
     const { showRingUpdate } = useRingUpdate();
     const { selectedGroupId, selectedGroupName, getGroupIds } = useSelectedGroup();
+    const { taggedUsers, setTaggedUsers } = usePostComposer();
 
     // Compute display text based on state
     const groupDisplayText = selectedGroupId === null ? "All Friends" : (selectedGroupName || "Selected Group");
+
+    // Auto-fill encouragers when posting about a task
+    useEffect(() => {
+        if (!taskInfo?.id) return;
+        let cancelled = false;
+        (async () => {
+            try {
+                const encs = await getEncouragementsByTask(taskInfo.id);
+                if (cancelled) return;
+                const prefilled: TaggedUser[] = encs.map((e) => ({
+                    id: e.sender?.id,
+                    handle: (e.sender as any)?.handle ?? "",
+                    display_name: e.sender?.name,
+                })).filter((u) => u.id);
+                const seen = new Set<string>();
+                setTaggedUsers(prefilled.filter((u) => {
+                    if (seen.has(u.id)) return false;
+                    seen.add(u.id);
+                    return true;
+                }));
+            } catch (e) {
+                console.warn("failed to fetch encouragements for auto-tag", e);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [taskInfo?.id]);
 
     const hasActualPhotos = photos.length > 0;
     const handleCaptionChange = (text: string) => {
@@ -138,7 +170,8 @@ export default function Caption() {
                 taskInfo?.public ?? false,
                 uploadResult.sizeInfo,
                 selectedGroups,
-                uploadResult.dualUrl
+                uploadResult.dualUrl,
+                taggedUsers.map((u) => ({ id: u.id, handle: u.handle })),
             );
 
             // Update user stats locally if available
@@ -249,13 +282,49 @@ export default function Caption() {
 
                     {/* Caption and options */}
                     <View style={{ padding: 16, gap: 12 }}>
-                        <LongTextInput
+                        <MentionTextInput
                             placeholder="Enter a caption"
                             value={data.caption}
                             setValue={handleCaptionChange}
                             fontSize={16}
                             minHeight={120}
+                            onMentionPicked={(c: MentionCandidate) => {
+                                setTaggedUsers((prev) => {
+                                    if (prev.find((p) => p.id === c.id)) return prev;
+                                    return [...prev, { id: c.id, handle: c.handle, display_name: c.display_name }];
+                                });
+                            }}
                         />
+                        <TaggedUsersChips
+                            users={taggedUsers}
+                            onRemove={(id) => setTaggedUsers((prev) => prev.filter((p) => p.id !== id))}
+                        />
+                        <TouchableOpacity
+                            style={{
+                                width: "100%",
+                                padding: 20,
+                                justifyContent: "space-between",
+                                backgroundColor: ThemedColor.lightened,
+                                borderRadius: 8,
+                                flexDirection: "row",
+                                alignItems: "center",
+                            }}
+                            onPress={() => {
+                                router.push("/(logged-in)/posting/tag-people" as Href);
+                            }}
+                            activeOpacity={0.7}>
+                            <ThemedText>Tag people</ThemedText>
+                            <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
+                                <ThemedText style={{ color: ThemedColor.primary }}>
+                                    {taggedUsers.length === 0
+                                        ? "None"
+                                        : taggedUsers.length === 1
+                                            ? `@${taggedUsers[0].handle}`
+                                            : `${taggedUsers.length} tagged`}
+                                </ThemedText>
+                                <Ionicons name="chevron-forward" size={16} color={ThemedColor.primary} />
+                            </View>
+                        </TouchableOpacity>
                         <TouchableOpacity
                             style={{
                                 width: "100%",

--- a/frontend/app/(logged-in)/posting/tag-people.tsx
+++ b/frontend/app/(logged-in)/posting/tag-people.tsx
@@ -1,0 +1,106 @@
+import React, { useState, useMemo } from "react";
+import { View, FlatList, TouchableOpacity, TextInput } from "react-native";
+import { router } from "expo-router";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ThemedView } from "@/components/ThemedView";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+import { usePostComposer } from "@/contexts/PostComposerContext";
+import { Ionicons } from "@expo/vector-icons";
+import type { TaggedUser } from "@/components/inputs/TaggedUsersChips";
+
+export default function TagPeople() {
+    const insets = useSafeAreaInsets();
+    const ThemedColor = useThemeColor();
+    const { taggedUsers, setTaggedUsers } = usePostComposer();
+    const [selected, setSelected] = useState<Map<string, TaggedUser>>(
+        () => new Map(taggedUsers.map((u) => [u.id, u])),
+    );
+    const [query, setQuery] = useState("");
+    const { filter } = useFriendsForMention();
+    const matches = useMemo(() => filter(query), [query, filter]);
+
+    const toggle = (c: MentionCandidate) => {
+        setSelected((prev) => {
+            const next = new Map(prev);
+            if (next.has(c.id)) next.delete(c.id);
+            else next.set(c.id, { id: c.id, handle: c.handle, display_name: c.display_name });
+            return next;
+        });
+    };
+
+    const done = () => {
+        setTaggedUsers(Array.from(selected.values()));
+        router.back();
+    };
+
+    return (
+        <ThemedView style={{ flex: 1, paddingTop: insets.top }}>
+            <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: 16, paddingVertical: 12 }}>
+                <TouchableOpacity onPress={() => router.back()} hitSlop={8}>
+                    <Ionicons name="arrow-back" size={22} color={ThemedColor.text} />
+                </TouchableOpacity>
+                <ThemedText type="subtitle" style={{ marginLeft: 12, flex: 1 }}>Tag people</ThemedText>
+                <TouchableOpacity onPress={done}>
+                    <ThemedText style={{ color: ThemedColor.primary }}>Done</ThemedText>
+                </TouchableOpacity>
+            </View>
+            <TextInput
+                value={query}
+                onChangeText={setQuery}
+                placeholder="Search friends"
+                placeholderTextColor={ThemedColor.caption}
+                style={{
+                    marginHorizontal: 16,
+                    padding: 12,
+                    borderRadius: 8,
+                    backgroundColor: ThemedColor.lightened,
+                    color: ThemedColor.text,
+                }}
+            />
+            <FlatList
+                data={matches}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => {
+                    const checked = selected.has(item.id);
+                    return (
+                        <FriendRow
+                            item={item}
+                            checked={checked}
+                            onToggle={toggle}
+                            primaryColor={ThemedColor.primary}
+                            captionColor={ThemedColor.caption}
+                        />
+                    );
+                }}
+            />
+        </ThemedView>
+    );
+}
+
+type FriendRowProps = {
+    item: MentionCandidate;
+    checked: boolean;
+    onToggle: (c: MentionCandidate) => void;
+    primaryColor: string;
+    captionColor: string;
+};
+
+function FriendRow({ item, checked, onToggle, primaryColor, captionColor }: FriendRowProps) {
+    return (
+        <TouchableOpacity
+            onPress={() => onToggle(item)}
+            style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 16, gap: 12 }}>
+            <View style={{ flex: 1 }}>
+                <ThemedText type="defaultSemiBold">{item.display_name}</ThemedText>
+                <ThemedText type="caption">@{item.handle}</ThemedText>
+            </View>
+            <Ionicons
+                name={checked ? "checkmark-circle" : "ellipse-outline"}
+                size={22}
+                color={checked ? primaryColor : captionColor}
+            />
+        </TouchableOpacity>
+    );
+}

--- a/frontend/components/cards/PostCard.tsx
+++ b/frontend/components/cards/PostCard.tsx
@@ -46,6 +46,7 @@ type Props = {
     username: string;
     userId: string;
     caption: string;
+    taggedUsers?: Array<{ id: string; handle: string }>;
     time: number;
     priority?: string;
     points?: number;
@@ -70,6 +71,7 @@ const PostCard = React.memo(({
     username,
     userId,
     caption,
+    taggedUsers = [],
     time,
     priority,
     points,
@@ -609,6 +611,7 @@ const PostCard = React.memo(({
                     )}
                     <PostCardFooter
                         caption={caption}
+                        taggedUsers={taggedUsers}
                         category={category}
                         taskName={taskName}
                         reactions={localReactions}

--- a/frontend/components/cards/PostCardCaption.tsx
+++ b/frontend/components/cards/PostCardCaption.tsx
@@ -1,0 +1,61 @@
+import React from "react";
+import { Text } from "react-native";
+import { router } from "expo-router";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { Href } from "expo-router";
+
+type Props = {
+    caption: string;
+    taggedUsers: Array<{ id: string; handle: string }>;
+};
+
+const PostCardCaption = ({ caption, taggedUsers }: Props) => {
+    const ThemedColor = useThemeColor();
+    const tagIndex = React.useMemo(() => {
+        const m = new Map<string, string>(); // handle (lowercased) -> id
+        for (const t of taggedUsers) m.set(t.handle.toLowerCase(), t.id);
+        return m;
+    }, [taggedUsers]);
+
+    // Split the caption into plain text + mention runs.
+    // Regex: @ followed by handle chars (a-z 0-9 _ .).
+    const parts: Array<{ type: "text" | "mention"; value: string; id?: string }> = [];
+    const re = /@([a-zA-Z0-9_.]+)/g;
+    let last = 0;
+    let match: RegExpExecArray | null;
+    while ((match = re.exec(caption)) !== null) {
+        const id = tagIndex.get(match[1].toLowerCase());
+        if (match.index > last) {
+            parts.push({ type: "text", value: caption.slice(last, match.index) });
+        }
+        if (id) {
+            parts.push({ type: "mention", value: match[0], id });
+        } else {
+            parts.push({ type: "text", value: match[0] }); // raw @ without a matching tag → plain text
+        }
+        last = re.lastIndex;
+    }
+    if (last < caption.length) {
+        parts.push({ type: "text", value: caption.slice(last) });
+    }
+
+    return (
+        <ThemedText>
+            {parts.map((p, i) =>
+                p.type === "mention" ? (
+                    <Text
+                        key={i}
+                        style={{ color: ThemedColor.primary }}
+                        onPress={() => router.push(`/account/${p.id}` as Href)}>
+                        {p.value}
+                    </Text>
+                ) : (
+                    <Text key={i}>{p.value}</Text>
+                ),
+            )}
+        </ThemedText>
+    );
+};
+
+export default PostCardCaption;

--- a/frontend/components/cards/PostCardFooter.tsx
+++ b/frontend/components/cards/PostCardFooter.tsx
@@ -8,6 +8,9 @@ import ReactPills from "../inputs/ReactPills";
 import ReactionAction from "../inputs/ReactionAction";
 import type { SlackReaction } from "./PostCard";
 import PostCardCaption from "./PostCardCaption";
+import TaggedUsersChips from "@/components/inputs/TaggedUsersChips";
+import { router } from "expo-router";
+import type { Href } from "expo-router";
 
 export type PostCardFooterProps = {
     caption?: string;
@@ -89,6 +92,10 @@ const PostCardFooter = ({
                 {caption ? (
                     <PostCardCaption caption={caption} taggedUsers={taggedUsers} />
                 ) : null}
+                <TaggedUsersChips
+                    users={taggedUsers.map((t) => ({ id: t.id, handle: t.handle }))}
+                    onPressUser={(id) => router.push(`/account/${id}` as Href)}
+                />
 
                 {!readOnly && (
                     <View style={styles.reactionsRow}>

--- a/frontend/components/cards/PostCardFooter.tsx
+++ b/frontend/components/cards/PostCardFooter.tsx
@@ -7,9 +7,11 @@ import { Confetti } from "phosphor-react-native";
 import ReactPills from "../inputs/ReactPills";
 import ReactionAction from "../inputs/ReactionAction";
 import type { SlackReaction } from "./PostCard";
+import PostCardCaption from "./PostCardCaption";
 
 export type PostCardFooterProps = {
     caption?: string;
+    taggedUsers?: Array<{ id: string; handle: string }>;
     category?: string;
     taskName?: string;
     reactions?: SlackReaction[];
@@ -27,6 +29,7 @@ export type PostCardFooterProps = {
 
 const PostCardFooter = ({
     caption,
+    taggedUsers = [],
     category,
     taskName,
     reactions = [],
@@ -84,9 +87,7 @@ const PostCardFooter = ({
 
             <View style={styles.captionSection}>
                 {caption ? (
-                    <ThemedText type="default" style={[styles.caption, { color: ThemedColor.text }]}>
-                        {caption}
-                    </ThemedText>
+                    <PostCardCaption caption={caption} taggedUsers={taggedUsers} />
                 ) : null}
 
                 {!readOnly && (

--- a/frontend/components/inputs/Comment.tsx
+++ b/frontend/components/inputs/Comment.tsx
@@ -57,6 +57,7 @@ const Comment = ({
 
     const [commentText, setCommentText] = useState("");
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [pickerMentions, setPickerMentions] = useState<{ id: string; handle: string }[]>([]);
     const [replyingTo, setReplyingTo] = useState<{
         id: string;
         name: string;
@@ -197,13 +198,19 @@ const Comment = ({
             const parentId = replyingTo?.id;
             let finalCommentText = commentText.trim();
 
-            // Build mentions array
-            const mentions = [];
+            // Build mentions array: union reply-driven + picker-driven, deduped by id
+            const mentionMap = new Map<string, { id: string; handle: string }>();
+
+            // Add picker-derived mentions first
+            for (const m of pickerMentions) {
+                mentionMap.set(m.id, m);
+            }
+
             if (replyingTo) {
                 // Find the user being replied to from localComments
                 const parentComment = localComments.find(c => c.id === replyingTo.immediateParent);
                 if (parentComment) {
-                    mentions.push({
+                    mentionMap.set(parentComment.user._id, {
                         id: parentComment.user._id,
                         handle: parentComment.user.handle,
                     });
@@ -215,9 +222,12 @@ const Comment = ({
                 }
             }
 
+            const mentions = Array.from(mentionMap.values());
+
             const newComment = await addComment(postId, finalCommentText, parentId, mentions);
             setCommentText("");
             setReplyingTo(null);
+            setPickerMentions([]);
 
             setLocalComments((prev) => [...prev, newComment]);
 
@@ -408,6 +418,7 @@ const Comment = ({
                         onChangeText={setCommentText}
                         onSubmit={handleSubmitComment}
                         value={commentText}
+                        onMentionsChange={setPickerMentions}
                     />
                     <SendButton onSend={handleSubmitComment} />
                 </View>

--- a/frontend/components/inputs/CommentInput.tsx
+++ b/frontend/components/inputs/CommentInput.tsx
@@ -1,7 +1,10 @@
-import { StyleSheet, Text, View, useWindowDimensions } from "react-native";
-import React from "react";
+import { StyleSheet, View, useWindowDimensions } from "react-native";
+import React, { useEffect } from "react";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
+import MentionAutocomplete from "./MentionAutocomplete";
+import { useMentionTrigger } from "@/hooks/useMentionTrigger";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
 
 type Props = {
     onSubmit?: () => void;
@@ -10,6 +13,7 @@ type Props = {
     width?: number;
     value?: string;
     autoFocus?: boolean;
+    onMentionsChange?: (mentions: { id: string; handle: string }[]) => void;
 };
 
 const CommentInput = (props: Props) => {
@@ -20,24 +24,31 @@ const CommentInput = (props: Props) => {
     // Use controlled value if provided, otherwise use internal state
     const value = props.value !== undefined ? props.value : internalValue;
 
-    const handleChangeText = (text: string) => {
+    const setValue = (text: string) => {
         if (props.value !== undefined) {
-            // Controlled component
             props.onChangeText?.(text);
         } else {
-            // Uncontrolled component
             setInternalValue(text);
             props.onChangeText?.(text);
         }
     };
 
+    const { query, onChange, onSelection, onPick, picked } = useMentionTrigger(value, setValue);
+
+    // Notify parent whenever picked changes
+    useEffect(() => {
+        props.onMentionsChange?.(picked.map((p) => ({ id: p.id, handle: p.handle })));
+    }, [picked]);
+
     return (
         <View style={styles.container}>
+            <MentionAutocomplete query={query} onPick={onPick} />
             <BottomSheetTextInput
                 autoFocus={props.autoFocus}
                 placeholder={props.placeHolder || "Leave a comment"}
                 onSubmitEditing={props?.onSubmit}
-                onChangeText={handleChangeText}
+                onChangeText={onChange}
+                onSelectionChange={onSelection as any}
                 value={value}
                 multiline={false}
                 returnKeyType="send"

--- a/frontend/components/inputs/LongTextInput.tsx
+++ b/frontend/components/inputs/LongTextInput.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, TextInput, View } from "react-native";
+import { StyleSheet, TextInput, View, NativeSyntheticEvent, TextInputSelectionChangeEventData } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 
 type Props = {
@@ -9,15 +9,17 @@ type Props = {
     onBlur?: () => void;
     minHeight?: number;
     fontSize?: number;
+    onSelectionChange?: (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => void;
 };
 
-const LongTextInput = ({ 
-    placeholder, 
-    value, 
-    setValue, 
-    onBlur, 
+const LongTextInput = ({
+    placeholder,
+    value,
+    setValue,
+    onBlur,
     minHeight = 100,
-    fontSize = 16 
+    fontSize = 16,
+    onSelectionChange,
 }: Props) => {
     const ThemedColor = useThemeColor();
 
@@ -31,13 +33,14 @@ const LongTextInput = ({
                 value={value}
                 onChangeText={setValue}
                 onBlur={onBlur}
+                onSelectionChange={onSelectionChange}
                 style={{
                     backgroundColor: "transparent",
                     color: ThemedColor.text,
                     fontSize: fontSize,
                     fontFamily: "Outfit",
                     fontWeight: "400",
-                    lineHeight: fontSize * 1.5, 
+                    lineHeight: fontSize * 1.5,
                     padding: 0,
                     margin: 0,
                     borderWidth: 0,

--- a/frontend/components/inputs/MentionAutocomplete.tsx
+++ b/frontend/components/inputs/MentionAutocomplete.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { View, FlatList, TouchableOpacity, Image } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+
+type Props = {
+    query: string | null; // null = hidden
+    onPick: (candidate: MentionCandidate) => void;
+    maxRows?: number;
+};
+
+const ROW_HEIGHT = 56;
+
+const MentionAutocomplete = ({ query, onPick, maxRows = 5 }: Props) => {
+    const ThemedColor = useThemeColor();
+    const { filter, loading } = useFriendsForMention();
+
+    if (query === null) return null;
+    if (loading) return null;
+
+    const matches = filter(query);
+    if (matches.length === 0) return null;
+
+    return (
+        <View
+            style={{
+                backgroundColor: ThemedColor.lightened,
+                borderRadius: 12,
+                maxHeight: ROW_HEIGHT * maxRows,
+                marginHorizontal: 16,
+                marginBottom: 8,
+                overflow: "hidden",
+            }}>
+            <FlatList
+                data={matches}
+                keyExtractor={(item) => item.id}
+                keyboardShouldPersistTaps="always"
+                renderItem={({ item }) => (
+                    <TouchableOpacity
+                        onPress={() => onPick(item)}
+                        activeOpacity={0.7}
+                        style={{
+                            flexDirection: "row",
+                            alignItems: "center",
+                            paddingHorizontal: 16,
+                            height: ROW_HEIGHT,
+                            gap: 12,
+                        }}>
+                        {item.profile_picture ? (
+                            <Image
+                                source={{ uri: item.profile_picture }}
+                                style={{ width: 36, height: 36, borderRadius: 18 }}
+                            />
+                        ) : (
+                            <View
+                                style={{
+                                    width: 36,
+                                    height: 36,
+                                    borderRadius: 18,
+                                    backgroundColor: ThemedColor.background,
+                                }}
+                            />
+                        )}
+                        <View style={{ flex: 1 }}>
+                            <ThemedText type="defaultSemiBold">{item.display_name}</ThemedText>
+                            <ThemedText type="caption">@{item.handle}</ThemedText>
+                        </View>
+                    </TouchableOpacity>
+                )}
+            />
+        </View>
+    );
+};
+
+export default MentionAutocomplete;

--- a/frontend/components/inputs/MentionTextInput.tsx
+++ b/frontend/components/inputs/MentionTextInput.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef } from "react";
-import { View, NativeSyntheticEvent, TextInputSelectionChangeEventData } from "react-native";
+import React from "react";
+import { View } from "react-native";
 import LongTextInput from "./LongTextInput";
 import MentionAutocomplete from "./MentionAutocomplete";
+import { useMentionTrigger } from "@/hooks/useMentionTrigger";
 import type { MentionCandidate } from "@/hooks/useFriendsForMention";
 
 type Props = {
@@ -14,59 +15,22 @@ type Props = {
 };
 
 const MentionTextInput = ({ value, setValue, onMentionPicked, placeholder, fontSize, minHeight }: Props) => {
-    const [selection, setSelection] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
-    const [query, setQuery] = useState<string | null>(null);
-    const triggerStart = useRef<number | null>(null);
-
-    const recomputeTrigger = (text: string, caret: number) => {
-        for (let i = caret - 1; i >= 0; i--) {
-            const ch = text[i];
-            if (ch === "@") {
-                const prev = i === 0 ? " " : text[i - 1];
-                if (/\s/.test(prev) || i === 0) {
-                    triggerStart.current = i;
-                    setQuery(text.slice(i + 1, caret));
-                    return;
-                }
-            }
-            if (/\s/.test(ch)) break;
-        }
-        triggerStart.current = null;
-        setQuery(null);
-    };
-
-    const handleChange = (text: string) => {
-        setValue(text);
-        recomputeTrigger(text, selection.start);
-    };
-
-    const handleSelection = (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
-        const sel = e.nativeEvent.selection;
-        setSelection(sel);
-        recomputeTrigger(value, sel.start);
-    };
+    const { query, onChange, onSelection, onPick } = useMentionTrigger(value, setValue);
 
     const handlePick = (c: MentionCandidate) => {
-        if (triggerStart.current === null) return;
-        const before = value.slice(0, triggerStart.current);
-        const after = value.slice(selection.start);
-        const insertion = `@${c.handle} `;
-        const next = before + insertion + after;
-        setValue(next);
+        onPick(c);
         onMentionPicked(c);
-        triggerStart.current = null;
-        setQuery(null);
     };
 
     return (
         <View>
             <LongTextInput
                 value={value}
-                setValue={handleChange}
+                setValue={onChange}
                 placeholder={placeholder}
                 fontSize={fontSize}
                 minHeight={minHeight}
-                onSelectionChange={handleSelection}
+                onSelectionChange={onSelection}
             />
             <MentionAutocomplete query={query} onPick={handlePick} />
         </View>

--- a/frontend/components/inputs/MentionTextInput.tsx
+++ b/frontend/components/inputs/MentionTextInput.tsx
@@ -1,0 +1,76 @@
+import React, { useState, useRef } from "react";
+import { View, NativeSyntheticEvent, TextInputSelectionChangeEventData } from "react-native";
+import LongTextInput from "./LongTextInput";
+import MentionAutocomplete from "./MentionAutocomplete";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
+
+type Props = {
+    value: string;
+    setValue: (v: string) => void;
+    onMentionPicked: (candidate: MentionCandidate) => void;
+    placeholder?: string;
+    fontSize?: number;
+    minHeight?: number;
+};
+
+const MentionTextInput = ({ value, setValue, onMentionPicked, placeholder, fontSize, minHeight }: Props) => {
+    const [selection, setSelection] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
+    const [query, setQuery] = useState<string | null>(null);
+    const triggerStart = useRef<number | null>(null);
+
+    const recomputeTrigger = (text: string, caret: number) => {
+        for (let i = caret - 1; i >= 0; i--) {
+            const ch = text[i];
+            if (ch === "@") {
+                const prev = i === 0 ? " " : text[i - 1];
+                if (/\s/.test(prev) || i === 0) {
+                    triggerStart.current = i;
+                    setQuery(text.slice(i + 1, caret));
+                    return;
+                }
+            }
+            if (/\s/.test(ch)) break;
+        }
+        triggerStart.current = null;
+        setQuery(null);
+    };
+
+    const handleChange = (text: string) => {
+        setValue(text);
+        recomputeTrigger(text, selection.start);
+    };
+
+    const handleSelection = (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+        const sel = e.nativeEvent.selection;
+        setSelection(sel);
+        recomputeTrigger(value, sel.start);
+    };
+
+    const handlePick = (c: MentionCandidate) => {
+        if (triggerStart.current === null) return;
+        const before = value.slice(0, triggerStart.current);
+        const after = value.slice(selection.start);
+        const insertion = `@${c.handle} `;
+        const next = before + insertion + after;
+        setValue(next);
+        onMentionPicked(c);
+        triggerStart.current = null;
+        setQuery(null);
+    };
+
+    return (
+        <View>
+            <LongTextInput
+                value={value}
+                setValue={handleChange}
+                placeholder={placeholder}
+                fontSize={fontSize}
+                minHeight={minHeight}
+                onSelectionChange={handleSelection}
+            />
+            <MentionAutocomplete query={query} onPick={handlePick} />
+        </View>
+    );
+};
+
+export default MentionTextInput;

--- a/frontend/components/inputs/TaggedUsersChips.tsx
+++ b/frontend/components/inputs/TaggedUsersChips.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { View, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { Ionicons } from "@expo/vector-icons";
+
+export type TaggedUser = {
+    id: string;
+    handle: string;
+    display_name?: string;
+};
+
+type Props = {
+    users: TaggedUser[];
+    onRemove?: (id: string) => void; // composer mode
+    onPressUser?: (id: string) => void; // read mode
+};
+
+const TaggedUsersChips = ({ users, onRemove, onPressUser }: Props) => {
+    const ThemedColor = useThemeColor();
+    if (users.length === 0) return null;
+
+    const readMode = !onRemove;
+
+    if (readMode) {
+        const names = users.map((u) => u.display_name ?? u.handle);
+        return (
+            <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6, paddingHorizontal: 16, paddingVertical: 6 }}>
+                <ThemedText type="caption">with </ThemedText>
+                {users.map((u, i) => (
+                    <TouchableOpacity key={u.id} onPress={() => onPressUser?.(u.id)} activeOpacity={0.7}>
+                        <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
+                            {names[i]}
+                            {i < users.length - 1 ? ", " : ""}
+                        </ThemedText>
+                    </TouchableOpacity>
+                ))}
+            </View>
+        );
+    }
+
+    return (
+        <View style={{ flexDirection: "row", flexWrap: "wrap", gap: 6, paddingHorizontal: 16 }}>
+            {users.map((u) => (
+                <View
+                    key={u.id}
+                    style={{
+                        flexDirection: "row",
+                        alignItems: "center",
+                        paddingHorizontal: 10,
+                        paddingVertical: 6,
+                        backgroundColor: ThemedColor.lightened,
+                        borderRadius: 16,
+                        gap: 6,
+                    }}>
+                    <ThemedText type="caption">@{u.handle}</ThemedText>
+                    <TouchableOpacity onPress={() => onRemove?.(u.id)} hitSlop={8}>
+                        <Ionicons name="close-circle" size={16} color={ThemedColor.caption} />
+                    </TouchableOpacity>
+                </View>
+            ))}
+        </View>
+    );
+};
+
+export default TaggedUsersChips;

--- a/frontend/contexts/PostComposerContext.tsx
+++ b/frontend/contexts/PostComposerContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, useState, Dispatch, SetStateAction } from "react";
+import type { TaggedUser } from "@/components/inputs/TaggedUsersChips";
+
+type Ctx = {
+    taggedUsers: TaggedUser[];
+    setTaggedUsers: Dispatch<SetStateAction<TaggedUser[]>>;
+};
+
+const PostComposerCtx = createContext<Ctx | null>(null);
+
+export const PostComposerProvider = ({ children }: { children: React.ReactNode }) => {
+    const [taggedUsers, setTaggedUsers] = useState<TaggedUser[]>([]);
+    return <PostComposerCtx.Provider value={{ taggedUsers, setTaggedUsers }}>{children}</PostComposerCtx.Provider>;
+};
+
+export const usePostComposer = () => {
+    const ctx = useContext(PostComposerCtx);
+    if (!ctx) throw new Error("usePostComposer must be used inside PostComposerProvider");
+    return ctx;
+};

--- a/frontend/hooks/useFriendsForMention.ts
+++ b/frontend/hooks/useFriendsForMention.ts
@@ -1,0 +1,54 @@
+import { useEffect, useMemo, useState } from "react";
+import { getFriendsAPI } from "@/api/connection";
+
+export type MentionCandidate = {
+    id: string;
+    handle: string;
+    display_name: string;
+    profile_picture?: string;
+};
+
+export const useFriendsForMention = () => {
+    const [friends, setFriends] = useState<MentionCandidate[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const list = await getFriendsAPI();
+                if (cancelled) return;
+                setFriends(
+                    list.map((f: any) => ({
+                        id: f._id ?? f.id,
+                        handle: f.handle,
+                        display_name: f.display_name,
+                        profile_picture: f.profile_picture,
+                    })),
+                );
+            } catch (e) {
+                console.warn("useFriendsForMention: failed to load friends", e);
+            } finally {
+                if (!cancelled) setLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const filter = useMemo(
+        () => (query: string) => {
+            const q = query.trim().toLowerCase();
+            if (!q) return friends;
+            return friends.filter(
+                (f) =>
+                    f.handle.toLowerCase().startsWith(q) ||
+                    f.display_name.toLowerCase().includes(q),
+            );
+        },
+        [friends],
+    );
+
+    return { friends, filter, loading };
+};

--- a/frontend/hooks/useMentionTrigger.ts
+++ b/frontend/hooks/useMentionTrigger.ts
@@ -1,0 +1,50 @@
+import { useState, useRef } from "react";
+import type { NativeSyntheticEvent, TextInputSelectionChangeEventData } from "react-native";
+import type { MentionCandidate } from "./useFriendsForMention";
+
+export const useMentionTrigger = (value: string, setValue: (v: string) => void) => {
+    const [selection, setSelection] = useState<{ start: number; end: number }>({ start: 0, end: 0 });
+    const [query, setQuery] = useState<string | null>(null);
+    const [picked, setPicked] = useState<MentionCandidate[]>([]);
+    const triggerStart = useRef<number | null>(null);
+
+    const recompute = (text: string, caret: number) => {
+        for (let i = caret - 1; i >= 0; i--) {
+            const ch = text[i];
+            if (ch === "@") {
+                const prev = i === 0 ? " " : text[i - 1];
+                if (/\s/.test(prev) || i === 0) {
+                    triggerStart.current = i;
+                    setQuery(text.slice(i + 1, caret));
+                    return;
+                }
+            }
+            if (/\s/.test(ch)) break;
+        }
+        triggerStart.current = null;
+        setQuery(null);
+    };
+
+    const onChange = (text: string) => {
+        setValue(text);
+        recompute(text, selection.start);
+    };
+
+    const onSelection = (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => {
+        const sel = e.nativeEvent.selection;
+        setSelection(sel);
+        recompute(value, sel.start);
+    };
+
+    const onPick = (c: MentionCandidate) => {
+        if (triggerStart.current === null) return;
+        const before = value.slice(0, triggerStart.current);
+        const after = value.slice(selection.start);
+        setValue(before + `@${c.handle} ` + after);
+        setPicked((p) => (p.find((x) => x.id === c.id) ? p : [...p, c]));
+        triggerStart.current = null;
+        setQuery(null);
+    };
+
+    return { query, onChange, onSelection, onPick, picked, setPicked };
+};


### PR DESCRIPTION
## Summary

- Adds friends-only user tagging to posts. Tagged users get a deep-linked push + in-app notification.
- Auto-tags task encouragers when the post references a task they encouraged.
- New shared `@`-autocomplete picker used in both the post composer and the comment composer (fixes the gap where comment mentions only fired on reply).

## Architecture

- One new field `TaggedUsers []MentionReference` on `PostDocument` — single source of truth for who's tagged.
- Caption stays plain text; render-time scan links `@handle` runs against `TaggedUsers`.
- Friends-only validation runs server-side via two bounded queries against `friend-requests` (matches existing patterns).
- Encourager auto-tag reuses existing `encouragement.GetEncouragementsByTaskAndReceiver`.
- Deep-link mirrors the existing `comment` notification path (`{type: "post_tag", post_id}` payload → `getNotificationRoute()` → `/posting/[id]`).

## Spec + plan

- Design doc: `docs/superpowers/specs/2026-06-01-user-tagging-design.md`
- Implementation plan: `docs/superpowers/plans/2026-06-01-user-tagging.md`

Both gitignored (local artifacts) — happy to share if helpful for review.

## What's in the diff

**Backend (~600 LOC)**
- `PostDocument.TaggedUsers` field + `PostDocumentAPI` wire-through
- `CreatePostParams.TaggedUsers` (max=20) and `UpdatePostParams.TaggedUsers *[]MentionInput` (pointer for absent vs cleared)
- `NotificationTypePostTag = "POST_TAG"`
- `ResolveTaggedUsers` helper — filters non-friends, drops self, dedupes, preserves order, returns canonical handles
- Tag integration in `CreatePostHuma` (auto-unions encourager IDs when task is set) and in `UpdatePartialPost` (edit-diff fan-out, notify only newly added)
- `sendTagPushNotification` mirroring `sendCommentNotification`
- MongoDB index `{ "taggedUsers._id": 1 }` on `posts`
- 5 new test cases covering validation, dedupe, self-exclusion, auto-tag, edit-diff

**Frontend (~700 LOC)**
- New shared picker primitives: `useFriendsForMention`, `useMentionTrigger`, `MentionAutocomplete`, `MentionTextInput`, `TaggedUsersChips`
- New post-composer surfaces: inline `@` picker in caption, "Tag people" row → `tag-people.tsx` multi-select screen, encourager auto-fill chip pre-fill
- `PostComposerContext` shared between caption and tag-people screens
- Comment composer now uses the same `@`-autocomplete (preserving the existing reply-mention injection)
- `PostCardCaption` renders linked `@handle` runs; `TaggedUsersChips` shows "with X, Y" under the caption
- `"post_tag"` added to `NotificationType` union, route case in `getNotificationRoute()`, tap handler in `Notifications.tsx`
- Regenerated OpenAPI types pick up `taggedUsers` everywhere

## Validation

- `make test-backend` → **431/431 passing**, including 5 new tests for tagging behavior
- `bun run tsc --noEmit` → only pre-existing errors in `components/daily/DatePager.tsx` (untouched on this branch)
- Jest: `PostCardCaption.test.tsx` passing

## Test plan

- [ ] Two test users mutually-friended. User A posts with `@userB` in caption → User B sees push + in-app notification → tap routes to post detail
- [ ] Tag People multi-select screen: select multiple friends, hit Done → composer chip row reflects selection
- [ ] Post about a task that User B previously encouraged → composer pre-fills the encourager chip
- [ ] Edit post and add a new tag → only newly-added user gets notification (no spam to existing tags)
- [ ] In comment composer, type `@` → picker appears → pick a friend → mention fires notification
- [ ] PostCard renders caption with `@handle` highlighted and chip row "with X, Y" underneath
- [ ] Cold-start push tap: lock device, tap the push → app opens directly to post detail

## Out of scope (per spec)

- Public/non-friend tagging
- Tagged-user approval gate or untag-self
- "Tagged in" profile tab (index supports it for future)
- Photo-pin tag placement

## Known follow-ups (non-blocking)

- Update-path notification fan-out silently swallows per-user errors (`_ =`) — create-path uses `slog.Error`. Worth aligning for observability.
- Shared `fanOutTagNotifications` helper could eliminate ~15 lines of duplication between create and update paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)