### PR TITLE
feat: post from anywhere (FAB + completed-task camera button)

### DIFF
--- a/frontend/__tests__/TaskCardPostButton.test.tsx
+++ b/frontend/__tests__/TaskCardPostButton.test.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import { render, fireEvent } from "@testing-library/react-native";
 
-jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+const mockPush = jest.fn();
+jest.mock("expo-router", () => ({ useRouter: () => ({ push: mockPush }) }));
 jest.mock("@/contexts/tasksContext", () => ({
     useTasks: () => ({ setTask: jest.fn(), updateTask: jest.fn() }),
 }));
@@ -67,6 +68,10 @@ const baseProps = {
 };
 
 describe("TaskCard post button", () => {
+    beforeEach(() => {
+        mockPush.mockClear();
+    });
+
     test("does not render the post button when onPostPress is absent", () => {
         const { queryByTestId } = render(<TaskCard {...baseProps} />);
         expect(queryByTestId("task-card-post-button")).toBeNull();
@@ -79,5 +84,27 @@ describe("TaskCard post button", () => {
         );
         fireEvent.press(getByTestId("task-card-post-button"));
         expect(onPostPress).toHaveBeenCalledTimes(1);
+    });
+
+    test("pressing the post button does not trigger the card's tap-to-redirect", () => {
+        jest.useFakeTimers();
+        try {
+            const onPostPress = jest.fn();
+            const { getByTestId } = render(
+                <TaskCard
+                    {...baseProps}
+                    redirect={true}
+                    task={{ id: "task-1", content: "Run 5k" } as any}
+                    onPostPress={onPostPress}
+                />
+            );
+            fireEvent.press(getByTestId("task-card-post-button"));
+            // Flush the card's double-tap timeout + redirect debounce.
+            jest.runAllTimers();
+            expect(onPostPress).toHaveBeenCalledTimes(1);
+            expect(mockPush).not.toHaveBeenCalled();
+        } finally {
+            jest.useRealTimers();
+        }
     });
 });

--- a/frontend/__tests__/TaskCardPostButton.test.tsx
+++ b/frontend/__tests__/TaskCardPostButton.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, fireEvent } from "@testing-library/react-native";
+
+jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("@/contexts/tasksContext", () => ({
+    useTasks: () => ({ setTask: jest.fn(), updateTask: jest.fn() }),
+}));
+jest.mock("@/contexts/dragContext", () => ({ useDragOptional: () => null }));
+jest.mock("@/hooks/useAnalytics", () => ({ useAnalytics: () => ({ capture: jest.fn() }) }));
+jest.mock("react-native-reanimated", () => {
+    const RN = require("react-native");
+    const Animated = {
+        View: RN.View,
+        Text: RN.Text,
+        Image: RN.Image,
+        createAnimatedComponent: (c: any) => c,
+        addWhitelistedNativeProps: () => {},
+    };
+    return {
+        __esModule: true,
+        default: Animated,
+        runOnJS: (fn: any) => fn,
+        useSharedValue: (v: any) => ({ value: v }),
+        useAnimatedStyle: () => ({}),
+        useAnimatedReaction: () => {},
+        withTiming: (v: any) => v,
+        withSpring: (v: any) => v,
+        Easing: { linear: (v: any) => v },
+    };
+});
+jest.mock("react-native-gesture-handler", () => {
+    const chain: any = {};
+    chain.activateAfterLongPress = () => chain;
+    chain.onStart = () => chain;
+    chain.onUpdate = () => chain;
+    chain.onEnd = () => chain;
+    return {
+        Gesture: { Pan: () => chain },
+        GestureDetector: ({ children }: any) => children,
+    };
+});
+jest.mock("@gorhom/bottom-sheet", () => ({
+    BottomSheetTextInput: "TextInput",
+    BottomSheet: "View",
+    BottomSheetModal: "View",
+    BottomSheetView: "View",
+    BottomSheetScrollView: "ScrollView",
+    useBottomSheetModal: () => ({ dismiss: jest.fn() }),
+}));
+jest.mock("@react-native-async-storage/async-storage", () => ({
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    clear: jest.fn(() => Promise.resolve()),
+}));
+jest.mock("axios", () => ({ create: () => ({ get: jest.fn(), post: jest.fn(), interceptors: { request: { use: jest.fn() }, response: { use: jest.fn() } } }) }));
+jest.mock("expo-secure-store", () => ({ getItemAsync: jest.fn(), setItemAsync: jest.fn(), deleteItemAsync: jest.fn() }));
+
+import TaskCard from "@/components/cards/TaskCard";
+
+const baseProps = {
+    content: "Run 5k",
+    value: 10,
+    priority: 1 as const,
+    id: "task-1",
+    categoryId: "cat-1",
+};
+
+describe("TaskCard post button", () => {
+    test("does not render the post button when onPostPress is absent", () => {
+        const { queryByTestId } = render(<TaskCard {...baseProps} />);
+        expect(queryByTestId("task-card-post-button")).toBeNull();
+    });
+
+    test("renders the post button and calls onPostPress when pressed", () => {
+        const onPostPress = jest.fn();
+        const { getByTestId } = render(
+            <TaskCard {...baseProps} onPostPress={onPostPress} />
+        );
+        fireEvent.press(getByTestId("task-card-post-button"));
+        expect(onPostPress).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/__tests__/TaskSelectionView.test.tsx
+++ b/frontend/__tests__/TaskSelectionView.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Animated } from "react-native";
+import { render, fireEvent } from "@testing-library/react-native";
+import { TaskSelectionView } from "@/components/ui/fab/TaskSelectionView";
+
+const setup = () => {
+    const handlers = {
+        onTaskPress: jest.fn(),
+        onPostPress: jest.fn(),
+        onWorkspacePress: jest.fn(),
+        onVoiceInputPress: jest.fn(),
+    };
+    const utils = render(
+        <TaskSelectionView
+            opacity={new Animated.Value(1)}
+            onLayout={jest.fn()}
+            {...handlers}
+        />
+    );
+    return { ...utils, ...handlers };
+};
+
+describe("TaskSelectionView", () => {
+    test("renders all four action rows on any tab", () => {
+        const { getByText } = setup();
+        getByText("Task");
+        getByText("Post");
+        getByText("Workspace");
+        getByText("Voice Input");
+    });
+
+    test("each row triggers its own handler", () => {
+        const view = setup();
+        fireEvent.press(view.getByText("Task"));
+        fireEvent.press(view.getByText("Post"));
+        fireEvent.press(view.getByText("Workspace"));
+        fireEvent.press(view.getByText("Voice Input"));
+        expect(view.onTaskPress).toHaveBeenCalledTimes(1);
+        expect(view.onPostPress).toHaveBeenCalledTimes(1);
+        expect(view.onWorkspacePress).toHaveBeenCalledTimes(1);
+        expect(view.onVoiceInputPress).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/app/(logged-in)/(tabs)/(task)/completed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/completed.tsx
@@ -12,6 +12,7 @@ import { getCompletedTasksAPI, PaginatedCompletedTasksResponse } from "@/api/tas
 import TaskCard from "@/components/cards/TaskCard";
 import { useTasks } from "@/contexts/tasksContext";
 import { stringToLocalAwareDate } from "@/utils/timeUtils";
+import { router } from "expo-router";
 
 const TASKS_PER_PAGE = 20;
 
@@ -170,6 +171,21 @@ const CompletedTasks = () => {
         return category?.name || "Unknown";
     };
 
+    const handlePostTask = (task: CompletedTask) => {
+        const categoryName = getCategoryName(task.categoryID);
+        router.push({
+            pathname: "/posting/cameraview",
+            params: {
+                taskInfo: JSON.stringify({
+                    id: task.id,
+                    name: task.content,
+                    category: task.categoryID,
+                    categoryName,
+                }),
+            },
+        });
+    };
+
     return (
         <DrawerLayout
             ref={drawerRef}
@@ -245,6 +261,7 @@ const CompletedTasks = () => {
                                                 id={task.id}
                                                 task={task as any}
                                                 detailed={false}
+                                                onPostPress={() => handlePostTask(task)}
                                                 inlineComponent={
                                                     task.timeCompleted ? (
                                                         <View style={styles.completionTimeContainer}>

--- a/frontend/components/cards/TaskCard.tsx
+++ b/frontend/components/cards/TaskCard.tsx
@@ -12,7 +12,7 @@ import { useDebounce } from "@/hooks/useDebounce";
 import EncourageModal from "../modals/EncourageModal";
 import CongratulateModal from "../modals/CongratulateModal";
 import { isAfter, formatDistanceToNow, parseISO, isBefore, isToday, isTomorrow, differenceInDays, format, isThisWeek } from "date-fns";
-import { Sparkle, Timer, Repeat } from "phosphor-react-native";
+import { Sparkle, Timer, Repeat, Camera } from "phosphor-react-native";
 import { getIntegrationIcon } from "@/utils/integrationUtils";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
 import { useAnalytics } from "@/hooks/useAnalytics";
@@ -50,6 +50,7 @@ interface Props {
     showRedOutline?: boolean; // Add red outline when categoryId is not configured
     detailed?: boolean; // Controls whether to show date labels like "(today)" or "(tomorrow)"
     inlineComponent?: React.ReactNode; // Optional component to render inline below the content text
+    onPostPress?: () => void; // When provided, renders a camera button that starts a post for this task
     highlightContent?: boolean; // Whether to highlight just the task content text
     encouragementConfig?: {
         userHandle?: string;
@@ -69,6 +70,7 @@ const TaskCard = ({
     priority,
     redirect = false,
     inlineComponent,
+    onPostPress,
     id,
     categoryId,
     encourage = false,
@@ -457,6 +459,17 @@ const TaskCard = ({
                     {inlineComponent && <View style={styles.inlineWrapper}>{inlineComponent}</View>}
                 </View>
                 <View style={styles.iconRow}>
+                    {onPostPress && (
+                        <TouchableOpacity
+                            testID="task-card-post-button"
+                            hitSlop={8}
+                            onPress={(e) => {
+                                e?.stopPropagation?.();
+                                onPostPress();
+                            }}>
+                            <Camera size={20} color={ThemedColor.caption} weight="regular" />
+                        </TouchableOpacity>
+                    )}
                     <ConditionalView condition={!encourage}>
                         <ConditionalView condition={isRunningState}>
                             <Timer size={20} color={ThemedColor.caption} weight="regular" />

--- a/frontend/components/ui/FloatingActionButton.tsx
+++ b/frontend/components/ui/FloatingActionButton.tsx
@@ -365,9 +365,9 @@ export const FloatingActionButton: React.FC<FloatingActionButtonProps> = ({ visi
                             <TaskSelectionView
                                 opacity={animations.taskSelectionOpacity}
                                 onTaskPress={handleTaskPress}
-                                onSecondaryPress={isOnFeedTab ? handlePostPress : handleWorkspacePress}
+                                onPostPress={handlePostPress}
+                                onWorkspacePress={handleWorkspacePress}
                                 onVoiceInputPress={handleVoiceInputPress}
-                                isOnFeedTab={isOnFeedTab}
                                 onLayout={(event) => {
                                     const h = event.nativeEvent.layout.height;
                                     if (h > 0) {

--- a/frontend/components/ui/fab/TaskSelectionView.tsx
+++ b/frontend/components/ui/fab/TaskSelectionView.tsx
@@ -7,90 +7,71 @@ import { useThemeColor } from "@/hooks/useThemeColor";
 interface TaskSelectionViewProps {
     opacity: Animated.Value;
     onTaskPress: () => void;
-    onSecondaryPress: () => void;
+    onPostPress: () => void;
+    onWorkspacePress: () => void;
     onVoiceInputPress: () => void;
-    isOnFeedTab: boolean;
     onLayout: (event: any) => void;
 }
 
 export const TaskSelectionView: React.FC<TaskSelectionViewProps> = ({
     opacity,
     onTaskPress,
-    onSecondaryPress,
+    onPostPress,
+    onWorkspacePress,
     onVoiceInputPress,
-    isOnFeedTab,
     onLayout,
 }) => {
     const ThemedColor = useThemeColor();
 
     return (
         <Animated.View
-            style={[
-                styles.menuSection,
-                {
-                    opacity,
-                }
-            ]}
+            style={[styles.menuSection, { opacity }]}
             onLayout={onLayout}
         >
-            <TouchableOpacity
-                style={[styles.menuItem, { borderBottomColor: ThemedColor.lightened }]}
-                onPress={onTaskPress}
-            >
+            <TouchableOpacity style={styles.menuItem} onPress={onTaskPress}>
                 <View style={styles.menuItemContent}>
                     <View style={[styles.iconContainer, { backgroundColor: ThemedColor.lightened }]}>
                         <CheckCircle size={24} color={ThemedColor.primary} weight="bold" />
                     </View>
                     <View style={styles.menuItemText}>
                         <ThemedText type="defaultSemiBold">Task</ThemedText>
-                        <ThemedText type="caption">
-                            Create a new task
-                        </ThemedText>
+                        <ThemedText type="caption">Create a new task</ThemedText>
                     </View>
                 </View>
             </TouchableOpacity>
 
-            <TouchableOpacity
-                style={styles.menuItem}
-                onPress={onSecondaryPress}
-            >
+            <TouchableOpacity style={styles.menuItem} onPress={onPostPress}>
                 <View style={styles.menuItemContent}>
-                    <View
-                        style={[
-                            styles.iconContainer,
-                            { backgroundColor: ThemedColor.lightened },
-                        ]}
-                    >
-                        {isOnFeedTab ? (
-                            <Camera size={20} color={ThemedColor.primary} weight="bold" />
-                        ) : (
-                            <Folder size={20} color={ThemedColor.primary} weight="bold" />
-                        )}
+                    <View style={[styles.iconContainer, { backgroundColor: ThemedColor.lightened }]}>
+                        <Camera size={20} color={ThemedColor.primary} weight="bold" />
                     </View>
                     <View style={styles.menuItemText}>
-                        <ThemedText type="defaultSemiBold">
-                            {isOnFeedTab ? "Post" : "Workspace"}
-                        </ThemedText>
-                        <ThemedText type="caption">
-                            {isOnFeedTab ? "Share a completed task" : "Create a new workspace"}
-                        </ThemedText>
+                        <ThemedText type="defaultSemiBold">Post</ThemedText>
+                        <ThemedText type="caption">Share a completed task</ThemedText>
                     </View>
                 </View>
             </TouchableOpacity>
 
-            <TouchableOpacity
-                style={styles.menuItem}
-                onPress={onVoiceInputPress}
-            >
+            <TouchableOpacity style={styles.menuItem} onPress={onWorkspacePress}>
+                <View style={styles.menuItemContent}>
+                    <View style={[styles.iconContainer, { backgroundColor: ThemedColor.lightened }]}>
+                        <Folder size={20} color={ThemedColor.primary} weight="bold" />
+                    </View>
+                    <View style={styles.menuItemText}>
+                        <ThemedText type="defaultSemiBold">Workspace</ThemedText>
+                        <ThemedText type="caption">Create a new workspace</ThemedText>
+                    </View>
+                </View>
+            </TouchableOpacity>
+
+            <TouchableOpacity style={styles.menuItem} onPress={onVoiceInputPress}>
                 <View style={styles.menuItemContent}>
                     <View style={[styles.iconContainer, { backgroundColor: ThemedColor.lightened }]}>
                         <Microphone size={22} color={ThemedColor.primary} weight="bold" />
                     </View>
                     <View style={styles.menuItemText}>
                         <ThemedText type="defaultSemiBold">Voice Input</ThemedText>
-                        <ThemedText type="caption">
-                            Capture tasks with your voice
-                        </ThemedText>
+                        <ThemedText type="caption">Capture tasks with your voice</ThemedText>
                     </View>
                 </View>
             </TouchableOpacity>


### PR DESCRIPTION
## Summary
- The FAB used to show **Post** only on the feed tab (its 2nd menu row was overloaded: Post on feed / Workspace elsewhere). It now always shows four rows on every tab: **Task, Post, Workspace, Voice Input**.
- Added an optional `onPostPress` camera button to `TaskCard`, rendered in the right-side icon row; pressing it starts a post for that task and does **not** trigger the card's tap-to-redirect.
- The completed-tasks / archive page wires that button to the existing `/posting/cameraview` flow for each completed task.
- The closed FAB button icon stays contextual (Camera on feed, Plus elsewhere) by design — unchanged.

No changes to the posting route, caption screen, photo upload, `createPost`, or backend — the posting pipeline was already tab-agnostic.

## Test Plan
- [x] `bun run test` — new suites `TaskSelectionView` and `TaskCardPostButton` pass (36 tests; pre-existing unrelated `AboutScreen` suite failure from a missing `@/app/about` module is not touched here).
- [x] `bunx tsc --noEmit` — no type errors in the four changed files; no `as any` on the route.
- [ ] Manual: FAB shows all four rows on the feed and a non-feed tab; **Post** off-feed opens the completed-task picker → camera; **Workspace** opens the create-workspace modal.
- [ ] Manual: archive page camera button opens the posting flow for that task; tapping elsewhere on the card still opens task detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)