### PR TITLE
Hide Google Calendar card on home once calendar is linked

### DIFF
--- a/frontend/components/dashboard/HomescrollContent.tsx
+++ b/frontend/components/dashboard/HomescrollContent.tsx
@@ -400,7 +400,9 @@ export const HomeScrollContent: React.FC<HomeScrollContentProps> = ({
                 </View>
 
                 {/* Google Calendar Connection Card */}
-                {showGoogleCalendarCard && (
+                {/* Once Google Calendar is linked, the whole section is hidden from the
+                    home page — there's nothing left to prompt. (Sync still lives elsewhere.) */}
+                {showGoogleCalendarCard && !isCalendarLinked && (
                     <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 18 }}>
                         <View style={{ marginBottom: 8 }}>
                             <SectionHeader title="GOOGLE CALENDAR" visible={dashboardConfig.google_calendar} onToggleVisibility={() => toggleSection("google_calendar")} />


### PR DESCRIPTION
## Summary
On the dashboard/home page, the Google Calendar section kept showing even after the user linked their calendar (rendering a "Sync"/"Linked" card). Now the whole section is hidden once a completed connection exists.

- Single change: gate the section render on `!isCalendarLinked` in `HomescrollContent`.
- Robust regardless of which code path sets the linked flag (mount check, Android deep-link fallback, post-setup refresh).
- `GoogleCalendarCard` itself is untouched — its linked/Sync UI stays in the code, just isn't surfaced on home.

## Test Plan
- [x] `tsc --noEmit` clean for `HomescrollContent.tsx`
- [ ] Manual: with no calendar linked → connect prompt shows; after linking → Google Calendar section disappears from home; pending/incomplete setup still shows "Finish setup"

🤖 Generated with [Claude Code](https://claude.com/claude-code)