### PR TITLE
feat(analytics): tag breakdown on the Analytics page

### DIFF
--- a/frontend/__tests__/tagBreakdown.test.ts
+++ b/frontend/__tests__/tagBreakdown.test.ts
@@ -1,0 +1,95 @@
+import {
+    buildTagAggregates,
+    selectedTagTemplateIds,
+    TagAggregate,
+    TemplateLike,
+    CategoryLike,
+} from "@/utils/tagBreakdown";
+
+const cat = (id: string, tags: string[]): CategoryLike => ({ id, tags });
+
+const tmpl = (
+    id: string,
+    categoryID: string,
+    timesCompleted = 0,
+): TemplateLike => ({ id, categoryID, timesCompleted });
+
+describe("buildTagAggregates", () => {
+    it("sums timesCompleted per tag across templates in matching categories", () => {
+        const categories = [cat("c1", ["fitness"]), cat("c2", ["fitness", "work"])];
+        const templates = [
+            tmpl("t1", "c1", 10),
+            tmpl("t2", "c2", 5),
+            tmpl("t3", "c2", 2),
+        ];
+        const result = buildTagAggregates(templates, categories);
+        expect(result).toEqual<TagAggregate[]>([
+            { tag: "fitness", count: 17 },
+            { tag: "work", count: 7 },
+        ]);
+    });
+
+    it("includes zero-count tags, ranked at the bottom", () => {
+        const categories = [cat("c1", ["fitness"]), cat("c2", ["idle"])];
+        const templates = [tmpl("t1", "c1", 4)];
+        const result = buildTagAggregates(templates, categories);
+        expect(result).toEqual<TagAggregate[]>([
+            { tag: "fitness", count: 4 },
+            { tag: "idle", count: 0 },
+        ]);
+    });
+
+    it("dedupes a tag that appears on multiple categories into one entry", () => {
+        const categories = [cat("c1", ["health"]), cat("c2", ["health"])];
+        const templates = [tmpl("t1", "c1", 3), tmpl("t2", "c2", 4)];
+        const result = buildTagAggregates(templates, categories);
+        expect(result).toEqual<TagAggregate[]>([{ tag: "health", count: 7 }]);
+    });
+
+    it("breaks count ties alphabetically", () => {
+        const categories = [cat("c1", ["zebra"]), cat("c2", ["apple"])];
+        const templates = [tmpl("t1", "c1", 5), tmpl("t2", "c2", 5)];
+        const result = buildTagAggregates(templates, categories);
+        expect(result.map((r) => r.tag)).toEqual(["apple", "zebra"]);
+    });
+
+    it("ignores templates whose category is missing or untagged", () => {
+        const categories = [cat("c1", ["fitness"]), cat("c2", [])];
+        const templates = [
+            tmpl("t1", "c1", 4),
+            tmpl("t2", "c2", 9),
+            tmpl("t3", "gone", 9),
+        ];
+        const result = buildTagAggregates(templates, categories);
+        expect(result).toEqual<TagAggregate[]>([{ tag: "fitness", count: 4 }]);
+    });
+
+    it("treats a missing timesCompleted as zero", () => {
+        const categories = [cat("c1", ["fitness"])];
+        const templates = [{ id: "t1", categoryID: "c1" } as TemplateLike];
+        const result = buildTagAggregates(templates, categories);
+        expect(result).toEqual<TagAggregate[]>([{ tag: "fitness", count: 0 }]);
+    });
+});
+
+describe("selectedTagTemplateIds", () => {
+    it("returns template IDs whose category carries any selected tag", () => {
+        const categories = [cat("c1", ["fitness"]), cat("c2", ["work"])];
+        const templates = [tmpl("t1", "c1"), tmpl("t2", "c2"), tmpl("t3", "c1")];
+        const result = selectedTagTemplateIds(["fitness"], templates, categories);
+        expect(result.sort()).toEqual(["t1", "t3"]);
+    });
+
+    it("unions templates across multiple selected tags without duplicates", () => {
+        const categories = [cat("c1", ["fitness", "work"]), cat("c2", ["work"])];
+        const templates = [tmpl("t1", "c1"), tmpl("t2", "c2")];
+        const result = selectedTagTemplateIds(["fitness", "work"], templates, categories);
+        expect(result.sort()).toEqual(["t1", "t2"]);
+    });
+
+    it("returns an empty array when no tags are selected", () => {
+        const categories = [cat("c1", ["fitness"])];
+        const templates = [tmpl("t1", "c1")];
+        expect(selectedTagTemplateIds([], templates, categories)).toEqual([]);
+    });
+});

--- a/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
@@ -105,7 +105,7 @@ const Activity = () => {
     const [showAllTemplates, setShowAllTemplates] = useState(false);
     const insets = useSafeAreaInsets();
     const params = useLocalSearchParams();
-    const { categories } = useTasks();
+    const { workspaces } = useTasks();
 
     const userId = user?._id || (params.id as string);
     const displayName = params.displayName as string || user?.display_name;
@@ -152,15 +152,20 @@ const Activity = () => {
         ? templates
         : templates.slice(0, INITIAL_TEMPLATES_SHOWN);
 
+    const allCategories = useMemo(
+        () => workspaces.flatMap((ws) => ws.categories ?? []),
+        [workspaces],
+    );
+
     const tagAggregates = useMemo(
-        () => buildTagAggregates(templates, categories),
-        [templates, categories],
+        () => buildTagAggregates(templates, allCategories),
+        [templates, allCategories],
     );
 
     const effectiveTemplateIds = useMemo(() => {
-        const tagIds = selectedTagTemplateIds(selectedTags, templates, categories);
+        const tagIds = selectedTagTemplateIds(selectedTags, templates, allCategories);
         return Array.from(new Set([...selectedTemplateIds, ...tagIds]));
-    }, [selectedTemplateIds, selectedTags, templates, categories]);
+    }, [selectedTemplateIds, selectedTags, templates, allCategories]);
 
     const breakdownMode = effectiveTemplateIds.length > 0;
 

--- a/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
@@ -11,6 +11,9 @@ import { activityAPI, getMonthlyActivityLevels, ActivityDocument, calculateActiv
 import CompletedTasksBottomSheetModal from "@/components/modals/CompletedTasksBottomSheetModal";
 import RecurringTasksSelectionModal from "@/components/modals/RecurringTasksSelectionModal";
 import { getUserTemplatesAPI } from "@/api/task";
+import { useTasks } from "@/contexts/tasksContext";
+import TagBreakdownRow from "@/components/activity/TagBreakdownRow";
+import { buildTagAggregates, selectedTagTemplateIds } from "@/utils/tagBreakdown";
 import { useAuth } from "@/hooks/useAuth";
 import { RecurringTaskCard } from "@/components/activity/RecurringTaskCard";
 import CalendarMonth, { CELL_SIZE, GRID_GAP } from "@/components/activity/CalendarMonth";
@@ -96,8 +99,8 @@ const Activity = () => {
     const [modalVisible, setModalVisible] = useState(false);
     const [templates, setTemplates] = useState<any[]>([]);
     const [selectedTemplateIds, setSelectedTemplateIds] = useState<string[]>([]);
+    const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const [breakdownModalVisible, setBreakdownModalVisible] = useState(false);
-    const [breakdownMode, setBreakdownMode] = useState(false);
     const [recurringTasksExpanded, setRecurringTasksExpanded] = useState(true);
     const [showAllTemplates, setShowAllTemplates] = useState(false);
     const insets = useSafeAreaInsets();
@@ -148,11 +151,31 @@ const Activity = () => {
         ? templates
         : templates.slice(0, INITIAL_TEMPLATES_SHOWN);
 
+    const { categories } = useTasks();
+
+    const tagAggregates = useMemo(
+        () => buildTagAggregates(templates, categories),
+        [templates, categories],
+    );
+
+    const effectiveTemplateIds = useMemo(() => {
+        const tagIds = selectedTagTemplateIds(selectedTags, templates, categories);
+        return Array.from(new Set([...selectedTemplateIds, ...tagIds]));
+    }, [selectedTemplateIds, selectedTags, templates, categories]);
+
+    const breakdownMode = effectiveTemplateIds.length > 0;
+
+    const handleToggleTag = (tag: string) => {
+        setSelectedTags((prev) =>
+            prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+        );
+    };
+
     const getBreakdownActivityLevels = (targetMonth: number): number[] => {
         const daysInMonth = new Date(year, targetMonth, 0).getDate();
         const monthlyLevels: number[] = new Array(daysInMonth).fill(0);
 
-        selectedTemplateIds.forEach((templateId) => {
+        effectiveTemplateIds.forEach((templateId) => {
             const template = templates.find((t) => t.id === templateId);
             if (!template?.completionDates) return;
 
@@ -173,15 +196,9 @@ const Activity = () => {
     const handleToggleTemplate = (templateId: string) => {
         setSelectedTemplateIds(prev => {
             if (prev.includes(templateId)) {
-                const newIds = prev.filter(id => id !== templateId);
-                if (newIds.length === 0) {
-                    setBreakdownMode(false);
-                }
-                return newIds;
-            } else {
-                setBreakdownMode(true);
-                return [...prev, templateId];
+                return prev.filter(id => id !== templateId);
             }
+            return [...prev, templateId];
         });
     };
 
@@ -208,6 +225,15 @@ const Activity = () => {
                             total tasks completed this year
                         </ThemedText>
                     </View>
+                )}
+
+                {/* Tag Breakdown - only for own activity */}
+                {isOwnActivity && tagAggregates.length > 0 && (
+                    <TagBreakdownRow
+                        tags={tagAggregates}
+                        selectedTags={selectedTags}
+                        onToggle={handleToggleTag}
+                    />
                 )}
 
                 {/* Recurring Tasks Section - only for own activity */}
@@ -347,7 +373,6 @@ const Activity = () => {
                 selectedTemplateIds={selectedTemplateIds}
                 onApply={(selectedIds) => {
                     setSelectedTemplateIds(selectedIds);
-                    setBreakdownMode(selectedIds.length > 0);
                     setBreakdownModalVisible(false);
                 }}
             />

--- a/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
@@ -105,6 +105,7 @@ const Activity = () => {
     const [showAllTemplates, setShowAllTemplates] = useState(false);
     const insets = useSafeAreaInsets();
     const params = useLocalSearchParams();
+    const { categories } = useTasks();
 
     const userId = user?._id || (params.id as string);
     const displayName = params.displayName as string || user?.display_name;
@@ -150,8 +151,6 @@ const Activity = () => {
     const visibleTemplates = showAllTemplates
         ? templates
         : templates.slice(0, INITIAL_TEMPLATES_SHOWN);
-
-    const { categories } = useTasks();
 
     const tagAggregates = useMemo(
         () => buildTagAggregates(templates, categories),

--- a/frontend/components/activity/TagBreakdownRow.tsx
+++ b/frontend/components/activity/TagBreakdownRow.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { getCategoryDuotoneColors } from "@/utils/categoryColors";
+import type { TagAggregate } from "@/utils/tagBreakdown";
+
+interface TagBreakdownRowProps {
+    tags: TagAggregate[]; // pre-sorted by the parent
+    selectedTags: string[];
+    onToggle: (tag: string) => void;
+}
+
+export default function TagBreakdownRow({
+    tags,
+    selectedTags,
+    onToggle,
+}: TagBreakdownRowProps) {
+    if (tags.length === 0) return null;
+
+    return (
+        <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            contentContainerStyle={styles.row}
+        >
+            {tags.map(({ tag, count }) => {
+                const { primary, light } = getCategoryDuotoneColors(undefined, tag);
+                const isSelected = selectedTags.includes(tag);
+                return (
+                    <TouchableOpacity
+                        key={tag}
+                        onPress={() => onToggle(tag)}
+                        accessibilityRole="button"
+                        accessibilityState={{ selected: isSelected }}
+                    >
+                        <View
+                            style={[
+                                styles.chip,
+                                { backgroundColor: isSelected ? primary : light },
+                            ]}
+                        >
+                            <ThemedText
+                                type="caption"
+                                style={{ color: isSelected ? light : primary }}
+                            >
+                                {`${tag} · ${count}`}
+                            </ThemedText>
+                        </View>
+                    </TouchableOpacity>
+                );
+            })}
+        </ScrollView>
+    );
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        gap: 8,
+        paddingVertical: 4,
+    },
+    chip: {
+        paddingHorizontal: 16,
+        paddingVertical: 4,
+        borderRadius: 999,
+    },
+});

--- a/frontend/utils/tagBreakdown.ts
+++ b/frontend/utils/tagBreakdown.ts
@@ -1,0 +1,74 @@
+export interface TagAggregate {
+    tag: string;
+    count: number;
+}
+
+export interface TemplateLike {
+    id: string;
+    categoryID: string;
+    timesCompleted?: number;
+}
+
+export interface CategoryLike {
+    id: string;
+    tags?: string[];
+}
+
+const categoryTagsById = (
+    categories: CategoryLike[],
+): Map<string, string[]> => {
+    const map = new Map<string, string[]>();
+    for (const category of categories) {
+        map.set(category.id, category.tags ?? []);
+    }
+    return map;
+};
+
+// Lifetime completion count per tag, descending; ties broken alphabetically.
+// Every tag on any category is included, even with a zero count.
+export const buildTagAggregates = (
+    templates: TemplateLike[],
+    categories: CategoryLike[],
+): TagAggregate[] => {
+    const tagsById = categoryTagsById(categories);
+
+    const counts = new Map<string, number>();
+    for (const tags of tagsById.values()) {
+        for (const tag of tags) {
+            if (!counts.has(tag)) counts.set(tag, 0);
+        }
+    }
+
+    for (const template of templates) {
+        const tags = tagsById.get(template.categoryID);
+        if (!tags) continue;
+        const completed = template.timesCompleted ?? 0;
+        for (const tag of tags) {
+            counts.set(tag, (counts.get(tag) ?? 0) + completed);
+        }
+    }
+
+    return Array.from(counts.entries())
+        .map(([tag, count]) => ({ tag, count }))
+        .sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+};
+
+// Template IDs whose category carries any of the selected tags (deduped).
+export const selectedTagTemplateIds = (
+    selectedTags: string[],
+    templates: TemplateLike[],
+    categories: CategoryLike[],
+): string[] => {
+    if (selectedTags.length === 0) return [];
+    const selected = new Set(selectedTags);
+    const tagsById = categoryTagsById(categories);
+
+    const ids = new Set<string>();
+    for (const template of templates) {
+        const tags = tagsById.get(template.categoryID) ?? [];
+        if (tags.some((tag) => selected.has(tag))) {
+            ids.add(template.id);
+        }
+    }
+    return Array.from(ids);
+};


### PR DESCRIPTION
## What

Adds a **tag breakdown** to the Analytics page, mirroring the existing recurring-task breakdown. A horizontally-scrolling row of tag pills sits above the recurring-tasks section, ranked by lifetime completions (`tag · count`). Tapping pills (multi-select) recolors the activity heatmap to show completions from all recurring tasks whose category carries the selected tag(s).

Tags live on **categories** (`Categories.tags`), and templates carry a `categoryID` + `timesCompleted`, so the whole feature is a client-side join — **no backend change**.

## How it works

- `frontend/utils/tagBreakdown.ts` — two pure helpers:
  - `buildTagAggregates(templates, categories)` → `{ tag, count }[]`, summing `timesCompleted` per tag across all matching categories, ranked by count desc (alphabetical tie-break), including zero-count tags.
  - `selectedTagTemplateIds(selectedTags, templates, categories)` → deduped template IDs for the selected tags.
- `frontend/components/activity/TagBreakdownRow.tsx` — presentational ranked pill row (reuses the existing `TagChip` shape + duotone colors).
- `frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx` — wires it in. The heatmap breakdown now aggregates over the **union** of manually-selected templates and tag-derived templates. `breakdownMode` is now derived from `effectiveTemplateIds.length > 0` (replacing the old imperative state, which removes three state-sync points). Tags are joined against categories from **all workspaces**, not just the selected one.

## Behavior preservation

When no tags are selected, `effectiveTemplateIds` reduces to `selectedTemplateIds` and the existing template-only breakdown behaves exactly as before.

## Testing

- 9 new unit tests for the pure helpers (counts, sorting, dedupe, zero-count inclusion, missing/untagged categories, missing `timesCompleted`, union/empty selection).
- Full suite: **64 passing**. The one failing suite (`AboutScreen.test.tsx`) is pre-existing breakage on `main` (imports a non-existent `@/app/about`), unrelated to this change.

## Known follow-up (not in this PR)

The tag pills use the shared `getCategoryDuotoneColors` palette. A few palette entries (yellow/green) have low text-contrast in both the existing `TagChip` and these pills — an app-wide design-system concern, deliberately left out of scope to keep this feature consistent with every other tag chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)