### PR TITLE
feat(tabs): floating liquid-glass tab bar

### DIFF
--- a/frontend/app/(logged-in)/(tabs)/_layout.tsx
+++ b/frontend/app/(logged-in)/(tabs)/_layout.tsx
@@ -1,18 +1,15 @@
 import { Tabs, useRouter, useSegments } from "expo-router";
 import React, { useEffect, useRef, useState, useMemo } from "react";
-import { Platform, Animated } from "react-native";
 import { usePathname } from "expo-router";
 
-import { HapticTab } from "@/components/HapticTab";
-import TabBarBackground from "@/components/ui/TabBarBackground";
-import { useColorScheme } from "react-native";
-import { useAuth } from "@/hooks/useAuth";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useDrawer } from "@/contexts/drawerContext";
 import { useNavigationState } from "@react-navigation/native";
 import { useFocusMode } from "@/contexts/focusModeContext";
 import { useTasks } from "@/contexts/tasksContext";
 import { FloatingActionButton } from "@/components/ui/FloatingActionButton";
+import { LiquidGlassTabBar } from "@/components/ui/LiquidGlassTabBar";
+import { ProfileTabIcon } from "@/components/ui/ProfileTabIcon";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents, TabNames } from "@/utils/analytics";
 import { feedScrollVisibilityEvents } from "@/utils/feedScrollVisibilityEvents";
@@ -21,66 +18,22 @@ import { feedScrollVisibilityEvents } from "@/utils/feedScrollVisibilityEvents";
 import {
     PencilSimple,
     PencilSimpleLine,
-    Compass,
-    CompassTool,
     MagnifyingGlass,
-    User,
-    Stack,
-    StackSimple,
-    Cards,
-    SquaresFour,
-    GridFour,
-    Rows,
-    TextColumns,
+    Newspaper,
     Brain,
 } from "phosphor-react-native";
 
 // Narrow selector: only subscribe to the index, return -1 if state isn't ready yet
 const useTabIndex = () => useNavigationState((state) => state?.index ?? -1);
 
-// Custom tab button components
-const TasksTabButton = (props: any) => {
-    const currentIndex = useTabIndex();
-    return <HapticTab {...props} isSelected={currentIndex === 0} />;
-};
-
-const FeedTabButton = (props: any) => {
-    const { focusMode } = useFocusMode();
-    const currentIndex = useTabIndex();
-    if (focusMode) return null;
-    return <HapticTab {...props} isSelected={currentIndex === 1} />;
-};
-
-const SearchTabButton = (props: any) => {
-    const { focusMode } = useFocusMode();
-    const currentIndex = useTabIndex();
-    if (focusMode) return null;
-    return <HapticTab {...props} isSelected={currentIndex === 2} />;
-};
-
-const ActivityTabButton = (props: any) => {
-    const { focusMode } = useFocusMode();
-    const currentIndex = useTabIndex();
-    if (focusMode) return null;
-    return <HapticTab {...props} isSelected={currentIndex === 3} />;
-};
-
-const ProfileTabButton = (props: any) => {
-    const { focusMode } = useFocusMode();
-    const currentIndex = useTabIndex();
-    if (focusMode) return null;
-    return <HapticTab {...props} isSelected={currentIndex === 4} />;
-};
-
 export const unstable_settings = {
     initialRouteName: "index",
 };
 
 export default function TabLayout() {
-    let ThemedColor = useThemeColor();
+    const ThemedColor = useThemeColor();
     const pathname = usePathname();
     const segments = useSegments();
-    const router = useRouter();
     const { isDrawerOpen } = useDrawer();
     const { focusMode } = useFocusMode();
     const { startTodayTasks, dueTodayTasks, windowTasks } = useTasks();
@@ -92,10 +45,6 @@ export default function TabLayout() {
     useEffect(() => {
         return feedScrollVisibilityEvents.subscribe(setScrollVisible);
     }, []);
-    const [modalVisible, setModalVisible] = useState(true);
-    const toggleModal = () => {
-        setModalVisible(!modalVisible);
-    };
 
     const prevTabIndex = useRef(currentIndex);
 
@@ -109,29 +58,15 @@ export default function TabLayout() {
         }
     }, [currentIndex]);
 
-    // Calculate total tasks for today
+    // Calculate total tasks for today (shown as a badge on the Tasks tab)
     const todayTaskCount = useMemo(() => {
         return startTodayTasks.length + dueTodayTasks.length + windowTasks.length;
     }, [startTodayTasks, dueTodayTasks, windowTasks]);
 
-    // Create animated value for tab bar visibility
-    const tabBarOpacity = React.useRef(new Animated.Value(1)).current;
-    const tabBarTranslateY = React.useRef(new Animated.Value(0)).current;
-
-    // Define screens where you want to hide the tab bar
-    const hideTabBarScreens = [
-        // "/blueprint",
-        "/blueprint/create",
-        "/voice",
-        "/review",
-    ];
-
-    // Define screens where you want to hide the FAB (but keep tab bar visible)
-    const hideFABScreens = [
-        "/daily",
-        "/review",
-        "/settings",
-    ];
+    // Screens where the whole tab bar hides
+    const hideTabBarScreens = ["/blueprint/create", "/voice", "/review"];
+    // Screens where only the FAB hides (tab bar stays visible)
+    const hideFABScreens = ["/daily", "/review", "/settings"];
 
     const shouldHideTabBar =
         hideTabBarScreens.some((screen) => pathname.startsWith(screen)) ||
@@ -142,94 +77,22 @@ export default function TabLayout() {
     const shouldHideFAB =
         shouldHideTabBar || hideFABScreens.some((screen) => pathname.startsWith(screen));
 
-    // Animate tab bar visibility
-    useEffect(() => {
-        const animationDuration = 300; // 300ms for smooth animation
-
-        if (shouldHideTabBar) {
-            // Animate out
-            Animated.parallel([
-                Animated.timing(tabBarOpacity, {
-                    toValue: 0,
-                    duration: animationDuration,
-                    useNativeDriver: true,
-                }),
-                Animated.timing(tabBarTranslateY, {
-                    toValue: 100, // Move down to hide
-                    duration: animationDuration,
-                    useNativeDriver: true,
-                }),
-            ]).start();
-        } else {
-            // Animate in
-            Animated.parallel([
-                Animated.timing(tabBarOpacity, {
-                    toValue: 1,
-                    duration: animationDuration,
-                    useNativeDriver: true,
-                }),
-                Animated.timing(tabBarTranslateY, {
-                    toValue: 0, // Move back to original position
-                    duration: animationDuration,
-                    useNativeDriver: true,
-                }),
-            ]).start();
-        }
-    }, [shouldHideTabBar, tabBarOpacity, tabBarTranslateY]);
-
     return (
         <>
             <Tabs
+                tabBar={(props) => (
+                    <LiquidGlassTabBar
+                        {...props}
+                        badges={{ "(task)": todayTaskCount > 0 ? todayTaskCount : undefined }}
+                        visible={!shouldHideTabBar}
+                    />
+                )}
                 screenOptions={{
-                    tabBarActiveTintColor: "#854DFF", // Purple color for selected state
-                    tabBarInactiveTintColor: ThemedColor.text, // Default text color for inactive state
-                    tabBarShowLabel: false, // Hide default labels
                     headerShown: false,
                     tabBarHideOnKeyboard: true,
-                    headerTitleStyle: {
-                        fontFamily: "Outfit",
-                    },
-                    tabBarBackground: TabBarBackground,
                     animation: "fade",
-                    tabBarVariant: "uikit",
-                    tabBarPosition: "bottom",
-                    tabBarItemStyle: {
-                        flex: 1,
-                        alignItems: "center",
-                        justifyContent: "flex-start", // Keep this for top alignment
-                    },
                     sceneStyle: {
                         backgroundColor: ThemedColor.background,
-                    },
-                    tabBarStyle: {
-                        ...Platform.select({
-                            ios: {
-                                borderTopWidth: 1,
-                                borderColor: ThemedColor.tertiary,
-                                position: "absolute",
-                                paddingTop: 12,
-                                height: 90,
-                                paddingBottom: 32,
-                                borderBottomLeftRadius: 0,
-                                borderBottomRightRadius: 0,
-                                width: "100%",
-                                overflow: "hidden",
-                            },
-                            android: {
-                                borderTopWidth: 1,
-                                borderColor: ThemedColor.tertiary,
-                                position: "absolute",
-                                paddingTop: 12,
-                                height: 90,
-                                paddingBottom: 64,
-                                borderRadius: 30,
-                                width: "100%",
-                                overflow: "hidden",
-                                borderWidth: 1,
-                            },
-                        }),
-                        opacity: tabBarOpacity,
-                        transform: [{ translateY: tabBarTranslateY }],
                     },
                 }}>
                 <Tabs.Screen
@@ -242,8 +105,6 @@ export default function TabLayout() {
                             ) : (
                                 <PencilSimpleLine size={24} color={color} />
                             ),
-                        tabBarBadge: todayTaskCount > 0 ? todayTaskCount : undefined,
-                        tabBarButton: TasksTabButton,
                         tabBarAccessibilityLabel: "Tasks",
                     }}
                 />
@@ -251,13 +112,9 @@ export default function TabLayout() {
                     name="(feed)"
                     options={{
                         title: "Feed",
-                        tabBarIcon: ({ color, focused }) =>
-                            focused ? (
-                                <SquaresFour size={24} color={color} weight="fill" />
-                            ) : (
-                                <SquaresFour size={24} color={color} />
-                            ),
-                        tabBarButton: FeedTabButton,
+                        tabBarIcon: ({ color, focused }) => (
+                            <Newspaper size={24} color={color} weight={focused ? "fill" : "regular"} />
+                        ),
                         tabBarAccessibilityLabel: "Feed",
                     }}
                 />
@@ -265,13 +122,9 @@ export default function TabLayout() {
                     name="(search)"
                     options={{
                         title: "Search",
-                        tabBarIcon: ({ color, focused }) =>
-                            focused ? (
-                                <MagnifyingGlass size={24} color={color} weight="bold" />
-                            ) : (
-                                <MagnifyingGlass size={24} color={color} />
-                            ),
-                        tabBarButton: SearchTabButton,
+                        tabBarIcon: ({ color, focused }) => (
+                            <MagnifyingGlass size={24} color={color} weight={focused ? "bold" : "regular"} />
+                        ),
                         tabBarAccessibilityLabel: "Search",
                     }}
                 />
@@ -279,9 +132,9 @@ export default function TabLayout() {
                     name="(activity)"
                     options={{
                         title: "Activity",
-                        tabBarIcon: ({ color, focused }) =>
-                            focused ? <Brain size={24} color={color} weight="fill" /> : <Brain size={24} color={color} />,
-                        tabBarButton: ActivityTabButton,
+                        tabBarIcon: ({ color, focused }) => (
+                            <Brain size={24} color={color} weight={focused ? "fill" : "regular"} />
+                        ),
                         tabBarAccessibilityLabel: "Activity",
                     }}
                 />
@@ -289,9 +142,7 @@ export default function TabLayout() {
                     name="(profile)"
                     options={{
                         title: "Profile",
-                        tabBarIcon: ({ color, focused }) =>
-                            focused ? <User size={24} color={color} weight="fill" /> : <User size={24} color={color} />,
-                        tabBarButton: ProfileTabButton,
+                        tabBarIcon: ({ color, focused }) => <ProfileTabIcon focused={focused} color={color} />,
                         tabBarAccessibilityLabel: "Profile",
                     }}
                 />

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -41,6 +41,7 @@
         "expo-dev-client": "^55.0.24",
         "expo-device": "~55.0.14",
         "expo-font": "~55.0.6",
+        "expo-glass-effect": "~55.0.11",
         "expo-haptics": "~55.0.14",
         "expo-image": "~55.0.8",
         "expo-image-picker": "~55.0.18",
@@ -1335,7 +1336,7 @@
 
     "expo-font": ["expo-font@55.0.6", "", { "dependencies": { "fontfaceobserver": "^2.1.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-x9czUA3UQWjIwa0ZUEs/eWJNqB4mAue/m4ltESlNPLZhHL0nWWqIfsyHmklTLFH7mVfcHSJvew6k+pR2FE1zVw=="],
 
-    "expo-glass-effect": ["expo-glass-effect@55.0.10", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-5kL/jATvgJWdrqPdxixrECJqD2l8cfQ4ALr1DK7qi9XkyI97ejXvUjB2VsfEePNy3Fg+/VwzA3n3L7Nv3tAPkw=="],
+    "expo-glass-effect": ["expo-glass-effect@55.0.11", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-wqq7GUOqSkfoFJzreZvBG0jzjsq5c582m3glhWSjcmIuByxXXWp6j6GY6hyFuYKzpOXhbuvusVxGCQi0yWnp3g=="],
 
     "expo-haptics": ["expo-haptics@55.0.14", "", { "peerDependencies": { "expo": "*" } }, "sha512-KjDItBsA9mi1f5nRwf8g1wOdfEcLHwvEdt5Jl1sMCDETR/homcGOl+F3QIiPOl/PRlbGVieQsjTtF4DGtHOj6g=="],
 
@@ -2678,6 +2679,8 @@
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "expo-router/@expo/metro-runtime": ["@expo/metro-runtime@55.0.9", "", { "dependencies": { "@expo/log-box": "55.0.10", "anser": "^1.4.9", "pretty-format": "^29.7.0", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0" }, "peerDependencies": { "expo": "*", "react": "*", "react-dom": "*", "react-native": "*" }, "optionalPeers": ["react-dom"] }, "sha512-H37b2Mc/8GiQbwtUFzUTxA3KsAMZu00SRg/RhbHa9xVE7J0n5ZX4NHy0LJEFAbkzTb1TUy1hLpo3oEKnG+rLyg=="],
+
+    "expo-router/expo-glass-effect": ["expo-glass-effect@55.0.10", "", { "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-5kL/jATvgJWdrqPdxixrECJqD2l8cfQ4ALr1DK7qi9XkyI97ejXvUjB2VsfEePNy3Fg+/VwzA3n3L7Nv3tAPkw=="],
 
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
 

--- a/frontend/components/ui/FloatingActionButton.tsx
+++ b/frontend/components/ui/FloatingActionButton.tsx
@@ -20,7 +20,8 @@ import CreateWorkspaceBottomSheetModal from "@/components/modals/CreateWorkspace
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 
-const TAB_BAR_HEIGHT = 83;
+// Clears the floating glass pill: paddingBottom (insets.bottom + 8) + 64px pill + 8px gap.
+const TAB_BAR_HEIGHT = 80;
 
 type FABState = "collapsed" | "task-selection" | "workspace-creation" | "post-task-selection";
 

--- a/frontend/components/ui/GlassTabItem.tsx
+++ b/frontend/components/ui/GlassTabItem.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { Pressable, View, Platform } from "react-native";
+import * as Haptics from "expo-haptics";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+type IconRenderer = (props: { focused: boolean; color: string; size: number }) => React.ReactNode;
+
+type Props = {
+    focused: boolean;
+    onPress: () => void;
+    renderIcon?: IconRenderer;
+    accessibilityLabel?: string;
+    badge?: number;
+    // When true, inactive icons invert against the backdrop (difference blend)
+    // so they stay legible over any content behind the glass. Off for avatars.
+    invert?: boolean;
+};
+
+// A single tab slot: renders the route's icon (reused from the screen's
+// tabBarIcon option) with a light haptic on press and an optional count badge.
+export function GlassTabItem({ focused, onPress, renderIcon, accessibilityLabel, badge, invert = true }: Props) {
+    const ThemedColor = useThemeColor();
+    const isDark = ThemedColor.background === "#13121F";
+    // Active icon is brand purple. Inactive icons take the theme's text color
+    // with an opposite-tone glow so they stay legible over any backdrop.
+    const glowing = invert && !focused;
+    const color = focused ? ThemedColor.primary : ThemedColor.text;
+    const glow = isDark ? "rgba(0,0,0,0.9)" : "rgba(255,255,255,0.95)";
+
+    const handlePress = async () => {
+        if (Platform.OS === "ios") {
+            try {
+                await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+            } catch {
+                // haptics are best-effort
+            }
+        }
+        onPress();
+    };
+
+    return (
+        <Pressable
+            accessibilityRole="button"
+            accessibilityState={{ selected: focused }}
+            accessibilityLabel={accessibilityLabel}
+            onPress={handlePress}
+            style={{
+                flex: 1,
+                alignItems: "center",
+                justifyContent: "center",
+                height: "100%",
+            }}>
+            <View
+                style={{
+                    alignItems: "center",
+                    justifyContent: "center",
+                    ...(glowing
+                        ? { filter: [{ dropShadow: `0px 0px 2px ${glow}` }, { dropShadow: `0px 0px 3px ${glow}` }] }
+                        : null),
+                }}>
+                {renderIcon?.({ focused, color, size: 24 })}
+                {badge !== undefined && badge > 0 && (
+                    <View
+                        style={{
+                            position: "absolute",
+                            top: -8,
+                            right: -12,
+                            minWidth: 18,
+                            height: 18,
+                            paddingHorizontal: 5,
+                            borderRadius: 9,
+                            backgroundColor: ThemedColor.primary,
+                            alignItems: "center",
+                            justifyContent: "center",
+                        }}>
+                        <ThemedText
+                            type="caption"
+                            style={{ color: "#FFFFFF", fontSize: 11, lineHeight: 14 }}>
+                            {badge > 99 ? "99+" : badge}
+                        </ThemedText>
+                    </View>
+                )}
+            </View>
+        </Pressable>
+    );
+}

--- a/frontend/components/ui/LiquidGlassTabBar.tsx
+++ b/frontend/components/ui/LiquidGlassTabBar.tsx
@@ -1,0 +1,211 @@
+import React, { useEffect, useState } from "react";
+import { View, StyleSheet, Platform, useColorScheme, LayoutChangeEvent, Keyboard } from "react-native";
+import Animated, { useAnimatedStyle, useSharedValue, withSpring, withTiming } from "react-native-reanimated";
+import { BlurView } from "expo-blur";
+import { GlassView, isLiquidGlassAvailable } from "expo-glass-effect";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { GlassTabItem } from "./GlassTabItem";
+
+// iOS 26+ native Liquid Glass; falls back to BlurView/tint elsewhere.
+// Guarded so a dev client without the native module can't crash at import.
+let LIQUID_GLASS = false;
+try {
+    LIQUID_GLASS = isLiquidGlassAvailable();
+} catch {
+    LIQUID_GLASS = false;
+}
+
+const PILL_HEIGHT = 64;
+const H_MARGIN = 16;
+const INNER_PADDING = 6;
+const CAPSULE_INSET = 8;
+
+type Props = BottomTabBarProps & {
+    badges?: Record<string, number | undefined>;
+    visible?: boolean;
+};
+
+// Floating "liquid glass" tab bar: a detached blurred pill with a highlight
+// capsule that springs between tabs. Reuses each screen's tabBarIcon option.
+export function LiquidGlassTabBar({ state, descriptors, navigation, badges, visible = true }: Props) {
+    const ThemedColor = useThemeColor();
+    const scheme = useColorScheme();
+    const insets = useSafeAreaInsets();
+    const [contentWidth, setContentWidth] = useState(0);
+    const [keyboardUp, setKeyboardUp] = useState(false);
+
+    // Hide the floating pill when the keyboard is open (replaces tabBarHideOnKeyboard).
+    useEffect(() => {
+        const showEvent = Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+        const hideEvent = Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+        const show = Keyboard.addListener(showEvent, () => setKeyboardUp(true));
+        const hide = Keyboard.addListener(hideEvent, () => setKeyboardUp(false));
+        return () => {
+            show.remove();
+            hide.remove();
+        };
+    }, []);
+
+    const shown = visible && !keyboardUp;
+
+    const routeCount = state.routes.length;
+    const tabWidth = contentWidth > 0 ? contentWidth / routeCount : 0;
+
+    const capsuleX = useSharedValue(0);
+    useEffect(() => {
+        capsuleX.value = withSpring(state.index * tabWidth, { damping: 18, stiffness: 180, mass: 0.6 });
+    }, [state.index, tabWidth]);
+
+    const capsuleStyle = useAnimatedStyle(() => ({
+        width: Math.max(tabWidth, 0),
+        transform: [{ translateX: capsuleX.value }],
+    }));
+
+    const containerStyle = useAnimatedStyle(() => ({
+        opacity: withTiming(shown ? 1 : 0, { duration: 300 }),
+        transform: [{ translateY: withTiming(shown ? 0 : 120, { duration: 300 }) }],
+    }));
+
+    const onContentLayout = (e: LayoutChangeEvent) => setContentWidth(e.nativeEvent.layout.width);
+
+    const isDark = scheme === "dark";
+    const borderColor = isDark ? "rgba(255,255,255,0.18)" : "rgba(0,0,0,0.06)";
+    const glassTint = isDark ? "rgba(28,26,42,0.55)" : "rgba(255,255,255,0.55)";
+
+    return (
+        <Animated.View
+            pointerEvents={shown ? "box-none" : "none"}
+            style={[styles.root, { paddingBottom: insets.bottom + 8 }, containerStyle]}>
+            <View
+                style={[
+                    styles.shadowWrap,
+                    {
+                        boxShadow: isDark
+                            ? "0px 10px 24px rgba(0,0,0,0.55)"
+                            : "0px 8px 18px rgba(31,29,46,0.20)",
+                    },
+                ]}>
+                <View
+                    style={[
+                        styles.pill,
+                        {
+                            // Faint specular rim so the glass pane has a defined edge on white
+                            borderColor: LIQUID_GLASS
+                                ? isDark
+                                    ? "rgba(255,255,255,0.22)"
+                                    : "rgba(255,255,255,0.7)"
+                                : borderColor,
+                        },
+                    ]}>
+                    {LIQUID_GLASS ? (
+                        <>
+                            {/* BlurView gives reliable frost on simulator + device */}
+                            <BlurView
+                                tint={isDark ? "dark" : "light"}
+                                intensity={40}
+                                style={[StyleSheet.absoluteFill, { borderRadius: PILL_HEIGHT / 2 }]}
+                            />
+                            {/* Native Liquid Glass on top for real refraction/specular on device */}
+                            <GlassView
+                                glassEffectStyle="clear"
+                                isInteractive
+                                style={[StyleSheet.absoluteFill, { borderRadius: PILL_HEIGHT / 2 }]}
+                            />
+                        </>
+                    ) : (
+                        <>
+                            {Platform.OS === "ios" ? (
+                                <BlurView
+                                    tint={isDark ? "dark" : "light"}
+                                    intensity={40}
+                                    style={StyleSheet.absoluteFill}
+                                />
+                            ) : null}
+                            <View style={[StyleSheet.absoluteFill, { backgroundColor: glassTint }]} />
+                        </>
+                    )}
+
+                    <View style={styles.content} onLayout={onContentLayout}>
+                        {/* Sliding highlight capsule */}
+                        <Animated.View
+                            pointerEvents="none"
+                            style={[
+                                styles.capsule,
+                                {
+                                    // Soft lavender tint behind the active tab
+                                    backgroundColor: ThemedColor.primary + (isDark ? "33" : "24"),
+                                },
+                                capsuleStyle,
+                            ]}
+                        />
+
+                        {state.routes.map((route, index) => {
+                            const { options } = descriptors[route.key];
+                            const focused = state.index === index;
+
+                            const onPress = () => {
+                                const event = navigation.emit({
+                                    type: "tabPress",
+                                    target: route.key,
+                                    canPreventDefault: true,
+                                });
+                                if (!focused && !event.defaultPrevented) {
+                                    navigation.navigate(route.name as never);
+                                }
+                            };
+
+                            return (
+                                <GlassTabItem
+                                    key={route.key}
+                                    focused={focused}
+                                    onPress={onPress}
+                                    renderIcon={options.tabBarIcon}
+                                    accessibilityLabel={options.tabBarAccessibilityLabel}
+                                    badge={badges?.[route.name]}
+                                    invert={route.name !== "(profile)"}
+                                />
+                            );
+                        })}
+                    </View>
+                </View>
+            </View>
+        </Animated.View>
+    );
+}
+
+const styles = StyleSheet.create({
+    root: {
+        position: "absolute",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        paddingHorizontal: H_MARGIN,
+    },
+    shadowWrap: {
+        borderRadius: PILL_HEIGHT / 2,
+        // boxShadow (set inline, theme-aware) renders around the transparent
+        // glass box; elevation is the Android fallback.
+        elevation: 12,
+    },
+    pill: {
+        height: PILL_HEIGHT,
+        borderRadius: PILL_HEIGHT / 2,
+        borderWidth: StyleSheet.hairlineWidth,
+        overflow: "hidden",
+        paddingHorizontal: INNER_PADDING,
+    },
+    content: {
+        flex: 1,
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    capsule: {
+        position: "absolute",
+        left: 0,
+        top: CAPSULE_INSET,
+        bottom: CAPSULE_INSET,
+        borderRadius: (PILL_HEIGHT - 2 * CAPSULE_INSET) / 2,
+    },
+});

--- a/frontend/components/ui/ProfileTabIcon.tsx
+++ b/frontend/components/ui/ProfileTabIcon.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { View } from "react-native";
+import { User } from "phosphor-react-native";
+import CachedImage from "@/components/CachedImage";
+import { useAuth } from "@/hooks/useAuth";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+// Profile tab icon: shows the user's avatar with a ring when focused,
+// falling back to the Phosphor User icon when there's no picture.
+export function ProfileTabIcon({ focused, color, size = 24 }: { focused: boolean; color: string; size?: number }) {
+    const { user } = useAuth();
+    const ThemedColor = useThemeColor();
+    const uri = user?.profile_picture;
+
+    if (!uri) {
+        return <User size={size} color={color} weight={focused ? "fill" : "regular"} />;
+    }
+
+    const dim = size + 4;
+    return (
+        <View
+            style={{
+                width: dim,
+                height: dim,
+                borderRadius: dim / 2,
+                borderWidth: focused ? 2 : 1,
+                borderColor: focused ? ThemedColor.primary : ThemedColor.tertiary,
+                overflow: "hidden",
+            }}>
+            <CachedImage
+                source={{ uri }}
+                style={{ width: "100%", height: "100%" }}
+                variant="thumbnail"
+                cachePolicy="memory-disk"
+            />
+        </View>
+    );
+}

--- a/frontend/ios/Kindred.xcodeproj/project.pbxproj
+++ b/frontend/ios/Kindred.xcodeproj/project.pbxproj
@@ -275,13 +275,13 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
+						DevelopmentTeam = JCSXY9MWTL;
 						LastSwiftMigration = 1250;
-						DevelopmentTeam = "JCSXY9MWTL";
 						ProvisioningStyle = Automatic;
 					};
 					B1246A99F1364D26B7893B99 = {
+						DevelopmentTeam = JCSXY9MWTL;
 						LastSwiftMigration = 1250;
-						DevelopmentTeam = "JCSXY9MWTL";
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -604,8 +604,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Kindred/Kindred.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "JCSXY9MWTL";
+				DEVELOPMENT_TEAM = JCSXY9MWTL;
 				ENABLE_BITCODE = NO;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
@@ -617,7 +619,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -631,8 +633,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Debug;
 		};
@@ -643,15 +643,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Kindred/Kindred.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "JCSXY9MWTL";
+				DEVELOPMENT_TEAM = JCSXY9MWTL;
 				INFOPLIST_FILE = Kindred/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-ObjC",
@@ -664,8 +666,6 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Release;
 		};
@@ -675,22 +675,22 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = ExpoWidgetsTarget/ExpoWidgetsTarget.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 70;
+				DEVELOPMENT_TEAM = JCSXY9MWTL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ExpoWidgetsTarget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ExpoWidgetsTarget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kindred.kindredtsl.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
-				DEVELOPMENT_TEAM = "JCSXY9MWTL";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Release;
 		};
@@ -822,22 +822,22 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_ENTITLEMENTS = ExpoWidgetsTarget/ExpoWidgetsTarget.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 70;
+				DEVELOPMENT_TEAM = JCSXY9MWTL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = ExpoWidgetsTarget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = ExpoWidgetsTarget;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.0.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.kindred.kindredtsl.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 1;
-				DEVELOPMENT_TEAM = "JCSXY9MWTL";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
 			};
 			name = Debug;
 		};

--- a/frontend/ios/Podfile.lock
+++ b/frontend/ios/Podfile.lock
@@ -240,7 +240,7 @@ PODS:
     - ExpoModulesCore
   - ExpoFont (55.0.6):
     - ExpoModulesCore
-  - ExpoGlassEffect (55.0.10):
+  - ExpoGlassEffect (55.0.11):
     - ExpoModulesCore
   - ExpoHaptics (55.0.14):
     - ExpoModulesCore
@@ -3217,7 +3217,7 @@ SPEC CHECKSUMS:
   ExpoDomWebView: 2b2fbd9a07de8790569257cbf9dfdaa31cf95c70
   ExpoFileSystem: 310d367cccbd30b9bda13c5865fe3d8d581dcf2a
   ExpoFont: cdd7a1d574a376fa003c713eff49e0a4df8672c7
-  ExpoGlassEffect: 72bcb9dc634262c59897ff7c53c16e2ff03990d0
+  ExpoGlassEffect: 2dedac2fe817f9b02d0dad29ce0aef7afebc5cd4
   ExpoHaptics: 679f09dc37d5981e619bc197732007a3334e80b8
   ExpoImage: ef931bba1fd3e907c2262216d17eb21095c9ac2b
   ExpoImagePicker: ce50d0bf7d27d1a822b08a84bea9bfc0b3924557

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "expo-dev-client": "^55.0.24",
     "expo-device": "~55.0.14",
     "expo-font": "~55.0.6",
+    "expo-glass-effect": "~55.0.11",
     "expo-haptics": "~55.0.14",
     "expo-image": "~55.0.8",
     "expo-image-picker": "~55.0.18",


### PR DESCRIPTION
## Summary
Redesigns the bottom tab bar into a detached, floating **liquid-glass pill** with a sliding highlight.

- Custom `tabBar` (reuses each screen's `tabBarIcon`) with a spring-animated **lavender capsule** that slides between tabs
- Native iOS 26 **Liquid Glass** via `expo-glass-effect` (`GlassView`) layered over a `BlurView` frost — reads on both simulator and device (GlassView refraction under-renders on the sim, BlurView guarantees frost)
- Drop shadow (`boxShadow`), **purple active icon**, `Newspaper` feed icon, **user avatar** in the profile tab
- Inactive icons use theme color + a contrast glow so they stay legible over any backdrop; keyboard-aware hide/show preserved
- FAB offset adjusted to clear the floating pill
- Adds `expo-glass-effect` (`~55.0.11`) + pod integration

## Testing
- Type-checks clean
- Verified on iPhone 17 / iOS 26.3 simulator: glass enabled (`isLiquidGlassAvailable() === true`), sliding capsule, purple/lavender, drop shadow, legible icons over light & busy backdrops

## Notes
- Full Liquid Glass refraction is most visible on a **physical iOS 26 device**; the simulator under-renders it, so `BlurView` provides the frost there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)