### PR TITLE
feat(mentions): tag suggestions as a popover under the caret

### DIFF
--- a/frontend/components/inputs/MentionAutocomplete.tsx
+++ b/frontend/components/inputs/MentionAutocomplete.tsx
@@ -1,18 +1,24 @@
 import React from "react";
-import { View, FlatList, TouchableOpacity } from "react-native";
+import { View, FlatList, TouchableOpacity, LayoutChangeEvent } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+import CachedImage from "@/components/CachedImage";
 
 type Props = {
     query: string | null;
     onPick: (candidate: MentionCandidate) => void;
+    // Vertical anchor relative to the input. Exactly one is set by the host.
+    top?: number;
+    bottom?: number;
+    onMeasureHeight?: (height: number) => void;
     maxRows?: number;
 };
 
-const ROW_HEIGHT = 44;
+const ROW_HEIGHT = 48;
+const AVATAR_SIZE = 32;
 
-const MentionAutocomplete = ({ query, onPick, maxRows = 5 }: Props) => {
+const MentionAutocomplete = ({ query, onPick, top, bottom, onMeasureHeight, maxRows = 5 }: Props) => {
     const ThemedColor = useThemeColor();
     const { filter, loading } = useFriendsForMention();
 
@@ -23,26 +29,39 @@ const MentionAutocomplete = ({ query, onPick, maxRows = 5 }: Props) => {
 
     return (
         <View
+            onLayout={(e: LayoutChangeEvent) => onMeasureHeight?.(e.nativeEvent.layout.height)}
             style={{
+                position: "absolute",
+                left: 0,
+                right: 0,
+                top,
+                bottom,
+                zIndex: 1000,
                 backgroundColor: ThemedColor.background,
                 borderRadius: 12,
                 borderWidth: 1,
                 borderColor: ThemedColor.lightened,
-                marginTop: 4,
                 maxHeight: ROW_HEIGHT * maxRows,
                 overflow: "hidden",
                 shadowColor: "#000",
                 shadowOffset: { width: 0, height: 4 },
                 shadowOpacity: 0.08,
                 shadowRadius: 12,
-                elevation: 4,
+                elevation: 8,
             }}>
             <FlatList
                 data={matches}
                 keyExtractor={(item) => item.id}
                 keyboardShouldPersistTaps="always"
                 renderItem={({ item }) => (
-                    <MentionRow item={item} query={query} onPick={onPick} primary={ThemedColor.primary} />
+                    <MentionRow
+                        item={item}
+                        query={query}
+                        onPick={onPick}
+                        primary={ThemedColor.primary}
+                        caption={ThemedColor.caption}
+                        placeholder={ThemedColor.lightened}
+                    />
                 )}
             />
         </View>
@@ -54,51 +73,74 @@ type RowProps = {
     query: string;
     onPick: (c: MentionCandidate) => void;
     primary: string;
+    caption: string;
+    placeholder: string;
 };
 
-function MentionRow({ item, query, onPick, primary }: RowProps) {
+function MentionRow({ item, query, onPick, primary, caption, placeholder }: RowProps) {
     const q = query.toLowerCase();
-    const handleLower = item.handle.toLowerCase();
     const nameLower = item.display_name.toLowerCase();
-    const handleMatch = q && handleLower.startsWith(q) ? item.handle.slice(0, q.length) : null;
     const nameMatchIdx = q ? nameLower.indexOf(q) : -1;
+    // Handle already includes the leading "@"; match the query against it without it.
+    const handleBody = item.handle.replace(/^@/, "");
+    const handleMatchLen = q && handleBody.toLowerCase().startsWith(q) ? q.length : 0;
 
     return (
         <TouchableOpacity
             onPress={() => onPick(item)}
             activeOpacity={0.6}
             style={{
-                paddingHorizontal: 16,
+                flexDirection: "row",
+                alignItems: "center",
+                gap: 10,
+                paddingHorizontal: 12,
                 height: ROW_HEIGHT,
-                justifyContent: "center",
             }}>
-            <ThemedText type="default">
-                {nameMatchIdx >= 0 ? (
-                    <>
-                        <ThemedText type="default">{item.display_name.slice(0, nameMatchIdx)}</ThemedText>
-                        <ThemedText type="defaultSemiBold" style={{ color: primary }}>
-                            {item.display_name.slice(nameMatchIdx, nameMatchIdx + q.length)}
-                        </ThemedText>
-                        <ThemedText type="default">{item.display_name.slice(nameMatchIdx + q.length)}</ThemedText>
-                    </>
-                ) : (
-                    <ThemedText type="default">{item.display_name}</ThemedText>
-                )}
-                {"  "}
-                <ThemedText type="caption">
-                    @
-                    {handleMatch ? (
+            {item.profile_picture ? (
+                <CachedImage
+                    source={{ uri: item.profile_picture }}
+                    variant="thumbnail"
+                    cachePolicy="memory-disk"
+                    style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+                />
+            ) : (
+                <View
+                    style={{
+                        width: AVATAR_SIZE,
+                        height: AVATAR_SIZE,
+                        borderRadius: AVATAR_SIZE / 2,
+                        backgroundColor: placeholder,
+                    }}
+                />
+            )}
+            <View style={{ flex: 1, gap: 1 }}>
+                <ThemedText type="default" numberOfLines={1}>
+                    {nameMatchIdx >= 0 ? (
                         <>
+                            {item.display_name.slice(0, nameMatchIdx)}
                             <ThemedText type="defaultSemiBold" style={{ color: primary }}>
-                                {handleMatch}
+                                {item.display_name.slice(nameMatchIdx, nameMatchIdx + q.length)}
                             </ThemedText>
-                            <ThemedText type="caption">{item.handle.slice(q.length)}</ThemedText>
+                            {item.display_name.slice(nameMatchIdx + q.length)}
                         </>
                     ) : (
-                        item.handle
+                        item.display_name
                     )}
                 </ThemedText>
-            </ThemedText>
+                <ThemedText type="caption" numberOfLines={1} style={{ color: caption }}>
+                    @
+                    {handleMatchLen > 0 ? (
+                        <>
+                            <ThemedText type="defaultSemiBold" style={{ color: primary, fontSize: 14 }}>
+                                {handleBody.slice(0, handleMatchLen)}
+                            </ThemedText>
+                            {handleBody.slice(handleMatchLen)}
+                        </>
+                    ) : (
+                        handleBody
+                    )}
+                </ThemedText>
+            </View>
         </TouchableOpacity>
     );
 }

--- a/frontend/components/inputs/MentionTextInput.tsx
+++ b/frontend/components/inputs/MentionTextInput.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { View } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { View, Text, Keyboard, LayoutChangeEvent, useWindowDimensions } from "react-native";
 import LongTextInput from "./LongTextInput";
 import MentionAutocomplete from "./MentionAutocomplete";
 import { useMentionTrigger } from "@/hooks/useMentionTrigger";
@@ -14,16 +14,54 @@ type Props = {
     minHeight?: number;
 };
 
-const MentionTextInput = ({ value, setValue, onMentionPicked, placeholder, fontSize, minHeight }: Props) => {
-    const { query, onChange, onSelection, onPick } = useMentionTrigger(value, setValue);
+const GAP = 4;
+
+const MentionTextInput = ({
+    value,
+    setValue,
+    onMentionPicked,
+    placeholder,
+    fontSize = 16,
+    minHeight,
+}: Props) => {
+    const { query, caret, onChange, onSelection, onPick } = useMentionTrigger(value, setValue);
+    const { height: windowHeight } = useWindowDimensions();
+    const lineHeight = fontSize * 1.5;
+
+    const containerRef = useRef<View>(null);
+    const [lineBottomY, setLineBottomY] = useState(lineHeight);
+    const [inputHeight, setInputHeight] = useState(0);
+    const [popoverHeight, setPopoverHeight] = useState(0);
+    const [pageY, setPageY] = useState(0);
+    const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+    useEffect(() => {
+        const show = Keyboard.addListener("keyboardDidShow", (e) => setKeyboardHeight(e.endCoordinates.height));
+        const hide = Keyboard.addListener("keyboardDidHide", () => setKeyboardHeight(0));
+        return () => {
+            show.remove();
+            hide.remove();
+        };
+    }, []);
 
     const handlePick = (c: MentionCandidate) => {
         onPick(c);
         onMentionPicked(c);
     };
 
+    const onContainerLayout = (e: LayoutChangeEvent) => {
+        setInputHeight(e.nativeEvent.layout.height);
+        containerRef.current?.measureInWindow((_x, y) => setPageY(y));
+    };
+
+    // Decide whether to drop the popover below the caret line or flip it above.
+    const lineTopY = lineBottomY - lineHeight;
+    const belowBottomEdge = pageY + lineBottomY + GAP + popoverHeight;
+    const availableBottom = windowHeight - keyboardHeight - 8;
+    const flipAbove = popoverHeight > 0 && belowBottomEdge > availableBottom;
+
     return (
-        <View>
+        <View ref={containerRef} style={{ position: "relative" }} onLayout={onContainerLayout}>
             <LongTextInput
                 value={value}
                 setValue={onChange}
@@ -32,7 +70,32 @@ const MentionTextInput = ({ value, setValue, onMentionPicked, placeholder, fontS
                 minHeight={minHeight}
                 onSelectionChange={onSelection}
             />
-            <MentionAutocomplete query={query} onPick={handlePick} />
+            {/* Hidden mirror: matches the input's text layout so its height = bottom Y of the caret's line. */}
+            <Text
+                aria-hidden
+                pointerEvents="none"
+                onLayout={(e) => setLineBottomY(e.nativeEvent.layout.height)}
+                style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    opacity: 0,
+                    zIndex: -1,
+                    fontSize,
+                    fontFamily: "Outfit",
+                    fontWeight: "400",
+                    lineHeight,
+                }}>
+                {value.slice(0, caret) || " "}
+            </Text>
+            <MentionAutocomplete
+                query={query}
+                onPick={handlePick}
+                top={flipAbove ? undefined : lineBottomY + GAP}
+                bottom={flipAbove ? inputHeight - lineTopY + GAP : undefined}
+                onMeasureHeight={setPopoverHeight}
+            />
         </View>
     );
 };

--- a/frontend/hooks/useMentionTrigger.ts
+++ b/frontend/hooks/useMentionTrigger.ts
@@ -47,5 +47,5 @@ export const useMentionTrigger = (value: string, setValue: (v: string) => void) 
         setQuery(null);
     };
 
-    return { query, onChange, onSelection, onPick, picked, setPicked };
+    return { query, caret: selection.start, onChange, onSelection, onPick, picked, setPicked };
 };


### PR DESCRIPTION
## What

When tagging inline on the captioning screen, the `@`-mention suggestions now appear as an **overlay popover dropped right under the caret's line**, instead of as an inline block that pushed the rest of the form down.

## Why

The old autocomplete rendered as an inline block (`marginTop: 4`) below the input — it reflowed the form and floated disconnected from the `@` the user just typed. It also rendered `@@beaker` (doubled `@`), since the candidate handle already carries a leading `@`.

## How

- **Caret-line anchoring** — RN's `TextInput` exposes no caret-coordinate API, so `MentionTextInput` renders a hidden "mirror" `Text` (identical width/font/`lineHeight`) containing the text up to the caret. Its measured height = the bottom-Y of the caret's line (wrapping handled for free). The popover is positioned absolutely at that Y, left-aligned to the input.
- **Flip-above** — tracks keyboard height + the input's window position; when the popover would run past the visible area, it anchors above the caret line instead of below.
- **Overlay** — `position: absolute` with high `zIndex`/`elevation`, so it floats over the chips/buttons rather than reflowing them.
- **Row redesign** — avatar (`CachedImage`) + display name + handle, with match highlighting.
- **Bugfix** — strips the handle's baked-in `@` so it renders a single `@handle` (no more `@@beaker`).

## Files

- `frontend/hooks/useMentionTrigger.ts` — expose `caret` (additive)
- `frontend/components/inputs/MentionTextInput.tsx` — positioning host + mirror measurement + flip-above
- `frontend/components/inputs/MentionAutocomplete.tsx` — overlay + row redesign

## Testing

- `tsc`: clean for the changed files
- `__tests__/PostCardCaption.test.tsx`: 3/3 pass
- Manually verified on the caption screen — popover lands under the correct line and reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)