### PR TITLE
feat(posts): feature kudos on posts (the other half of encouraged tasks)

### DIFF
--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -175,6 +175,25 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 		}
 	}
 
+	// Append a denormalized kudos onto the post so cards can render the
+	// congratulator cluster (and the in-thread kudos) without a join.
+	// Best-effort: a missing post or failed update is logged, not fatal.
+	if r.PostID != nil && !r.PostID.IsZero() && s.Posts != nil {
+		kudos := types.PostKudos{
+			CongratulationID: id,
+			Sender: types.KudosSender{
+				ID:   r.Sender.ID,
+				Name: r.Sender.Name,
+				Icon: r.Sender.Picture,
+			},
+			Message:   r.Message,
+			Timestamp: congratulation.Timestamp,
+		}
+		if _, err := s.Posts.UpdateOne(ctx, bson.M{"_id": r.PostID}, bson.M{"$push": bson.M{"kudos": kudos}}); err != nil {
+			slog.Error("Failed to append kudos to post", "error", err, "post_id", r.PostID.Hex())
+		}
+	}
+
 	// ReferenceID points to the post the congratulation is on (if any) so tapping the notification
 	// opens that post. Congratulations without a post (no current backend path produces this,
 	// but the field is optional) get a zero referenceID and the frontend will fall back.

--- a/backend/internal/handlers/congratulation/service_test.go
+++ b/backend/internal/handlers/congratulation/service_test.go
@@ -295,6 +295,16 @@ func (s *CongratulationServiceTestSuite) TestCreateCongratulation_WithPostID() {
 	s.NoError(err)
 	s.NotNil(result)
 	s.Equal("Amazing post!", result.Message)
+
+	// The congratulation should have been appended as a kudos on the post.
+	var updatedPost types.PostDocument
+	err = s.Collections["posts"].FindOne(s.Ctx, bson.M{"_id": postID}).Decode(&updatedPost)
+	s.NoError(err)
+	s.Len(updatedPost.Kudos, 1)
+	s.Equal("Amazing post!", updatedPost.Kudos[0].Message)
+	s.Equal(user1.ID, updatedPost.Kudos[0].Sender.ID)
+	s.Equal(user1.DisplayName, updatedPost.Kudos[0].Sender.Name)
+	s.Equal(user1.ProfilePicture, updatedPost.Kudos[0].Sender.Icon)
 }
 
 func (s *CongratulationServiceTestSuite) TestCreateCongratulation_InsufficientBalance() {

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -431,7 +431,19 @@ type PostDocument struct {
 	Reactions map[string][]primitive.ObjectID `bson:"reactions" json:"reactions"`
 	Comments  []CommentDocument               `bson:"comments" json:"comments"`
 
+	// Kudos recorded on this post (denormalized when a congratulation is sent).
+	Kudos []PostKudos `bson:"kudos,omitempty" json:"kudos,omitempty"`
+
 	Metadata PostMetadata `bson:"metadata" json:"metadata"`
+}
+
+// PostKudos is one congratulation recorded on a post. Denormalized (mirrors
+// TaskKudos) so the card can render the congratulator cluster without a join.
+type PostKudos struct {
+	CongratulationID primitive.ObjectID `bson:"congratulationId" json:"congratulationId"`
+	Sender           KudosSender        `bson:"sender" json:"sender"`
+	Message          string             `bson:"message" json:"message"`
+	Timestamp        time.Time          `bson:"timestamp" json:"timestamp"`
 }
 
 type CommentDocument struct {
@@ -642,6 +654,7 @@ type PostDocumentAPI struct {
 
 	Reactions map[string][]string  `json:"reactions"`
 	Comments  []CommentDocumentAPI `json:"comments"`
+	Kudos     []PostKudos          `json:"kudos,omitempty"`
 
 	Metadata PostMetadata `json:"metadata"`
 }
@@ -681,6 +694,7 @@ func (p *PostDocument) ToAPI() *PostDocumentAPI {
 		TaggedUsers: p.TaggedUsers,
 		Reactions:   apiReactions,
 		Comments:    apiComments,
+		Kudos:       p.Kudos,
 		Metadata:    p.Metadata,
 	}
 }

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -10668,6 +10668,10 @@ components:
                     type: array
                     items:
                         type: string
+                kudos:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/PostKudos'
                 metadata:
                     $ref: '#/components/schemas/PostMetadata'
                 reactions:
@@ -10694,6 +10698,24 @@ components:
                 - reactions
                 - comments
                 - metadata
+        PostKudos:
+            type: object
+            additionalProperties: false
+            properties:
+                congratulationId:
+                    type: string
+                message:
+                    type: string
+                sender:
+                    $ref: '#/components/schemas/KudosSender'
+                timestamp:
+                    type: string
+                    format: date-time
+            required:
+                - congratulationId
+                - sender
+                - message
+                - timestamp
         PostMetadata:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -5645,6 +5645,7 @@ export interface components {
             dual?: string;
             groups?: string[];
             images: string[];
+            kudos?: components["schemas"]["PostKudos"][];
             metadata: components["schemas"]["PostMetadata"];
             reactions: {
                 [key: string]: string[];
@@ -5653,6 +5654,13 @@ export interface components {
             taggedUsers?: components["schemas"]["MentionReference"][];
             task?: components["schemas"]["PostTaskExtendedReference"];
             user: components["schemas"]["UserExtendedReference"];
+        };
+        PostKudos: {
+            congratulationId: string;
+            message: string;
+            sender: components["schemas"]["KudosSender"];
+            /** Format: date-time */
+            timestamp: string;
         };
         PostMetadata: {
             /** Format: date-time */

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -78,6 +78,13 @@ export interface TaskKudos {
     type: string; // "message" | "image"
 }
 
+export interface PostKudos {
+    congratulationId: string;
+    sender: KudosSender;
+    message: string;
+    timestamp: string;
+}
+
 export interface Task {
     id: string;
     priority: number;

--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -6,6 +6,7 @@ import PagerView from "react-native-pager-view";
 import NotificationsView from "@/components/notifications/NotificationsView";
 import PostCard from "@/components/cards/PostCard";
 import type { TaggedUser } from "@/components/cards/types";
+import type { PostKudos } from "@/api/types";
 import ReportedPostCard from "@/components/cards/ReportedPostCard";
 import TaskFeedCard from "@/components/cards/TaskFeedCard";
 import RingsClosedFeedCard from "@/components/cards/RingsClosedFeedCard";
@@ -67,6 +68,7 @@ type PostData = {
     };
     reactions: { [emoji: string]: string[] } | {};
     comments: any[] | null;
+    kudos?: PostKudos[];
     metadata: {
         createdAt: string;
         updatedAt: string;
@@ -533,6 +535,7 @@ export default function Feed() {
                         time={postTime}
                         reactions={postReactions}
                         comments={post.comments}
+                        kudos={post.kudos}
                         category={post.task?.category?.name}
                         taskName={post.task?.content}
                         onHide={handleHidePost}
@@ -572,6 +575,7 @@ export default function Feed() {
                     taskName={post.task?.content}
                     reactions={postReactions}
                     comments={post.comments || []}
+                    kudos={post.kudos}
                     images={post.images || []}
                     size={post.size}
                     onReactionUpdate={() => refreshSinglePost(post._id)}

--- a/frontend/app/(logged-in)/posting/[id].tsx
+++ b/frontend/app/(logged-in)/posting/[id].tsx
@@ -165,6 +165,7 @@ export default function PostDetail() {
                             : []
                     }
                     comments={post.comments || []}
+                    kudos={post.kudos}
                     images={post.images || []}
                     size={post.size}
                     onReactionUpdate={refreshPost}

--- a/frontend/components/UserInfo/CongratulationCommentRow.tsx
+++ b/frontend/components/UserInfo/CongratulationCommentRow.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { Confetti } from "phosphor-react-native";
+import { ThemedText } from "../ThemedText";
+import PreviewIcon from "../profile/PreviewIcon";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+type Props = {
+    name: string;
+    message: string;
+    icon: string;
+    time?: string;
+};
+
+// A congratulation rendered inline in a post's comment thread. Distinct from a
+// normal comment: confetti accent + primary "congratulated" label, no reply.
+const CongratulationCommentRow = ({ name, message, icon, time }: Props) => {
+    const ThemedColor = useThemeColor();
+
+    return (
+        <View style={styles.container}>
+            <View style={{ paddingTop: 8 }}>
+                <PreviewIcon size={"smallMedium"} icon={icon} />
+            </View>
+            <View style={{ gap: 2, flex: 1 }}>
+                <View style={{ flexDirection: "row", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
+                    <Confetti size={14} weight="fill" color={ThemedColor.primary} />
+                    <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
+                        {name || "Someone"} congratulated you
+                    </ThemedText>
+                    {time !== undefined && (
+                        <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                            {time}
+                        </ThemedText>
+                    )}
+                </View>
+                {message ? (
+                    <ThemedText type="default" style={[styles.message, { color: ThemedColor.text }]}>
+                        {message}
+                    </ThemedText>
+                ) : null}
+            </View>
+        </View>
+    );
+};
+
+export default CongratulationCommentRow;
+
+const styles = StyleSheet.create({
+    container: {
+        flexDirection: "row",
+        gap: 12,
+        alignItems: "flex-start",
+        width: "100%",
+    },
+    message: {
+        flexWrap: "wrap",
+        width: "100%",
+        flexShrink: 1,
+        lineHeight: 20,
+    },
+});

--- a/frontend/components/cards/KudosAvatars.tsx
+++ b/frontend/components/cards/KudosAvatars.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import CachedImage from "../CachedImage";
+import { encouragedCardColors } from "./encouragedTask";
+import type { PostKudos } from "@/api/types";
+
+// An overlapping stack of the avatars of users who congratulated a post — the
+// post-side mirror of EncouragerAvatars. The avatars carry the same soft
+// primary glow as the encouraged-task state (here scoped to the icons, not
+// the whole card). Caps at MAX to bound width.
+const SIZE = 22;
+const MAX = 3;
+
+type Props = {
+    kudos: PostKudos[];
+    ringColor: string;
+    placeholderColor: string;
+    glowColor: string;
+};
+
+const KudosAvatars = ({ kudos, ringColor, placeholderColor, glowColor }: Props) => {
+    const shown = kudos.slice(0, MAX);
+    const glow = encouragedCardColors(glowColor).glow;
+    return (
+        <View style={styles.row}>
+            {shown.map((k, i) => {
+                const style = [
+                    styles.avatar,
+                    glow,
+                    {
+                        borderColor: ringColor,
+                        marginLeft: i === 0 ? 0 : -SIZE / 2.5,
+                        zIndex: shown.length - i,
+                    },
+                ];
+                return k.sender.icon ? (
+                    <CachedImage
+                        key={k.congratulationId}
+                        source={{ uri: k.sender.icon }}
+                        style={style}
+                        variant="thumbnail"
+                        cachePolicy="memory-disk"
+                    />
+                ) : (
+                    <View key={k.congratulationId} style={[style, { backgroundColor: placeholderColor }]} />
+                );
+            })}
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+    },
+    avatar: {
+        width: SIZE,
+        height: SIZE,
+        borderRadius: SIZE / 2,
+        borderWidth: 1.5,
+    },
+});
+
+export default KudosAvatars;

--- a/frontend/components/cards/PostCard.tsx
+++ b/frontend/components/cards/PostCard.tsx
@@ -31,6 +31,8 @@ import PostCardFooter from "./PostCardFooter";
 import { getUsersByIds, type UserExtendedReference } from "@/api/profile";
 import { buildReactionGroups, type ReactionGroup } from "@/utils/reactions";
 import ReactionsBottomSheetModal from "@/components/modals/ReactionsBottomSheetModal";
+import CongratulatorsBottomSheetModal from "@/components/modals/CongratulatorsBottomSheetModal";
+import type { PostKudos } from "@/api/types";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useRouter } from "expo-router";
@@ -60,6 +62,7 @@ type Props = {
     dual?: string;
     id?: string;
     comments?: CommentProps[];
+    kudos?: PostKudos[];
     category?: string;
     taskName?: string;
     size?: ImageSize;
@@ -84,6 +87,7 @@ const PostCard = React.memo(({
     images,
     dual,
     comments,
+    kudos = [],
     category,
     taskName,
     id,
@@ -101,6 +105,7 @@ const PostCard = React.memo(({
     const [imageHeight, setImageHeight] = useState<number>(512);
     const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
     const [reactionsSheetVisible, setReactionsSheetVisible] = useState(false);
+    const [congratulatorsSheetVisible, setCongratulatorsSheetVisible] = useState(false);
     const [reactionGroups, setReactionGroups] = useState<ReactionGroup[]>([]);
     const [reactionsLoading, setReactionsLoading] = useState(false);
     const [reactionsError, setReactionsError] = useState<string | null>(null);
@@ -647,12 +652,14 @@ const PostCard = React.memo(({
                         category={category}
                         taskName={taskName}
                         reactions={localReactions}
+                        kudos={kudos}
                         userId={userId}
                         currentUserId={user?._id}
                         onReaction={handleReaction}
                         hasUserReacted={hasUserReacted}
                         onCongratulatePress={handleCongratulatePress}
                         onOpenComments={handleOpenComments}
+                        onKudosPress={() => setCongratulatorsSheetVisible(true)}
                         commentCount={currentComments.length}
                         onLongPressReaction={handleLongPressReaction}
                     />
@@ -713,6 +720,7 @@ const PostCard = React.memo(({
                     }}>
                     <Comment
                         comments={currentComments}
+                        kudos={kudos}
                         postId={id}
                         ref={bottomSheetModalRef}
                         onClose={handleClose}
@@ -750,6 +758,13 @@ const PostCard = React.memo(({
                     loading={reactionsLoading}
                     error={reactionsError}
                     onRetry={() => loadReactionViewers(localReactions)}
+                />
+
+                {/* Congratulators bottom sheet */}
+                <CongratulatorsBottomSheetModal
+                    visible={congratulatorsSheetVisible}
+                    setVisible={setCongratulatorsSheetVisible}
+                    kudos={kudos}
                 />
         </View>
     );

--- a/frontend/components/cards/PostCardFooter.tsx
+++ b/frontend/components/cards/PostCardFooter.tsx
@@ -6,8 +6,10 @@ import { HORIZONTAL_PADDING } from "@/constants/spacing";
 import { Confetti } from "phosphor-react-native";
 import ReactPills from "../inputs/ReactPills";
 import ReactionAction from "../inputs/ReactionAction";
+import KudosAvatars from "./KudosAvatars";
 import type { SlackReaction } from "./PostCard";
 import type { TaggedUser } from "./types";
+import type { PostKudos } from "@/api/types";
 import PostCardCaption from "./PostCardCaption";
 
 export type PostCardFooterProps = {
@@ -16,6 +18,7 @@ export type PostCardFooterProps = {
     category?: string;
     taskName?: string;
     reactions?: SlackReaction[];
+    kudos?: PostKudos[];
     /** Read-only mode: disables all interactions (used in preview) */
     readOnly?: boolean;
     // Interactive-mode props (ignored when readOnly)
@@ -25,6 +28,7 @@ export type PostCardFooterProps = {
     hasUserReacted?: (emoji: string) => boolean;
     onCongratulatePress?: () => void;
     onOpenComments?: () => void;
+    onKudosPress?: () => void;
     commentCount?: number;
     onLongPressReaction?: (reaction: SlackReaction) => void;
 };
@@ -35,6 +39,7 @@ const PostCardFooter = ({
     category,
     taskName,
     reactions = [],
+    kudos = [],
     readOnly = false,
     userId,
     currentUserId,
@@ -42,6 +47,7 @@ const PostCardFooter = ({
     hasUserReacted,
     onCongratulatePress,
     onOpenComments,
+    onKudosPress,
     commentCount = 0,
     onLongPressReaction,
 }: PostCardFooterProps) => {
@@ -95,6 +101,16 @@ const PostCardFooter = ({
 
                 {!readOnly && (
                     <View style={styles.reactionsRow}>
+                        {kudos.length > 0 && (
+                            <TouchableOpacity onPress={onKudosPress} activeOpacity={0.7} style={styles.kudosCluster}>
+                                <KudosAvatars
+                                    kudos={kudos}
+                                    ringColor={ThemedColor.background}
+                                    placeholderColor={ThemedColor.primary}
+                                    glowColor={ThemedColor.primary}
+                                />
+                            </TouchableOpacity>
+                        )}
                         {reactions.map((react, index) => (
                             <ReactPills
                                 key={`${react.emoji}-${index}`}
@@ -176,6 +192,11 @@ const styles = StyleSheet.create({
         flexDirection: "row",
         gap: 8,
         flexWrap: "wrap",
+        alignItems: "center",
+    },
+    kudosCluster: {
+        justifyContent: "center",
+        marginRight: 2,
     },
     commentButton: {
         paddingTop: 4,

--- a/frontend/components/inputs/Comment.tsx
+++ b/frontend/components/inputs/Comment.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from "react";
 import { View, StyleSheet, TouchableOpacity, Platform, Keyboard, Dimensions } from "react-native";
 import UserInfoRowComment from "../UserInfo/UserInfoRowComment";
+import CongratulationCommentRow from "../UserInfo/CongratulationCommentRow";
+import type { PostKudos } from "@/api/types";
 import { ThemedText } from "../ThemedText";
 import SendButton from "./SendButton";
 import CommentInput from "./CommentInput";
@@ -29,10 +31,13 @@ export type CommentProps = {
         isDeleted: boolean;
         lastEdited: string;
     };
+    // Set on synthetic rows derived from post kudos; rendered as a congratulation.
+    isKudos?: boolean;
 };
 
 export type PopupProp = {
     comments: CommentProps[];
+    kudos?: PostKudos[];
     postId?: string;
     ref: React.RefObject<BottomSheetModal>;
     onClose: () => void;
@@ -44,6 +49,7 @@ export type PopupProp = {
 
 const Comment = ({
     comments,
+    kudos,
     postId,
     onCommentAdded,
     onCommentDeleted,
@@ -151,6 +157,32 @@ const Comment = ({
     const sortedComments = useMemo(() => {
         return sortCommentsHierarchically(localComments.filter((comment) => !deletingComments.has(comment.id)));
     }, [localComments, deletingComments]);
+
+    // Kudos rendered as synthetic root "comments" so they interleave with real
+    // comments by timestamp. They never have a parentId, so they sort as roots.
+    const kudosItems = useMemo<CommentProps[]>(
+        () =>
+            (kudos ?? []).map((k) => ({
+                id: k.congratulationId,
+                isKudos: true,
+                user: {
+                    _id: k.sender.id,
+                    display_name: k.sender.name,
+                    handle: k.sender.handle ?? "",
+                    profile_picture: k.sender.icon,
+                },
+                content: k.message,
+                metadata: { createdAt: k.timestamp, isDeleted: false, lastEdited: k.timestamp },
+            })),
+        [kudos]
+    );
+
+    // Merged list (comments + kudos) that the thread renders. The visible
+    // "Comments (N)" count below stays comments-only on purpose.
+    const feedItems = useMemo(() => {
+        const comments = localComments.filter((comment) => !deletingComments.has(comment.id));
+        return sortCommentsHierarchically([...comments, ...kudosItems]);
+    }, [localComments, deletingComments, kudosItems]);
 
     // gets the time to show in how long ago a comment was made - memoized
     const getTimeAgo = useCallback((createdAt: string): string => {
@@ -344,6 +376,25 @@ const Comment = ({
     // Render comment item - memoized
     const renderCommentItem = useCallback(
         ({ item: comment }: { item: CommentProps }) => {
+            if (comment.isKudos) {
+                return (
+                    <TouchableOpacity
+                        style={styles.commentItem}
+                        onPress={() => {
+                            onClose();
+                            if (comment.user._id) router.push(`/account/${comment.user._id}`);
+                        }}
+                        activeOpacity={0.7}>
+                        <CongratulationCommentRow
+                            name={comment.user.display_name}
+                            message={comment.content}
+                            icon={comment.user.profile_picture}
+                            time={getTimeAgo(comment.metadata.createdAt)}
+                        />
+                    </TouchableOpacity>
+                );
+            }
+
             const canDelete = canDeleteComment(comment.user._id);
             const isDeleting = deletingComments.has(comment.id);
 
@@ -396,7 +447,7 @@ const Comment = ({
                 <ThemedText style={styles.commentsTitle}>Comments ({sortedComments?.length || 0})</ThemedText>
             </View>
             <BottomSheetFlatList
-                data={sortedComments}
+                data={feedItems}
                 renderItem={renderCommentItem}
                 keyExtractor={(item) => item.id}
                 ListEmptyComponent={ListEmptyComponent}

--- a/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
+++ b/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
+import { router, type Href } from "expo-router";
+import { ThemedText } from "@/components/ThemedText";
+import DefaultModal from "./DefaultModal";
+import CachedImage from "@/components/CachedImage";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import type { PostKudos } from "@/api/types";
+
+interface Props {
+    visible: boolean;
+    setVisible: (visible: boolean) => void;
+    kudos: PostKudos[];
+}
+
+// The "who congratulated" list for a post. Mirrors ReactionsBottomSheetModal
+// but reads from the post's denormalized kudos array (no fetch) and shows each
+// congratulator's message rather than a handle.
+export default function CongratulatorsBottomSheetModal({ visible, setVisible, kudos }: Props) {
+    const ThemedColor = useThemeColor();
+    const styles = createStyles(ThemedColor);
+
+    return (
+        <DefaultModal visible={visible} setVisible={setVisible}>
+            <View style={styles.container}>
+                <ThemedText type="subtitle" style={styles.title}>Congratulations</ThemedText>
+
+                <BottomSheetFlatList
+                    data={kudos}
+                    keyExtractor={(k) => k.congratulationId}
+                    renderItem={({ item }) => (
+                        <TouchableOpacity
+                            style={styles.row}
+                            onPress={() => {
+                                setVisible(false);
+                                if (item.sender.id) router.push(`/account/${item.sender.id}` as Href);
+                            }}>
+                            {item.sender.icon ? (
+                                <CachedImage
+                                    source={{ uri: item.sender.icon }}
+                                    variant="thumbnail"
+                                    cachePolicy="memory-disk"
+                                    style={styles.avatar}
+                                />
+                            ) : (
+                                <View style={[styles.avatar, { backgroundColor: ThemedColor.tertiary }]} />
+                            )}
+                            <View style={{ flex: 1 }}>
+                                <ThemedText type="defaultSemiBold" numberOfLines={1}>
+                                    {item.sender.name}
+                                </ThemedText>
+                                {item.message ? (
+                                    <ThemedText type="caption" style={{ color: ThemedColor.caption }} numberOfLines={2}>
+                                        {item.message}
+                                    </ThemedText>
+                                ) : null}
+                            </View>
+                        </TouchableOpacity>
+                    )}
+                />
+            </View>
+        </DefaultModal>
+    );
+}
+
+const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
+    StyleSheet.create({
+        container: { paddingHorizontal: 20, paddingBottom: 16, gap: 12, minHeight: 200 },
+        title: { marginBottom: 4 },
+        row: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 10 },
+        avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: ThemedColor.tertiary },
+    });


### PR DESCRIPTION
## What

Posts now feature **kudos** the way tasks feature encouragements. When a post is congratulated, the congratulation is recorded on the post and surfaced on the card.

## Backend

- `PostKudos` struct + `Kudos` field on `PostDocument` and `PostDocumentAPI` (denormalized, mirrors `TaskKudos`).
- `congratulation.Service.CreateCongratulation` now `$push`es a `PostKudos` (sender + message) onto the post when a `postId` is present. Best-effort: a missing post / failed update is logged, not fatal — and the existing self-congratulation gating is unchanged.
- Service test extended (`TestCreateCongratulation_WithPostID`) to assert the kudos lands on the post.

## Frontend

1. **Congratulator cluster** (`KudosAvatars`) — overlapping avatars rendered in the post card's reactions row, **left of the reaction pills**, carrying the same soft primary glow as the encouraged-task state (scoped to the icons; the card itself stays normal).
2. **Tap → congratulator list** — opens `CongratulatorsBottomSheetModal` listing who congratulated and their messages (reads the post's denormalized kudos, no fetch).
3. **Kudos as a comment** — each kudos renders inline in the comments thread as a special `CongratulationCommentRow` (confetti accent + message), interleaved with real comments by timestamp. The visible "View N comments" count stays **comments-only**.

`kudos` is threaded from the feed and single-post views through `PostCard` → `PostCardFooter` / comments sheet.

## Generated API

`api-spec.yaml` + `types.ts` regenerated, **scoped** to just the `PostKudos` schema + `kudos` property (reverted the unrelated pre-existing spec drift on main so this PR stays focused).

## Testing

- `go build ./...`, `go vet` (congratulation/types), `go test ./internal/handlers/congratulation/...` — all pass.
- Frontend `tsc` — clean for all changed files (the only errors are the pre-existing broken `DatePager.tsx` on main).

## Notes / follow-ups

- Existing posts predating this have no `kudos` (treated as empty via `omitempty`).
- Backend kudos `sender.handle` is empty (the congratulation sender struct has no handle); the cluster uses the icon and the list shows name + message, so this isn't needed today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)