### PR TITLE
fix(posts): render kudos avatar glow, bump size, fix congratulation copy

### DIFF
--- a/frontend/components/UserInfo/CongratulationCommentRow.tsx
+++ b/frontend/components/UserInfo/CongratulationCommentRow.tsx
@@ -26,7 +26,7 @@ const CongratulationCommentRow = ({ name, message, icon, time }: Props) => {
                 <View style={{ flexDirection: "row", gap: 6, alignItems: "center", flexWrap: "wrap" }}>
                     <Confetti size={14} weight="fill" color={ThemedColor.primary} />
                     <ThemedText type="caption" style={{ color: ThemedColor.primary }}>
-                        {name || "Someone"} congratulated you
+                        {name || "Someone"} sent a congratulations
                     </ThemedText>
                     {time !== undefined && (
                         <ThemedText type="caption" style={{ color: ThemedColor.caption }}>

--- a/frontend/components/cards/KudosAvatars.tsx
+++ b/frontend/components/cards/KudosAvatars.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import CachedImage from "../CachedImage";
-import { encouragedCardColors } from "./encouragedTask";
 import type { PostKudos } from "@/api/types";
 
 // An overlapping stack of the avatars of users who congratulated a post — the
-// post-side mirror of EncouragerAvatars. The avatars carry the same soft
-// primary glow as the encouraged-task state (here scoped to the icons, not
-// the whole card). Caps at MAX to bound width.
+// post-side mirror of EncouragerAvatars. Each avatar carries a soft primary
+// glow (the encouraged-task accent, scoped to the icons). The glow lives on a
+// wrapping View, not the image: expo-image doesn't reliably render shadow
+// props, and iOS needs an opaque surface to cast from.
 const SIZE = 22;
 const MAX = 3;
 
@@ -20,31 +20,32 @@ type Props = {
 
 const KudosAvatars = ({ kudos, ringColor, placeholderColor, glowColor }: Props) => {
     const shown = kudos.slice(0, MAX);
-    const glow = encouragedCardColors(glowColor).glow;
     return (
         <View style={styles.row}>
-            {shown.map((k, i) => {
-                const style = [
-                    styles.avatar,
-                    glow,
-                    {
-                        borderColor: ringColor,
-                        marginLeft: i === 0 ? 0 : -SIZE / 2.5,
-                        zIndex: shown.length - i,
-                    },
-                ];
-                return k.sender.icon ? (
-                    <CachedImage
-                        key={k.congratulationId}
-                        source={{ uri: k.sender.icon }}
-                        style={style}
-                        variant="thumbnail"
-                        cachePolicy="memory-disk"
-                    />
-                ) : (
-                    <View key={k.congratulationId} style={[style, { backgroundColor: placeholderColor }]} />
-                );
-            })}
+            {shown.map((k, i) => (
+                <View
+                    key={k.congratulationId}
+                    style={[
+                        styles.glowWrap,
+                        {
+                            backgroundColor: ringColor,
+                            shadowColor: glowColor,
+                            marginLeft: i === 0 ? 0 : -SIZE / 2.5,
+                            zIndex: shown.length - i,
+                        },
+                    ]}>
+                    {k.sender.icon ? (
+                        <CachedImage
+                            source={{ uri: k.sender.icon }}
+                            style={[styles.avatar, { borderColor: ringColor }]}
+                            variant="thumbnail"
+                            cachePolicy="memory-disk"
+                        />
+                    ) : (
+                        <View style={[styles.avatar, { borderColor: ringColor, backgroundColor: placeholderColor }]} />
+                    )}
+                </View>
+            ))}
         </View>
     );
 };
@@ -53,6 +54,16 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
+    },
+    // Carries the glow; sized to the avatar so the shadow halos the circle.
+    glowWrap: {
+        width: SIZE,
+        height: SIZE,
+        borderRadius: SIZE / 2,
+        shadowOpacity: 0.6,
+        shadowRadius: 5,
+        shadowOffset: { width: 0, height: 0 },
+        elevation: 6,
     },
     avatar: {
         width: SIZE,

--- a/frontend/components/cards/KudosAvatars.tsx
+++ b/frontend/components/cards/KudosAvatars.tsx
@@ -8,7 +8,7 @@ import type { PostKudos } from "@/api/types";
 // glow (the encouraged-task accent, scoped to the icons). The glow lives on a
 // wrapping View, not the image: expo-image doesn't reliably render shadow
 // props, and iOS needs an opaque surface to cast from.
-const SIZE = 22;
+const SIZE = 28;
 const MAX = 3;
 
 type Props = {


### PR DESCRIPTION
Follow-up polish to the post-kudos feature (#424).

## Fixes

1. **Glow now renders.** The avatar glow was applied directly to `CachedImage` (expo-image), which doesn't render RN `shadow*` props. Moved the glow onto a wrapping `View` with an opaque surface (so iOS casts it) and tuned it for an icon-sized halo (`shadowOpacity 0.6`, `shadowRadius 5`, centered offset, `elevation 6`).
2. **Copy.** The in-thread congratulation now reads **"X sent a congratulations"** instead of "X congratulated you".
3. **Size.** Bumped the kudos avatars from 22 → 28px.

## Testing

- Frontend `tsc` clean for both changed files (only the pre-existing `DatePager.tsx` errors remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)