### PR TITLE
feat(kudos): emoji reactions on encouragements & congratulations

### DIFF
--- a/backend/internal/handlers/congratulation/congratulation.go
+++ b/backend/internal/handlers/congratulation/congratulation.go
@@ -14,6 +14,52 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+func (h *Handler) ReactToCongratulationHuma(ctx context.Context, input *ReactToCongratulationInput) (*ReactToCongratulationOutput, error) {
+	userID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+
+	reactorID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID", err)
+	}
+
+	id, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid ID format", err)
+	}
+
+	doc, notifySender, err := h.service.ReactToCongratulation(id, reactorID, input.Body.Emoji)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, huma.Error404NotFound("Congratulation not found", err)
+		}
+		if strings.Contains(err.Error(), "unauthorized") {
+			return nil, huma.Error403Forbidden("Only the receiver can react to this congratulation", err)
+		}
+		if strings.Contains(err.Error(), "invalid emoji") {
+			return nil, huma.Error400BadRequest(err.Error(), err)
+		}
+		slog.Error("failed to react to congratulation", "id", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to react to congratulation. Please try again.", err)
+	}
+
+	if notifySender {
+		senderID, err := primitive.ObjectIDFromHex(doc.Sender.ID)
+		if err == nil {
+			reactorInfo, err := h.service.GetSenderInfo(reactorID)
+			if err == nil {
+				if err := h.service.sendKudosReactionNotification(senderID, reactorInfo.Name, input.Body.Emoji); err != nil {
+					slog.Error("failed to send kudos reaction notification", "id", input.ID, "error", err)
+				}
+			}
+		}
+	}
+
+	return &ReactToCongratulationOutput{Body: *doc}, nil
+}
+
 type Handler struct {
 	service *Service
 }

--- a/backend/internal/handlers/congratulation/operations.go
+++ b/backend/internal/handlers/congratulation/operations.go
@@ -85,6 +85,17 @@ func RegisterSendBeakCongratulationOperation(api huma.API, handler *Handler) {
 	}, handler.SendBeakCongratulationHuma)
 }
 
+func RegisterReactToCongratulationOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "react-to-congratulation",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/congratulations/{id}/react",
+		Summary:     "React to a congratulation",
+		Description: "Add or toggle an emoji reaction on a received congratulation",
+		Tags:        []string{"congratulations"},
+	}, handler.ReactToCongratulationHuma)
+}
+
 // Register all congratulation operations
 func RegisterCongratulationOperations(api huma.API, handler *Handler) {
 	RegisterSendBeakCongratulationOperation(api, handler)
@@ -94,4 +105,5 @@ func RegisterCongratulationOperations(api huma.API, handler *Handler) {
 	RegisterGetCongratulationOperation(api, handler)
 	RegisterUpdateCongratulationOperation(api, handler)
 	RegisterDeleteCongratulationOperation(api, handler)
+	RegisterReactToCongratulationOperation(api, handler)
 }

--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -405,6 +405,79 @@ func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, 
 	return xutils.SendNotification(notification)
 }
 
+var validReactionEmojis = map[string]bool{"❤️": true, "🙌": true, "🔥": true, "😭": true}
+
+// ReactToCongratulation toggles an emoji reaction on a congratulation from its receiver.
+// Returns the updated document, whether the sender should be notified, and any error.
+func (s *Service) ReactToCongratulation(id, reactorID primitive.ObjectID, emoji string) (*CongratulationDocument, bool, error) {
+	if s.Congratulations == nil {
+		return nil, false, fmt.Errorf("congratulations collection not available")
+	}
+	if !validReactionEmojis[emoji] {
+		return nil, false, fmt.Errorf("invalid emoji: must be one of ❤️ 🙌 🔥 😭")
+	}
+
+	ctx := context.Background()
+
+	var internal CongratulationDocumentInternal
+	if err := s.Congratulations.FindOne(ctx, bson.M{"_id": id}).Decode(&internal); err != nil {
+		return nil, false, err
+	}
+
+	if internal.Receiver != reactorID {
+		return nil, false, fmt.Errorf("unauthorized: only the receiver can react")
+	}
+
+	var update bson.M
+	notifySender := false
+
+	if internal.Reaction == emoji {
+		update = bson.M{"$unset": bson.M{"reaction": "", "reactedAt": ""}}
+	} else {
+		now := time.Now()
+		update = bson.M{"$set": bson.M{"reaction": emoji, "reactedAt": now}}
+		notifySender = true
+	}
+
+	if _, err := s.Congratulations.UpdateOne(ctx, bson.M{"_id": id}, update); err != nil {
+		return nil, false, err
+	}
+
+	if err := s.Congratulations.FindOne(ctx, bson.M{"_id": id}).Decode(&internal); err != nil {
+		return nil, false, err
+	}
+
+	return internal.ToAPI(), notifySender, nil
+}
+
+// sendKudosReactionNotification notifies the original kudos sender that their kudos received a reaction.
+func (s *Service) sendKudosReactionNotification(senderID primitive.ObjectID, reactorName, emoji string) error {
+	if s.Users == nil {
+		return fmt.Errorf("users collection not available")
+	}
+
+	ctx := context.Background()
+
+	var sender types.User
+	if err := s.Users.FindOne(ctx, bson.M{"_id": senderID}).Decode(&sender); err != nil {
+		return fmt.Errorf("failed to get sender: %w", err)
+	}
+
+	if sender.PushToken == "" {
+		return nil
+	}
+
+	return xutils.SendNotification(xutils.Notification{
+		Token:   sender.PushToken,
+		Title:   "Your kudos landed " + emoji,
+		Message: reactorName + " reacted " + emoji,
+		Data: map[string]string{
+			"type": "kudos_reaction",
+			"url":  "/kudos",
+		},
+	})
+}
+
 // SendBeakCongratulation sends a congratulation from the beak system account
 // with a push notification. Used during onboarding tutorial.
 func (s *Service) SendBeakCongratulation(receiverID primitive.ObjectID, message, categoryName, taskName string) error {

--- a/backend/internal/handlers/congratulation/types.go
+++ b/backend/internal/handlers/congratulation/types.go
@@ -157,6 +157,8 @@ type CongratulationDocument struct {
 	TaskName     string               `bson:"taskName" json:"taskName" example:"Complete project proposal" doc:"Task name"`
 	Read         bool                 `bson:"read" json:"read" example:"false" doc:"Whether the congratulation has been read"`
 	Type         string               `bson:"type" json:"type" example:"message" doc:"Type of congratulation (message or image)"`
+	Reaction     string               `bson:"reaction,omitempty" json:"reaction,omitempty" example:"❤️" doc:"Emoji reaction from the receiver"`
+	ReactedAt    *time.Time           `bson:"reactedAt,omitempty" json:"reactedAt,omitempty" doc:"Timestamp when the receiver reacted"`
 }
 
 // Internal struct for MongoDB operations (keeps primitive.ObjectID)
@@ -172,6 +174,8 @@ type CongratulationDocumentInternal struct {
 	Type         string                       `bson:"type"`
 	PostID       *primitive.ObjectID          `bson:"postId,omitempty"`
 	Private      bool                         `bson:"private,omitempty"`
+	Reaction     string                       `bson:"reaction,omitempty"`
+	ReactedAt    *time.Time                   `bson:"reactedAt,omitempty"`
 }
 
 type UpdateCongratulationDocument struct {
@@ -194,7 +198,25 @@ func (c *CongratulationDocumentInternal) ToAPI() *CongratulationDocument {
 		TaskName:     c.TaskName,
 		Read:         c.Read,
 		Type:         c.Type,
+		Reaction:     c.Reaction,
+		ReactedAt:    c.ReactedAt,
 	}
+}
+
+// React input/output types
+type ReactToCongratulationInput struct {
+	Authorization string `header:"Authorization" required:"true" doc:"Bearer token for authentication"`
+	RefreshToken  string `header:"refresh_token" required:"true" doc:"Refresh token for authentication"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          ReactToKudosBody
+}
+
+type ReactToCongratulationOutput struct {
+	Body CongratulationDocument `json:"body"`
+}
+
+type ReactToKudosBody struct {
+	Emoji string `json:"emoji" validate:"required" doc:"Emoji reaction (one of ❤️ 🙌 🔥 😭)"`
 }
 
 /*

--- a/backend/internal/handlers/encouragement/encouragement.go
+++ b/backend/internal/handlers/encouragement/encouragement.go
@@ -14,6 +14,52 @@ import (
 	"go.mongodb.org/mongo-driver/mongo"
 )
 
+func (h *Handler) ReactToEncouragementHuma(ctx context.Context, input *ReactToEncouragementInput) (*ReactToEncouragementOutput, error) {
+	userID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Authentication required", err)
+	}
+
+	reactorID, err := primitive.ObjectIDFromHex(userID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID", err)
+	}
+
+	id, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid ID format", err)
+	}
+
+	doc, notifySender, err := h.service.ReactToEncouragement(id, reactorID, input.Body.Emoji)
+	if err != nil {
+		if err == mongo.ErrNoDocuments {
+			return nil, huma.Error404NotFound("Encouragement not found", err)
+		}
+		if strings.Contains(err.Error(), "unauthorized") {
+			return nil, huma.Error403Forbidden("Only the receiver can react to this encouragement", err)
+		}
+		if strings.Contains(err.Error(), "invalid emoji") {
+			return nil, huma.Error400BadRequest(err.Error(), err)
+		}
+		slog.Error("failed to react to encouragement", "id", input.ID, "error", err)
+		return nil, huma.Error500InternalServerError("Unable to react to encouragement. Please try again.", err)
+	}
+
+	if notifySender {
+		senderID, err := primitive.ObjectIDFromHex(doc.Sender.ID)
+		if err == nil {
+			reactorInfo, err := h.service.GetSenderInfo(reactorID)
+			if err == nil {
+				if err := h.service.sendKudosReactionNotification(senderID, reactorInfo.Name, input.Body.Emoji); err != nil {
+					slog.Error("failed to send kudos reaction notification", "id", input.ID, "error", err)
+				}
+			}
+		}
+	}
+
+	return &ReactToEncouragementOutput{Body: *doc}, nil
+}
+
 type Handler struct {
 	service *Service
 }

--- a/backend/internal/handlers/encouragement/operations.go
+++ b/backend/internal/handlers/encouragement/operations.go
@@ -74,6 +74,17 @@ func RegisterMarkEncouragementsReadOperation(api huma.API, handler *Handler) {
 	}, handler.MarkEncouragementsReadHuma)
 }
 
+func RegisterReactToEncouragementOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "react-to-encouragement",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/encouragements/{id}/react",
+		Summary:     "React to an encouragement",
+		Description: "Add or toggle an emoji reaction on a received encouragement",
+		Tags:        []string{"encouragements"},
+	}, handler.ReactToEncouragementHuma)
+}
+
 // Register all encouragement operations
 func RegisterEncouragementOperations(api huma.API, handler *Handler) {
 	RegisterMarkEncouragementsReadOperation(api, handler)
@@ -82,4 +93,5 @@ func RegisterEncouragementOperations(api huma.API, handler *Handler) {
 	RegisterGetEncouragementOperation(api, handler)
 	RegisterUpdateEncouragementOperation(api, handler)
 	RegisterDeleteEncouragementOperation(api, handler)
+	RegisterReactToEncouragementOperation(api, handler)
 }

--- a/backend/internal/handlers/encouragement/service.go
+++ b/backend/internal/handlers/encouragement/service.go
@@ -481,6 +481,79 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 	return xutils.SendNotification(notification)
 }
 
+var validReactionEmojis = map[string]bool{"❤️": true, "🙌": true, "🔥": true, "😭": true}
+
+// ReactToEncouragement toggles an emoji reaction on an encouragement from its receiver.
+// Returns the updated document, whether the sender should be notified, and any error.
+func (s *Service) ReactToEncouragement(id, reactorID primitive.ObjectID, emoji string) (*EncouragementDocument, bool, error) {
+	if s.Encouragements == nil {
+		return nil, false, fmt.Errorf("encouragements collection not available")
+	}
+	if !validReactionEmojis[emoji] {
+		return nil, false, fmt.Errorf("invalid emoji: must be one of ❤️ 🙌 🔥 😭")
+	}
+
+	ctx := context.Background()
+
+	var internal EncouragementDocumentInternal
+	if err := s.Encouragements.FindOne(ctx, bson.M{"_id": id}).Decode(&internal); err != nil {
+		return nil, false, err
+	}
+
+	if internal.Receiver != reactorID {
+		return nil, false, fmt.Errorf("unauthorized: only the receiver can react")
+	}
+
+	var update bson.M
+	notifySender := false
+
+	if internal.Reaction == emoji {
+		update = bson.M{"$unset": bson.M{"reaction": "", "reactedAt": ""}}
+	} else {
+		now := time.Now()
+		update = bson.M{"$set": bson.M{"reaction": emoji, "reactedAt": now}}
+		notifySender = true
+	}
+
+	if _, err := s.Encouragements.UpdateOne(ctx, bson.M{"_id": id}, update); err != nil {
+		return nil, false, err
+	}
+
+	if err := s.Encouragements.FindOne(ctx, bson.M{"_id": id}).Decode(&internal); err != nil {
+		return nil, false, err
+	}
+
+	return internal.ToAPI(), notifySender, nil
+}
+
+// sendKudosReactionNotification notifies the original kudos sender that their kudos received a reaction.
+func (s *Service) sendKudosReactionNotification(senderID primitive.ObjectID, reactorName, emoji string) error {
+	if s.Users == nil {
+		return fmt.Errorf("users collection not available")
+	}
+
+	ctx := context.Background()
+
+	var sender types.User
+	if err := s.Users.FindOne(ctx, bson.M{"_id": senderID}).Decode(&sender); err != nil {
+		return fmt.Errorf("failed to get sender: %w", err)
+	}
+
+	if sender.PushToken == "" {
+		return nil
+	}
+
+	return xutils.SendNotification(xutils.Notification{
+		Token:   sender.PushToken,
+		Title:   "Your kudos landed " + emoji,
+		Message: reactorName + " reacted " + emoji,
+		Data: map[string]string{
+			"type": "kudos_reaction",
+			"url":  "/kudos",
+		},
+	})
+}
+
 // NotifyEncouragersOfCompletion sends push notifications to all users who encouraged a specific task
 func (s *Service) NotifyEncouragersOfCompletion(taskID, taskOwnerID primitive.ObjectID, taskName string) error {
 	// Get all encouragements for this task

--- a/backend/internal/handlers/encouragement/types.go
+++ b/backend/internal/handlers/encouragement/types.go
@@ -137,6 +137,8 @@ type EncouragementDocument struct {
 	TaskID       string              `bson:"taskId,omitempty" json:"taskId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Task ID being encouraged"`
 	Read         bool                `bson:"read" json:"read" example:"false" doc:"Whether the encouragement has been read"`
 	Type         string              `bson:"type" json:"type" example:"message" doc:"Type of encouragement (message or image)"`
+	Reaction     string              `bson:"reaction,omitempty" json:"reaction,omitempty" example:"❤️" doc:"Emoji reaction from the receiver"`
+	ReactedAt    *time.Time          `bson:"reactedAt,omitempty" json:"reactedAt,omitempty" doc:"Timestamp when the receiver reacted"`
 }
 
 // Internal struct for MongoDB operations (keeps primitive.ObjectID)
@@ -152,6 +154,8 @@ type EncouragementDocumentInternal struct {
 	TaskID       primitive.ObjectID          `bson:"taskId,omitempty"`
 	Read         bool                        `bson:"read"`
 	Type         string                      `bson:"type"`
+	Reaction     string                      `bson:"reaction,omitempty"`
+	ReactedAt    *time.Time                  `bson:"reactedAt,omitempty"`
 }
 
 type UpdateEncouragementDocument struct {
@@ -173,6 +177,8 @@ func (e *EncouragementDocumentInternal) ToAPI() *EncouragementDocument {
 		Scope:     e.Scope,
 		Read:      e.Read,
 		Type:      e.Type,
+		Reaction:  e.Reaction,
+		ReactedAt: e.ReactedAt,
 	}
 
 	// Include task fields for task-scoped encouragements
@@ -186,6 +192,22 @@ func (e *EncouragementDocumentInternal) ToAPI() *EncouragementDocument {
 	}
 
 	return doc
+}
+
+// React input/output types
+type ReactToEncouragementInput struct {
+	Authorization string `header:"Authorization" required:"true" doc:"Bearer token for authentication"`
+	RefreshToken  string `header:"refresh_token" required:"true" doc:"Refresh token for authentication"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          ReactToKudosBody
+}
+
+type ReactToEncouragementOutput struct {
+	Body EncouragementDocument `json:"body"`
+}
+
+type ReactToKudosBody struct {
+	Emoji string `json:"emoji" validate:"required" doc:"Emoji reaction (one of ❤️ 🙌 🔥 😭)"`
 }
 
 /*

--- a/backend/internal/handlers/notifications/types.go
+++ b/backend/internal/handlers/notifications/types.go
@@ -30,6 +30,7 @@ const (
 	NotificationTypePost                  NotificationType = "POST"
 	NotificationTypeRingsClosed           NotificationType = "RINGS_CLOSED"
 	NotificationTypePostTag               NotificationType = "POST_TAG"
+	NotificationTypeKudosReaction         NotificationType = "KUDOS_REACTION"
 )
 
 // NotificationDocument represents a notification stored in the database

--- a/frontend/api/congratulation.ts
+++ b/frontend/api/congratulation.ts
@@ -2,6 +2,8 @@ import client from "@/api/client";
 import type { paths, components } from "./generated/types";
 import { withAuthHeaders } from "./utils";
 import type { RingDelta } from "./types";
+import * as SecureStore from "expo-secure-store";
+import axios from "axios";
 
 // Extract the type definitions from the generated types
 type CongratulationDocument = components["schemas"]["CongratulationDocument"];
@@ -102,6 +104,32 @@ export const updateCongratulationAPI = async (id: string, message: string): Prom
     }
 
     return data;
+};
+
+/**
+ * React to (or toggle off) a congratulation with an emoji.
+ * Only the receiver can react. Sending the current emoji removes it.
+ */
+export const reactToCongratulationAPI = async (id: string, emoji: string): Promise<CongratulationDocument> => {
+    let headers: Record<string, string> = { "Content-Type": "application/json" };
+    try {
+        const authData = await SecureStore.getItemAsync("auth_data");
+        if (authData) {
+            const parsed = JSON.parse(authData);
+            if (parsed.access_token) headers["Authorization"] = `Bearer ${parsed.access_token}`;
+            if (parsed.refresh_token) headers["refresh_token"] = parsed.refresh_token;
+        }
+    } catch (error) {
+        console.error("Error getting auth data for react request", error);
+    }
+
+    const response = await axios({
+        url: process.env.EXPO_PUBLIC_URL + `/api/v1/user/congratulations/${id}/react`,
+        method: "POST",
+        headers,
+        data: { emoji },
+    });
+    return response.data;
 };
 
 /**

--- a/frontend/api/encouragement.ts
+++ b/frontend/api/encouragement.ts
@@ -6,6 +6,9 @@ import * as SecureStore from "expo-secure-store";
 import axios from "axios";
 import { createLogger } from "@/utils/logger";
 
+export const REACTION_EMOJIS = ["❤️", "🙌", "🔥", "😭"] as const;
+export type ReactionEmoji = (typeof REACTION_EMOJIS)[number];
+
 const logger = createLogger('EncouragementAPI');
 
 // Extract the type definitions from the generated types
@@ -147,6 +150,32 @@ export const updateEncouragementAPI = async (id: string, message: string): Promi
 export const getEncouragementsByTask = async (taskId: string): Promise<EncouragementDocument[]> => {
     const all = await getEncouragementsAPI();
     return all.filter((e) => e.taskId === taskId);
+};
+
+/**
+ * React to (or toggle off) an encouragement with an emoji.
+ * Only the receiver can react. Sending the current emoji removes it.
+ */
+export const reactToEncouragementAPI = async (id: string, emoji: string): Promise<EncouragementDocument> => {
+    let headers: Record<string, string> = { "Content-Type": "application/json" };
+    try {
+        const authData = await SecureStore.getItemAsync("auth_data");
+        if (authData) {
+            const parsed = JSON.parse(authData);
+            if (parsed.access_token) headers["Authorization"] = `Bearer ${parsed.access_token}`;
+            if (parsed.refresh_token) headers["refresh_token"] = parsed.refresh_token;
+        }
+    } catch (error) {
+        logger.error("Error getting auth data for react request", error);
+    }
+
+    const response = await axios({
+        url: process.env.EXPO_PUBLIC_URL + `/api/v1/user/encouragements/${id}/react`,
+        method: "POST",
+        headers,
+        data: { emoji },
+    });
+    return response.data;
 };
 
 /**

--- a/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
@@ -25,6 +25,8 @@ export default function Kudos() {
         fetchKudosData,
         markEncouragementsAsRead,
         markCongratulationsAsRead,
+        reactToEncouragement,
+        reactToCongratulation,
     } = useKudos();
     const [refreshing, setRefreshing] = useState(false);
 
@@ -125,6 +127,7 @@ export default function Kudos() {
                         formatTime={formatTime}
                         visible={encouragementVisibleIds.has(item.id)}
                         index={index}
+                        onReact={reactToEncouragement}
                     />
                 )}
             />
@@ -168,6 +171,7 @@ export default function Kudos() {
                         formatTime={formatTime}
                         visible={congratulationVisibleIds.has(item.id)}
                         index={index}
+                        onReact={reactToCongratulation}
                     />
                 )}
             />

--- a/frontend/components/cards/KudosItem.tsx
+++ b/frontend/components/cards/KudosItem.tsx
@@ -1,9 +1,19 @@
-import React from "react";
-import { View, StyleSheet } from "react-native";
+import React, { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import Animated, {
+    useAnimatedStyle,
+    useSharedValue,
+    withSequence,
+    withSpring,
+} from "react-native-reanimated";
+import * as Haptics from "expo-haptics";
+import { Heart } from "phosphor-react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { useRouter } from "expo-router";
 import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
+import ReactionTray from "@/components/cards/ReactionTray";
+import type { ReactionEmoji } from "@/api/encouragement";
 
 interface KudosSender {
     name: string;
@@ -15,12 +25,14 @@ interface KudosData {
     id: string;
     sender: KudosSender;
     message: string;
-    scope?: string; // "task" or "profile"
+    scope?: string;
     categoryName?: string;
     taskName?: string;
     timestamp: string;
     read: boolean;
-    type?: string; // "message" or "image"
+    type?: string;
+    reaction?: string;
+    reactedAt?: string;
 }
 
 interface KudosItemProps {
@@ -28,17 +40,77 @@ interface KudosItemProps {
     formatTime: (timestamp: string) => string;
     visible?: boolean;
     index?: number;
+    onReact?: (id: string, emoji: string) => void;
     /** Optional content rendered in the bubble footer (e.g. an action button). */
     footerSlot?: React.ReactNode;
 }
 
-export default function KudosItem({ kudos, formatTime, visible = false, index = 0, footerSlot }: KudosItemProps) {
+export default function KudosItem({
+    kudos,
+    formatTime,
+    visible = false,
+    index = 0,
+    onReact,
+    footerSlot,
+}: KudosItemProps) {
     const ThemedColor = useThemeColor();
     const styles = createStyles(ThemedColor);
     const router = useRouter();
+    const [trayOpen, setTrayOpen] = useState(false);
+
+    const scale = useSharedValue(1);
+    const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
 
     const isImage = kudos.type === "image";
     const isProfileLevel = kudos.scope === "profile";
+    const hasReaction = Boolean(kudos.reaction);
+
+    const triggerPulse = () => {
+        scale.value = withSequence(withSpring(1.35, { damping: 10 }), withSpring(1, { damping: 14 }));
+    };
+
+    const handleTap = () => {
+        if (!onReact) return;
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        triggerPulse();
+        onReact(kudos.id, "❤️");
+    };
+
+    const handleLongPress = () => {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+        setTrayOpen(true);
+    };
+
+    const handleSelectEmoji = (emoji: ReactionEmoji) => {
+        if (!onReact) return;
+        triggerPulse();
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        onReact(kudos.id, emoji);
+    };
+
+    const reactionButton = onReact ? (
+        <View style={styles.reactionRow}>
+            <Pressable onPress={handleTap} onLongPress={handleLongPress} hitSlop={8}>
+                <Animated.View style={animatedStyle}>
+                    {hasReaction ? (
+                        <Text style={styles.reactionEmoji}>{kudos.reaction}</Text>
+                    ) : (
+                        <Heart
+                            size={18}
+                            color={ThemedColor.caption}
+                            weight="regular"
+                        />
+                    )}
+                </Animated.View>
+            </Pressable>
+            <ReactionTray
+                visible={trayOpen}
+                currentReaction={kudos.reaction}
+                onSelect={handleSelectEmoji}
+                onDismiss={() => setTrayOpen(false)}
+            />
+        </View>
+    ) : null;
 
     const header = isProfileLevel ? (
         <ThemedText type="defaultSemiBold" style={styles.categoryText}>
@@ -64,7 +136,7 @@ export default function KudosItem({ kudos, formatTime, visible = false, index = 
             imageUri={isImage ? kudos.message : undefined}
             timeLabel={formatTime(kudos.timestamp)}
             read={kudos.read}
-            footerSlot={footerSlot}
+            footerSlot={footerSlot ?? reactionButton}
             onAvatarPress={() => router.push(`/account/${kudos.sender.id}`)}
             visible={visible}
             index={index}
@@ -77,4 +149,11 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
         categoryText: { color: ThemedColor.text, fontSize: 15, flexShrink: 1 },
         dot: { width: 3, height: 3, borderRadius: 2, backgroundColor: ThemedColor.caption, flexShrink: 0 },
         taskName: { color: ThemedColor.text, fontSize: 15, flexShrink: 1 },
+        reactionRow: {
+            alignSelf: "flex-end",
+            marginTop: 4,
+        },
+        reactionEmoji: {
+            fontSize: 18,
+        },
     });

--- a/frontend/components/cards/ReactionTray.tsx
+++ b/frontend/components/cards/ReactionTray.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect } from "react";
+import { Modal, Pressable, StyleSheet, Text, View } from "react-native";
+import Animated, {
+    useAnimatedStyle,
+    useSharedValue,
+    withSpring,
+    withTiming,
+} from "react-native-reanimated";
+import { REACTION_EMOJIS, ReactionEmoji } from "@/api/encouragement";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+interface ReactionTrayProps {
+    visible: boolean;
+    currentReaction?: string;
+    onSelect: (emoji: ReactionEmoji) => void;
+    onDismiss: () => void;
+    anchorY?: number;
+}
+
+export default function ReactionTray({
+    visible,
+    currentReaction,
+    onSelect,
+    onDismiss,
+    anchorY,
+}: ReactionTrayProps) {
+    const ThemedColor = useThemeColor();
+    const translateY = useSharedValue(12);
+    const opacity = useSharedValue(0);
+
+    useEffect(() => {
+        if (visible) {
+            translateY.value = withSpring(0, { damping: 18, stiffness: 260 });
+            opacity.value = withTiming(1, { duration: 120 });
+        } else {
+            translateY.value = withTiming(12, { duration: 100 });
+            opacity.value = withTiming(0, { duration: 100 });
+        }
+    }, [visible]);
+
+    const animatedStyle = useAnimatedStyle(() => ({
+        transform: [{ translateY: translateY.value }],
+        opacity: opacity.value,
+    }));
+
+    if (!visible) return null;
+
+    return (
+        <Modal transparent animationType="none" onRequestClose={onDismiss}>
+            <Pressable style={styles.backdrop} onPress={onDismiss}>
+                <Pressable>
+                    <Animated.View
+                        style={[styles.tray, { backgroundColor: ThemedColor.card ?? ThemedColor.background }, animatedStyle]}
+                    >
+                        {REACTION_EMOJIS.map((emoji) => (
+                            <Pressable
+                                key={emoji}
+                                onPress={() => {
+                                    onSelect(emoji);
+                                    onDismiss();
+                                }}
+                                style={[
+                                    styles.emojiButton,
+                                    currentReaction === emoji && {
+                                        backgroundColor: "#854DFF1A",
+                                        borderRadius: 20,
+                                    },
+                                ]}
+                            >
+                                <Text style={styles.emoji}>{emoji}</Text>
+                            </Pressable>
+                        ))}
+                    </Animated.View>
+                </Pressable>
+            </Pressable>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    backdrop: {
+        flex: 1,
+        justifyContent: "center",
+        alignItems: "center",
+        backgroundColor: "rgba(0,0,0,0.3)",
+    },
+    tray: {
+        flexDirection: "row",
+        alignItems: "center",
+        paddingHorizontal: 12,
+        paddingVertical: 8,
+        borderRadius: 28,
+        gap: 4,
+        shadowColor: "#000",
+        shadowOffset: { width: 0, height: 4 },
+        shadowOpacity: 0.15,
+        shadowRadius: 12,
+        elevation: 8,
+    },
+    emojiButton: {
+        width: 44,
+        height: 44,
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    emoji: {
+        fontSize: 26,
+    },
+});

--- a/frontend/contexts/kudosContext.tsx
+++ b/frontend/contexts/kudosContext.tsx
@@ -1,11 +1,11 @@
 import React, { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo, ReactNode } from "react";
-import { getEncouragementsAPI, markEncouragementsReadAPI } from "@/api/encouragement";
-import { getCongratulationsAPI, markCongratulationsReadAPI } from "@/api/congratulation";
+import { getEncouragementsAPI, markEncouragementsReadAPI, reactToEncouragementAPI } from "@/api/encouragement";
+import { getCongratulationsAPI, markCongratulationsReadAPI, reactToCongratulationAPI } from "@/api/congratulation";
 import { createLogger } from "@/utils/logger";
 
 const logger = createLogger('KudosContext');
 
-interface Encouragement {
+export interface Encouragement {
     id: string;
     sender: {
         name: string;
@@ -19,9 +19,11 @@ interface Encouragement {
     timestamp: string;
     read: boolean;
     type?: string;
+    reaction?: string;
+    reactedAt?: string;
 }
 
-interface Congratulation {
+export interface Congratulation {
     id: string;
     sender: {
         name: string;
@@ -34,6 +36,8 @@ interface Congratulation {
     timestamp: string;
     read: boolean;
     type?: string;
+    reaction?: string;
+    reactedAt?: string;
 }
 
 interface KudosContextType {
@@ -47,6 +51,8 @@ interface KudosContextType {
     fetchKudosData: () => Promise<void>;
     markEncouragementsAsRead: () => Promise<void>;
     markCongratulationsAsRead: () => Promise<void>;
+    reactToEncouragement: (id: string, emoji: string) => Promise<void>;
+    reactToCongratulation: (id: string, emoji: string) => Promise<void>;
 }
 
 const KudosContext = createContext<KudosContextType | undefined>(undefined);
@@ -132,6 +138,32 @@ export const KudosProvider: React.FC<KudosProviderProps> = ({ children }) => {
         }
     }, [congratulations]);
 
+    const reactToEncouragement = useCallback(async (id: string, emoji: string) => {
+        const prev = encouragements;
+        setEncouragements((enc) =>
+            enc.map((e) => e.id === id ? { ...e, reaction: e.reaction === emoji ? undefined : emoji } : e)
+        );
+        try {
+            await reactToEncouragementAPI(id, emoji);
+        } catch (error) {
+            logger.error("Error reacting to encouragement:", error);
+            setEncouragements(prev);
+        }
+    }, [encouragements]);
+
+    const reactToCongratulation = useCallback(async (id: string, emoji: string) => {
+        const prev = congratulations;
+        setCongratulations((con) =>
+            con.map((c) => c.id === id ? { ...c, reaction: c.reaction === emoji ? undefined : emoji } : c)
+        );
+        try {
+            await reactToCongratulationAPI(id, emoji);
+        } catch (error) {
+            logger.error("Error reacting to congratulation:", error);
+            setCongratulations(prev);
+        }
+    }, [congratulations]);
+
     useEffect(() => {
         fetchKudosData();
     }, [fetchKudosData]);
@@ -147,6 +179,8 @@ export const KudosProvider: React.FC<KudosProviderProps> = ({ children }) => {
         fetchKudosData,
         markEncouragementsAsRead,
         markCongratulationsAsRead,
+        reactToEncouragement,
+        reactToCongratulation,
     }), [
         encouragements,
         congratulations,
@@ -158,6 +192,8 @@ export const KudosProvider: React.FC<KudosProviderProps> = ({ children }) => {
         fetchKudosData,
         markEncouragementsAsRead,
         markCongratulationsAsRead,
+        reactToEncouragement,
+        reactToCongratulation,
     ]);
 
     return <KudosContext.Provider value={value}>{children}</KudosContext.Provider>;


### PR DESCRIPTION
## Summary

- Receivers can react to received kudos (encouragements and congratulations) with one of four curated emojis: ❤️ 🙌 🔥 😭
- Single tap on the heart icon defaults to ❤️; long-press opens an emoji tray
- Tapping the active emoji removes it (toggle). Reactions are 1:1 — only the receiver can react
- Sender gets a push notification ("Your kudos landed ❤️") when their kudos receives a reaction
- Optimistic UI updates with automatic revert on failure

## Backend changes

- `reaction` + `reactedAt` fields added to `EncouragementDocument` / `CongratulationDocument` (API + internal structs, `ToAPI()` updated)
- `POST /v1/user/encouragements/{id}/react` and `POST /v1/user/congratulations/{id}/react` — body: `{ emoji: string }`
- Emoji validated server-side against allowlist (`❤️ 🙌 🔥 😭`)
- Authorization check: only the receiver of the kudos can react (403 otherwise)
- `NotificationTypeKudosReaction` constant added

## Frontend changes

- `reaction?` / `reactedAt?` added to `Encouragement` and `Congratulation` interfaces in `KudosContext`
- `reactToEncouragement` / `reactToCongratulation` methods added to context with optimistic updates
- New `ReactionTray` component — spring-animated modal with 4 emoji buttons, active emoji highlighted with purple tint
- `KudosItem` updated: outlined Heart (Phosphor) when unreacted, emoji text when reacted; scale-pulse animation + haptic on tap
- Both `KudosItem` lists in `kudos.tsx` wired to context react methods

## Test plan

- [ ] Open the Kudos screen and tap the heart on an encouragement → should fill with ❤️, sender gets push notification
- [ ] Long-press the heart → tray opens with 4 emojis, selecting one sets the reaction
- [ ] Tap the active emoji again → reaction removes (toggle)
- [ ] Verify optimistic update reverts if the API call fails (airplane mode test)
- [ ] Verify 403 if trying to react to someone else's kudos directly via API
- [ ] Verify invalid emoji is rejected with 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)