### PR TITLE
feat(kudos): react from notifications page, sent view, and reaction fixes

### DIFF
--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -249,7 +249,8 @@ func (s *Service) ToggleReaction(id, receiverID primitive.ObjectID, emoji string
 	return &emoji, nil
 }
 
-// sendReactionNotification pushes to the kudos sender when the receiver reacts.
+// sendReactionNotification notifies the kudos sender when the receiver reacts: an
+// in-app row on the notifications page plus a push that deep-links there.
 // Works for anonymous (private) congratulations too — the sender always knew they sent it.
 func (s *Service) sendReactionNotification(con *CongratulationDocumentInternal, emoji string) error {
 	if s.Users == nil {
@@ -257,6 +258,15 @@ func (s *Service) sendReactionNotification(con *CongratulationDocumentInternal, 
 	}
 
 	ctx := context.Background()
+
+	// Image kudos carry a URL in Message — leave it out of the notification copy.
+	content := fmt.Sprintf("reacted %s to your congratulations", emoji)
+	if con.Message != "" && con.Type != "image" {
+		content = fmt.Sprintf("%s: %q", content, con.Message)
+	}
+	if err := s.NotificationService.CreateNotification(con.Receiver, con.Sender.ID, content, notifications.NotificationTypeKudosReaction, con.ID); err != nil {
+		slog.Error("Failed to create kudos reaction notification", "error", err, "congratulation_id", con.ID.Hex())
+	}
 
 	var sender types.User
 	if err := s.Users.FindOne(ctx, bson.M{"_id": con.Sender.ID}).Decode(&sender); err != nil {
@@ -279,6 +289,7 @@ func (s *Service) sendReactionNotification(con *CongratulationDocumentInternal, 
 			"type":       "kudos_reaction",
 			"kudos_type": "congratulation",
 			"reaction":   emoji,
+			"url":        "/feed?page=notifications",
 		},
 	})
 }

--- a/backend/internal/handlers/encouragement/service.go
+++ b/backend/internal/handlers/encouragement/service.go
@@ -297,13 +297,23 @@ func (s *Service) ToggleReaction(id, receiverID primitive.ObjectID, emoji string
 	return &emoji, nil
 }
 
-// sendReactionNotification pushes to the kudos sender when the receiver reacts.
+// sendReactionNotification notifies the kudos sender when the receiver reacts: an
+// in-app row on the notifications page plus a push that deep-links there.
 func (s *Service) sendReactionNotification(enc *EncouragementDocumentInternal, emoji string) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
 
 	ctx := context.Background()
+
+	// Image kudos carry a URL in Message — leave it out of the notification copy.
+	content := fmt.Sprintf("reacted %s to your encouragement", emoji)
+	if enc.Message != "" && enc.Type != "image" {
+		content = fmt.Sprintf("%s: %q", content, enc.Message)
+	}
+	if err := s.NotificationService.CreateNotification(enc.Receiver, enc.Sender.ID, content, notifications.NotificationTypeKudosReaction, enc.ID); err != nil {
+		slog.Error("Failed to create kudos reaction notification", "error", err, "encouragement_id", enc.ID.Hex())
+	}
 
 	var sender types.User
 	if err := s.Users.FindOne(ctx, bson.M{"_id": enc.Sender.ID}).Decode(&sender); err != nil {
@@ -326,6 +336,7 @@ func (s *Service) sendReactionNotification(enc *EncouragementDocumentInternal, e
 			"type":       "kudos_reaction",
 			"kudos_type": "encouragement",
 			"reaction":   emoji,
+			"url":        "/feed?page=notifications",
 		},
 	})
 }

--- a/frontend/__tests__/KudosItem.test.tsx
+++ b/frontend/__tests__/KudosItem.test.tsx
@@ -4,6 +4,9 @@ import KudosItem from "@/components/cards/KudosItem";
 
 jest.mock("@/components/CachedImage", () => "CachedImage");
 jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+// Reanimated v4 pulls in react-native-worklets at import time, which crashes under jest
+jest.mock("react-native-worklets", () => require("react-native-worklets/src/mock"));
+jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"));
 
 const base = {
     id: "k1",

--- a/frontend/__tests__/SentKudosItem.test.tsx
+++ b/frontend/__tests__/SentKudosItem.test.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import SentKudosItem from "@/components/cards/SentKudosItem";
+
+jest.mock("@/components/CachedImage", () => "CachedImage");
+jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+
+const base = {
+    id: "k1",
+    sender: { name: "Me", picture: "https://x/me.png", id: "u0" },
+    receiverInfo: { name: "Sarah", picture: "https://x/a.png", id: "u1" },
+    message: "you crushed it",
+    categoryName: "Fitness",
+    taskName: "Morning run",
+    timestamp: new Date().toISOString(),
+    read: true,
+    type: "message",
+};
+
+describe("SentKudosItem", () => {
+    test("shows the receiver, message and a pending indicator before any reaction", () => {
+        const { getByText, getByTestId, queryByTestId } = render(
+            <SentKudosItem kudos={base} formatTime={() => "5m ago"} />,
+        );
+        getByText("To");
+        getByText("Sarah");
+        getByText("you crushed it");
+        getByText("5m ago");
+        getByTestId("pending-indicator");
+        expect(queryByTestId("sent-reaction")).toBeNull();
+    });
+
+    test("shows the reaction emoji inline once the receiver reacts", () => {
+        const { getByTestId, queryByTestId } = render(
+            <SentKudosItem kudos={{ ...base, reaction: "🔥" }} formatTime={() => "now"} />,
+        );
+        expect(getByTestId("sent-reaction")).toHaveTextContent("🔥");
+        expect(queryByTestId("pending-indicator")).toBeNull();
+    });
+
+    test("falls back gracefully when the receiver info is missing", () => {
+        const { getByText } = render(
+            <SentKudosItem kudos={{ ...base, receiverInfo: undefined }} formatTime={() => "now"} />,
+        );
+        getByText("A friend");
+    });
+});

--- a/frontend/__tests__/UserInfoEncouragementNotification.test.tsx
+++ b/frontend/__tests__/UserInfoEncouragementNotification.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import UserInfoEncouragementNotification from "@/components/UserInfo/UserInfoEncouragementNotification";
 
 jest.mock("@/components/CachedImage", () => "CachedImage");
@@ -7,6 +7,19 @@ jest.mock("expo-router", () => ({
     router: { push: jest.fn() },
     useRouter: () => ({ push: jest.fn() }),
 }));
+// Reanimated v4 pulls in react-native-worklets at import time, which crashes under jest
+jest.mock("react-native-worklets", () => require("react-native-worklets/src/mock"));
+jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"));
+
+// Controls what useKudosOptional returns per test (undefined = outside provider)
+let mockKudosCtx: any;
+jest.mock("@/contexts/kudosContext", () => ({
+    useKudosOptional: () => mockKudosCtx,
+}));
+
+beforeEach(() => {
+    mockKudosCtx = undefined;
+});
 
 const base = {
     name: "Sarah",
@@ -34,5 +47,61 @@ describe("UserInfoEncouragementNotification", () => {
         );
         getByTestId("bubble-image");
         expect(queryByText(url)).toBeNull();
+    });
+
+    test("no reaction button when the kudos can't be matched to context", () => {
+        const { queryByTestId } = render(
+            <UserInfoEncouragementNotification {...base} message="you crushed it" />,
+        );
+        expect(queryByTestId("kudos-reaction-button")).toBeNull();
+    });
+
+    test("reacts in place when the kudos is matched in context", () => {
+        const reactToEncouragement = jest.fn();
+        mockKudosCtx = {
+            encouragements: [
+                {
+                    id: "enc1",
+                    sender: { name: "Sarah", picture: "https://x/a.png", id: "u1" },
+                    message: "you crushed it",
+                    scope: "task",
+                    timestamp: new Date(base.time).toISOString(),
+                    read: true,
+                },
+            ],
+            congratulations: [],
+            reactToEncouragement,
+            reactToCongratulation: jest.fn(),
+        };
+
+        const { getByTestId } = render(
+            <UserInfoEncouragementNotification {...base} message="you crushed it" />,
+        );
+        fireEvent.press(getByTestId("kudos-reaction-button"));
+        expect(reactToEncouragement).toHaveBeenCalledWith("enc1", "❤️");
+    });
+
+    test("shows the current reaction from the matched kudos", () => {
+        mockKudosCtx = {
+            encouragements: [
+                {
+                    id: "enc1",
+                    sender: { name: "Sarah", picture: "https://x/a.png", id: "u1" },
+                    message: "you crushed it",
+                    scope: "task",
+                    timestamp: new Date(base.time).toISOString(),
+                    read: true,
+                    reaction: "🔥",
+                },
+            ],
+            congratulations: [],
+            reactToEncouragement: jest.fn(),
+            reactToCongratulation: jest.fn(),
+        };
+
+        const { getByText } = render(
+            <UserInfoEncouragementNotification {...base} message="you crushed it" />,
+        );
+        getByText("🔥");
     });
 });

--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -1,4 +1,4 @@
-import { useRouter } from "expo-router";
+import { useLocalSearchParams, useRouter } from "expo-router";
 import { useFocusEffect } from "@react-navigation/native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { feedScrollVisibilityEvents } from "@/utils/feedScrollVisibilityEvents";
@@ -81,13 +81,16 @@ type PostData = {
 
 export default function Feed() {
     const router = useRouter();
+    // Deep links (e.g. kudos reaction pushes) open straight onto the notifications page.
+    const { page } = useLocalSearchParams<{ page?: string }>();
+    const openOnNotifications = page === "notifications";
 
     // Feed ↔ Notifications live as the two pages of a horizontal pager so the other
     // side previews mid-swipe (Instagram-style). Page 0 = feed, page 1 = notifications.
     const pagerRef = useRef<PagerView>(null);
-    const [activePage, setActivePage] = useState(0);
+    const [activePage, setActivePage] = useState(openOnNotifications ? 1 : 0);
     // Lazily mount the notifications page on the first swipe toward it.
-    const [notificationsMounted, setNotificationsMounted] = useState(false);
+    const [notificationsMounted, setNotificationsMounted] = useState(openOnNotifications);
     // react-native-pager-view doesn't reliably honor `initialPage` on first layout
     // here (it can come up on page 1) — same reason DatePager sets the page
     // imperatively. Pin page 0 exactly once, after the pager has laid out.
@@ -715,7 +718,7 @@ export default function Feed() {
             onLayout={() => {
                 if (!didInitPage.current) {
                     didInitPage.current = true;
-                    pagerRef.current?.setPageWithoutAnimation(0);
+                    pagerRef.current?.setPageWithoutAnimation(openOnNotifications ? 1 : 0);
                 }
             }}
             onPageSelected={(e) => {

--- a/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/kudos.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { View, StyleSheet, TouchableOpacity, FlatList, ViewToken, RefreshControl } from "react-native";
 import KudosItem from "@/components/cards/KudosItem";
+import SentKudosItem from "@/components/cards/SentKudosItem";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
@@ -8,21 +9,67 @@ import { HORIZONTAL_PADDING } from "@/constants/spacing";
 import { router, useLocalSearchParams } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { formatDistanceToNow } from "date-fns";
-import { useKudos } from "@/contexts/kudosContext";
+import { useKudos, Encouragement, Congratulation } from "@/contexts/kudosContext";
 import AnimatedTabs, { AnimatedTabContent } from "@/components/inputs/AnimatedTabs";
+import SegmentedControl from "@/components/ui/SegmentedControl";
 
 const TABS = ["Encouragements", "Congratulations"];
+const VIEWS = ["Received", "Sent"];
+type KudosView = "Received" | "Sent";
 const KudosItemSeparator = () => <View style={{ height: 10 }} />;
 
+interface SentKudosListProps {
+    items: (Encouragement | Congratulation)[];
+    formatTime: (timestamp: string) => string;
+    refreshing: boolean;
+    onRefresh: () => void;
+    emptySubtext: string;
+    styles: ReturnType<typeof createStyles>;
+    tintColor: string;
+}
+
+function SentKudosList({ items, formatTime, refreshing, onRefresh, emptySubtext, styles, tintColor }: SentKudosListProps) {
+    if (items.length === 0) {
+        return (
+            <View style={styles.emptyContainer}>
+                <ThemedText type="subtitle" style={styles.emptyText}>
+                    Nothing sent yet
+                </ThemedText>
+                <ThemedText type="lightBody" style={styles.emptySubtext}>
+                    {emptySubtext}
+                </ThemedText>
+            </View>
+        );
+    }
+
+    return (
+        <FlatList
+            data={items}
+            keyExtractor={(item) => item.id}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            style={styles.scrollView}
+            ItemSeparatorComponent={KudosItemSeparator}
+            refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} tintColor={tintColor} />}
+            renderItem={({ item, index }) => (
+                <SentKudosItem kudos={item} formatTime={formatTime} visible index={index} />
+            )}
+        />
+    );
+}
+
 export default function Kudos() {
-    const { tab } = useLocalSearchParams<{ tab?: string }>();
+    const { tab, view } = useLocalSearchParams<{ tab?: string; view?: string }>();
     const ThemedColor = useThemeColor();
     const insets = useSafeAreaInsets();
     const {
         encouragements,
         congratulations,
+        sentEncouragements,
+        sentCongratulations,
         loading,
         fetchKudosData,
+        fetchSentKudos,
         markEncouragementsAsRead,
         markCongratulationsAsRead,
         reactToEncouragement,
@@ -30,14 +77,27 @@ export default function Kudos() {
     } = useKudos();
     const [refreshing, setRefreshing] = useState(false);
 
-    const onRefresh = useCallback(async () => {
-        setRefreshing(true);
-        await fetchKudosData();
-        setRefreshing(false);
-    }, [fetchKudosData]);
-
     const initialTab = tab === "congratulations" ? 1 : 0;
     const [activeTab, setActiveTab] = useState(initialTab);
+
+    // The deep-link view applies to the deep-linked tab; the other starts on Received.
+    const initialView: KudosView = view === "sent" ? "Sent" : "Received";
+    const [encouragementView, setEncouragementView] = useState<KudosView>(initialTab === 0 ? initialView : "Received");
+    const [congratulationView, setCongratulationView] = useState<KudosView>(initialTab === 1 ? initialView : "Received");
+
+    const sentViewActive = encouragementView === "Sent" || congratulationView === "Sent";
+
+    useEffect(() => {
+        if (sentViewActive) {
+            fetchSentKudos();
+        }
+    }, [sentViewActive, fetchSentKudos]);
+
+    const onRefresh = useCallback(async () => {
+        setRefreshing(true);
+        await Promise.all([fetchKudosData(), ...(sentViewActive ? [fetchSentKudos()] : [])]);
+        setRefreshing(false);
+    }, [fetchKudosData, fetchSentKudos, sentViewActive]);
 
     const [encouragementVisibleIds, setEncouragementVisibleIds] = useState<Set<string>>(new Set());
     const [congratulationVisibleIds, setCongratulationVisibleIds] = useState<Set<string>>(new Set());
@@ -194,8 +254,52 @@ export default function Kudos() {
             <AnimatedTabs tabs={TABS} activeTab={activeTab} setActiveTab={setActiveTab} />
 
             <AnimatedTabContent activeTab={activeTab} setActiveTab={setActiveTab} flex>
-                {renderEncouragementList()}
-                {renderCongratulationList()}
+                <View style={styles.tabBody}>
+                    <View style={styles.viewToggleRow}>
+                        <SegmentedControl
+                            options={VIEWS}
+                            selectedOption={encouragementView}
+                            onOptionPress={(option) => setEncouragementView(option as KudosView)}
+                            size="small"
+                        />
+                    </View>
+                    {encouragementView === "Received" ? (
+                        renderEncouragementList()
+                    ) : (
+                        <SentKudosList
+                            items={sentEncouragements}
+                            formatTime={formatTime}
+                            refreshing={refreshing}
+                            onRefresh={onRefresh}
+                            emptySubtext="Encouragements you send will appear here, along with reactions"
+                            styles={styles}
+                            tintColor={ThemedColor.text}
+                        />
+                    )}
+                </View>
+                <View style={styles.tabBody}>
+                    <View style={styles.viewToggleRow}>
+                        <SegmentedControl
+                            options={VIEWS}
+                            selectedOption={congratulationView}
+                            onOptionPress={(option) => setCongratulationView(option as KudosView)}
+                            size="small"
+                        />
+                    </View>
+                    {congratulationView === "Received" ? (
+                        renderCongratulationList()
+                    ) : (
+                        <SentKudosList
+                            items={sentCongratulations}
+                            formatTime={formatTime}
+                            refreshing={refreshing}
+                            onRefresh={onRefresh}
+                            emptySubtext="Congratulations you send will appear here, along with reactions"
+                            styles={styles}
+                            tintColor={ThemedColor.text}
+                        />
+                    )}
+                </View>
             </AnimatedTabContent>
         </ThemedView>
     );
@@ -224,6 +328,13 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>, insets: any
         title: {
             fontSize: 24,
             color: ThemedColor.text,
+        },
+        tabBody: {
+            flex: 1,
+        },
+        viewToggleRow: {
+            paddingHorizontal: HORIZONTAL_PADDING,
+            paddingBottom: 4,
         },
         scrollView: {
             flex: 1,

--- a/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
@@ -1,9 +1,10 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
 import { router } from "expo-router";
 import { ThemedText } from "../ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import KudosItem from "@/components/cards/KudosItem";
+import { useKudosOptional } from "@/contexts/kudosContext";
 import { getNotificationTimeLabel } from "./notificationTime";
 
 type Props = {
@@ -31,6 +32,7 @@ const UserInfoEncouragementNotification = ({
     type = "encouragement",
 }: Props) => {
     const ThemedColor = useThemeColor();
+    const kudosCtx = useKudosOptional();
     const isCongrats = type === "congratulation";
     // Notification content carries no kudos type, so an image/GIF kudos arrives
     // as its URL in `message`. Detect it so KudosItem renders the image, not the URL.
@@ -40,12 +42,32 @@ const UserInfoEncouragementNotification = ({
     // instead of an empty category/task row when we pass scope: "profile".
     const isProfileScope = !referenceId && !taskName;
 
+    // The notification row doesn't carry the kudos document ID, so match it back to the
+    // received kudos (sender + message, nearest in time) to enable reacting in place.
+    const pool = isCongrats ? kudosCtx?.congratulations : kudosCtx?.encouragements;
+    const matched = useMemo(() => {
+        if (!pool) return undefined;
+        const candidates = pool.filter((k) => k.sender.id === userId && (!message || k.message === message));
+        if (candidates.length === 0) return undefined;
+        return candidates.reduce((best, k) =>
+            Math.abs(new Date(k.timestamp).getTime() - time) < Math.abs(new Date(best.timestamp).getTime() - time)
+                ? k
+                : best,
+        );
+    }, [pool, userId, message, time]);
+
     const handlePress = () => {
         router.push(`/account/${userId}` as never);
     };
 
+    const handleReact = useMemo(() => {
+        if (!matched || !kudosCtx) return undefined;
+        return (id: string, emoji: string) =>
+            isCongrats ? kudosCtx.reactToCongratulation(id, emoji) : kudosCtx.reactToEncouragement(id, emoji);
+    }, [matched, kudosCtx, isCongrats]);
+
     const kudos = {
-        id: `${type}-${time}`,
+        id: matched?.id ?? `${type}-${time}`,
         sender: { name, picture: icon, id: userId },
         message: message || (isCongrats ? "Congratulated you!" : "Sent you an encouragement"),
         scope: isProfileScope ? "profile" : "task",
@@ -54,6 +76,7 @@ const UserInfoEncouragementNotification = ({
         timestamp: new Date(time).toISOString(),
         read: true,
         type: isImage ? "image" : "message",
+        reaction: matched?.reaction,
     };
 
     return (
@@ -61,6 +84,7 @@ const UserInfoEncouragementNotification = ({
             kudos={kudos}
             formatTime={(iso) => getNotificationTimeLabel(new Date(iso).getTime())}
             visible
+            onReact={handleReact}
             footerSlot={
                 <TouchableOpacity
                     onPress={handlePress}

--- a/frontend/components/UserInfo/UserInfoKudosReactionNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoKudosReactionNotification.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { router } from "expo-router";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
+import { getNotificationTimeLabel } from "./notificationTime";
+
+type Props = {
+    name: string;
+    userId: string;
+    /** Backend copy: `reacted ❤️ to your encouragement: "msg"` */
+    content: string;
+    icon: string;
+    time: number;
+};
+
+const UserInfoKudosReactionNotification = ({ name, userId, content, icon, time }: Props) => {
+    const ThemedColor = useThemeColor();
+
+    return (
+        <SpeechBubbleCard
+            sender={{ name, picture: icon, id: userId }}
+            header={
+                <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.text, fontSize: 15 }}>
+                    Your kudos landed
+                </ThemedText>
+            }
+            message={content}
+            timeLabel={getNotificationTimeLabel(time)}
+            read
+            onPress={() => router.push(`/account/${userId}`)}
+            onAvatarPress={() => router.push(`/account/${userId}`)}
+            visible
+        />
+    );
+};
+
+export default UserInfoKudosReactionNotification;

--- a/frontend/components/cards/KudosItem.tsx
+++ b/frontend/components/cards/KudosItem.tsx
@@ -90,7 +90,7 @@ export default function KudosItem({
 
     const reactionButton = onReact ? (
         <View style={styles.reactionRow}>
-            <Pressable onPress={handleTap} onLongPress={handleLongPress} hitSlop={8}>
+            <Pressable testID="kudos-reaction-button" onPress={handleTap} onLongPress={handleLongPress} hitSlop={8}>
                 <Animated.View style={animatedStyle}>
                     {hasReaction ? (
                         <Text style={styles.reactionEmoji}>{kudos.reaction}</Text>
@@ -128,6 +128,17 @@ export default function KudosItem({
         </>
     );
 
+    // A custom footer (e.g. "Send kudos back") and the reaction button can coexist.
+    const footer =
+        footerSlot && reactionButton ? (
+            <View style={styles.footerSplit}>
+                <View>{footerSlot}</View>
+                {reactionButton}
+            </View>
+        ) : (
+            footerSlot ?? reactionButton
+        );
+
     return (
         <SpeechBubbleCard
             sender={kudos.sender}
@@ -136,7 +147,7 @@ export default function KudosItem({
             imageUri={isImage ? kudos.message : undefined}
             timeLabel={formatTime(kudos.timestamp)}
             read={kudos.read}
-            footerSlot={footerSlot ?? reactionButton}
+            footerSlot={footer}
             onAvatarPress={() => router.push(`/account/${kudos.sender.id}`)}
             visible={visible}
             index={index}
@@ -155,5 +166,11 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
         },
         reactionEmoji: {
             fontSize: 18,
+        },
+        footerSplit: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 8,
         },
     });

--- a/frontend/components/cards/SentKudosItem.tsx
+++ b/frontend/components/cards/SentKudosItem.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useRouter } from "expo-router";
+import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
+import type { Encouragement, Congratulation } from "@/contexts/kudosContext";
+
+type SentKudos = Encouragement | Congratulation;
+
+interface SentKudosItemProps {
+    kudos: SentKudos;
+    formatTime: (timestamp: string) => string;
+    visible?: boolean;
+    index?: number;
+}
+
+interface SentReactionStatusProps {
+    reaction?: string;
+}
+
+/** The receiver's reaction once it lands, or a subtle pending ring until then. */
+export function SentReactionStatus({ reaction }: SentReactionStatusProps) {
+    const ThemedColor = useThemeColor();
+    const styles = createStyles(ThemedColor);
+
+    if (reaction) {
+        return (
+            <ThemedText testID="sent-reaction" style={styles.reactionEmoji}>
+                {reaction}
+            </ThemedText>
+        );
+    }
+    return <View testID="pending-indicator" style={styles.pendingRing} />;
+}
+
+export default function SentKudosItem({ kudos, formatTime, visible = false, index = 0 }: SentKudosItemProps) {
+    const ThemedColor = useThemeColor();
+    const styles = createStyles(ThemedColor);
+    const router = useRouter();
+
+    const isImage = kudos.type === "image";
+    const isProfileLevel = "scope" in kudos && kudos.scope === "profile";
+    const receiver = kudos.receiverInfo ?? { name: "A friend", picture: "", id: "" };
+
+    const header = (
+        <>
+            <ThemedText type="caption" style={styles.toLabel}>
+                To
+            </ThemedText>
+            {isProfileLevel ? (
+                <ThemedText type="defaultSemiBold" style={styles.categoryText}>
+                    Profile Encouragement 🎉
+                </ThemedText>
+            ) : (
+                <>
+                    <ThemedText type="defaultSemiBold" style={styles.categoryText} numberOfLines={1}>
+                        {kudos.categoryName}
+                    </ThemedText>
+                    <View style={styles.dot} />
+                    <ThemedText type="default" style={styles.taskName} numberOfLines={1}>
+                        {kudos.taskName}
+                    </ThemedText>
+                </>
+            )}
+        </>
+    );
+
+    return (
+        <SpeechBubbleCard
+            sender={receiver}
+            header={header}
+            message={isImage ? undefined : kudos.message}
+            imageUri={isImage ? kudos.message : undefined}
+            timeLabel={formatTime(kudos.timestamp)}
+            read
+            footerSlot={
+                <View style={styles.statusRow}>
+                    <SentReactionStatus reaction={kudos.reaction} />
+                </View>
+            }
+            onAvatarPress={receiver.id ? () => router.push(`/account/${receiver.id}`) : undefined}
+            visible={visible}
+            index={index}
+        />
+    );
+}
+
+const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
+    StyleSheet.create({
+        toLabel: { color: ThemedColor.caption, fontSize: 13, flexShrink: 0 },
+        categoryText: { color: ThemedColor.text, fontSize: 15, flexShrink: 1 },
+        dot: { width: 3, height: 3, borderRadius: 2, backgroundColor: ThemedColor.caption, flexShrink: 0 },
+        taskName: { color: ThemedColor.text, fontSize: 15, flexShrink: 1 },
+        statusRow: { flexDirection: "row", justifyContent: "flex-end" },
+        reactionEmoji: { fontSize: 18 },
+        pendingRing: {
+            width: 16,
+            height: 16,
+            borderRadius: 8,
+            borderWidth: 1.5,
+            borderColor: ThemedColor.caption,
+            opacity: 0.5,
+        },
+    });

--- a/frontend/components/cards/SpeechBubbleCard.tsx
+++ b/frontend/components/cards/SpeechBubbleCard.tsx
@@ -144,7 +144,8 @@ export default function SpeechBubbleCard({
 
                         {footerSlot ? (
                             <View style={styles.footerRow}>
-                                <View>{footerSlot}</View>
+                                {/* flex: 1 lets footers span the row (e.g. CTA left, reaction right) */}
+                                <View style={{ flex: 1 }}>{footerSlot}</View>
                             </View>
                         ) : null}
                     </View>

--- a/frontend/components/notifications/NotificationsView.tsx
+++ b/frontend/components/notifications/NotificationsView.tsx
@@ -6,6 +6,7 @@ import Ionicons from "@expo/vector-icons/Ionicons";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import UserInfoCommentNotification from "@/components/UserInfo/UserInfoCommentNotification";
 import UserInfoEncouragementNotification from "@/components/UserInfo/UserInfoEncouragementNotification";
+import UserInfoKudosReactionNotification from "@/components/UserInfo/UserInfoKudosReactionNotification";
 import UserInfoFriendAcceptedNotification from "@/components/UserInfo/UserInfoFriendAcceptedNotification";
 import UserInfoPostTagNotification from "@/components/UserInfo/UserInfoPostTagNotification";
 import UserInfoRingsClosedNotification from "@/components/UserInfo/UserInfoRingsClosedNotification";
@@ -235,6 +236,14 @@ const NotificationItem = ({
                     referenceId={notification.referenceId}
                     type="congratulation"
                 />
+            ) : notification.type === "kudos_reaction" ? (
+                <UserInfoKudosReactionNotification
+                    name={notification.name}
+                    userId={notification.userId}
+                    content={notification.content}
+                    icon={notification.icon}
+                    time={notification.time}
+                />
             ) : notification.type === "friend_request_accepted" ? (
                 <UserInfoFriendAcceptedNotification
                     name={notification.name}
@@ -373,6 +382,9 @@ const NotificationsView = ({ isActive, onBack }: NotificationsViewProps) => {
                     router.navigate("/(logged-in)/(tabs)/(task)/kudos?tab=congratulations");
                 }
                 break;
+            case "kudos_reaction":
+                router.push(`/account/${notification.userId}`);
+                break;
             case "friend_request_accepted":
                 break;
             case "comment":
@@ -465,6 +477,7 @@ const NotificationsView = ({ isActive, onBack }: NotificationsViewProps) => {
                     | "comment"
                     | "encouragement"
                     | "congratulation"
+                    | "kudos_reaction"
                     | "friend_request"
                     | "friend_request_accepted"
                     | "post_tag"

--- a/frontend/contexts/kudosContext.tsx
+++ b/frontend/contexts/kudosContext.tsx
@@ -21,7 +21,7 @@ interface KudosUserRef {
     id: string;
 }
 
-interface Encouragement {
+export interface Encouragement {
     id: string;
     sender: KudosUserRef;
     message: string;
@@ -32,10 +32,12 @@ interface Encouragement {
     read: boolean;
     type?: string;
     reaction?: string | null;
+    reactedAt?: string;
+    /** Present only on sent kudos (the receiver's profile info). */
     receiverInfo?: KudosUserRef;
 }
 
-interface Congratulation {
+export interface Congratulation {
     id: string;
     sender: KudosUserRef;
     message: string;
@@ -45,6 +47,8 @@ interface Congratulation {
     read: boolean;
     type?: string;
     reaction?: string | null;
+    reactedAt?: string;
+    /** Present only on sent kudos (the receiver's profile info). */
     receiverInfo?: KudosUserRef;
 }
 
@@ -76,6 +80,9 @@ export const useKudos = () => {
     }
     return context;
 };
+
+/** Like useKudos, but safe outside the provider (returns undefined). */
+export const useKudosOptional = () => useContext(KudosContext);
 
 interface KudosProviderProps {
     children: ReactNode;

--- a/frontend/utils/notifications.ts
+++ b/frontend/utils/notifications.ts
@@ -4,6 +4,7 @@ export type ProcessedNotification = {
         | "comment"
         | "encouragement"
         | "congratulation"
+        | "kudos_reaction"
         | "friend_request"
         | "friend_request_accepted"
         | "rings_closed"
@@ -41,6 +42,7 @@ export const SUPPORTED_TYPES = new Set([
     "comment",
     "encouragement",
     "congratulation",
+    "kudos_reaction",
     "friend_request_accepted",
     "rings_closed",
     "post_tag",
@@ -56,7 +58,9 @@ export const filterByActivityType = (
         case "all":
             return notifications;
         case "encouragements":
-            return notifications.filter((n) => n.type === "encouragement" || n.type === "congratulation");
+            return notifications.filter(
+                (n) => n.type === "encouragement" || n.type === "congratulation" || n.type === "kudos_reaction",
+            );
         case "comments":
             return notifications.filter((n) => n.type === "comment");
         case "social":


### PR DESCRIPTION
Completes the kudos design doc on top of main's kudos backend, moving the reaction surface to the notifications page per the kudos-screen deprecation.

> **Rebased/rebuilt 2026-06-11.** The original branch re-implemented backend work that had already landed directly on main (`3bacb3a`/`3a536db`: sent endpoints, reaction toggle, sender indexes, generated client). That half is dropped — this PR is now only what main doesn't have. The two boot/stale-emoji fixes the old description claimed are moot against main's implementation.

## React from the notifications page (receiver side)
- Kudos notification rows match themselves back to the received kudos via kudosContext (sender + message, nearest in time) and render the reaction button + current state inline, next to the "Send kudos back" CTA.
- New `kudos_reaction` notification row type rendered on the notifications page ("Your kudos landed — *Name* reacted ❤️ …"), using the `KUDOS_REACTION` constant #426 added but never used.

## Reaction closure loop (sender side, backend)
- Reacting now also writes a KUDOS_REACTION in-app notification for the sender; image kudos elide the message from the row copy.
- The reaction push carries `url=/feed?page=notifications` and the feed pager honors `?page=notifications`, so tapping the push lands on the notifications page.
- No OpenAPI surface change — `make generate-api` is clean against main.

## Sent view
- Received/Sent toggle on the kudos screen (kept while the screen is deprecated-but-present): pending ○ vs reacted-emoji state per sent kudos, receiver profile on each card. Uses the `/v1/user/{encouragements,congratulations}/sent` endpoints already on main.

## Tests
- New jest suites: KudosItem reactions, SentKudosItem, notification-row react-in-place (reanimated v4/worklets mocked — v4 crashes jest at import otherwise).
- Verified: full `go test -short -race ./...` green; jest at baseline except pre-existing `AboutScreen.test`/`dragHitTest.test`; tsc at the 14 pre-existing DatePager errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
