### PR TITLE
End-of-day review card: check off + quick-log your day in one go

### DIFF
--- a/backend/internal/handlers/task/log_handlers.go
+++ b/backend/internal/handlers/task/log_handlers.go
@@ -1,0 +1,105 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type LogTaskEntry struct {
+	Content string `json:"content" example:"Went to the gym" doc:"What the user got done"`
+}
+
+type LogTasksInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Body          struct {
+		WorkspaceName string         `json:"workspaceName" example:"Personal" doc:"Workspace whose Logged category receives the tasks"`
+		Tasks         []LogTaskEntry `json:"tasks" minItems:"1" maxItems:"50" doc:"Things the user did today"`
+	} `json:"body"`
+}
+
+type LogTasksOutput struct {
+	Body struct {
+		Message       string `json:"message" example:"Tasks logged"`
+		TasksLogged   int    `json:"tasksLogged" example:"3" doc:"Number of entries created and completed"`
+		CurrentStreak int    `json:"currentStreak" example:"5" doc:"The user's current streak count"`
+		FailedIndices []int  `json:"failedIndices,omitempty" doc:"Indices of entries that failed"`
+	}
+}
+
+func (h *Handler) LogTasks(ctx context.Context, input *LogTasksInput) (*LogTasksOutput, error) {
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	if strings.TrimSpace(input.Body.WorkspaceName) == "" {
+		return nil, huma.Error400BadRequest("Workspace name is required", nil)
+	}
+	contents := make([]string, 0, len(input.Body.Tasks))
+	for i, entry := range input.Body.Tasks {
+		content := strings.TrimSpace(entry.Content)
+		if content == "" {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Entry %d is empty", i), nil)
+		}
+		contents = append(contents, content)
+	}
+
+	result, err := h.service.LogTasks(userObjID, input.Body.WorkspaceName, contents)
+	if err != nil {
+		slog.Error("Failed to log tasks", "userId", userObjID.Hex(), "count", len(contents), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to log tasks due to a server error. Please try again.", err)
+	}
+
+	// Fire-and-forget: each logged task counts as a creation (Plan) and a
+	// completion (Do), matching the BulkCompleteTask pattern.
+	if h.service.RingService != nil && result.TasksLogged > 0 {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			for i := 0; i < result.TasksLogged; i++ {
+				for _, ring := range []rings.RingType{rings.RingPlan, rings.RingDo} {
+					_, delta, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, ring)
+					if err != nil {
+						slog.Error("Failed to increment ring on task log", "user_id", userObjID.Hex(), "ring", ring, "error", err)
+						return
+					}
+					if delta.JustClosedAll {
+						h.service.RingService.NotifyAllRingsClosed(userObjID)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	resp := &LogTasksOutput{}
+	resp.Body.Message = "Tasks logged"
+	resp.Body.TasksLogged = result.TasksLogged
+	resp.Body.CurrentStreak = result.CurrentStreak
+	if len(result.FailedIndices) > 0 {
+		resp.Body.FailedIndices = result.FailedIndices
+	}
+	return resp, nil
+}
+
+func RegisterLogTasksOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "log-tasks",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/tasks/log",
+		Summary:     "Log completed tasks",
+		Description: "Create and immediately complete tasks in the workspace's Logged category. Used by the end-of-day review card for work that was done but never tracked.",
+		Tags:        []string{"tasks"},
+	}, handler.LogTasks)
+}

--- a/backend/internal/handlers/task/log_service.go
+++ b/backend/internal/handlers/task/log_service.go
@@ -1,0 +1,95 @@
+package task
+
+import (
+	"context"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const loggedCategoryName = "Logged"
+
+type LogTasksResult struct {
+	TasksLogged   int
+	CurrentStreak int
+	FailedIndices []int
+}
+
+// FindOrCreateLoggedCategory returns the user's "Logged" category for the
+// workspace, creating it atomically (upsert) if absent.
+func (s *Service) FindOrCreateLoggedCategory(userID primitive.ObjectID, workspaceName string) (*types.CategoryDocument, error) {
+	ctx := context.Background()
+	filter := bson.M{
+		"user":          userID,
+		"workspaceName": workspaceName,
+		"name":          loggedCategoryName,
+	}
+	update := bson.M{
+		"$setOnInsert": bson.M{
+			"_id":           primitive.NewObjectID(),
+			"name":          loggedCategoryName,
+			"workspaceName": workspaceName,
+			"lastEdited":    time.Now(),
+			"tasks":         []TaskDocument{},
+			"user":          userID,
+		},
+	}
+	opts := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After)
+
+	var category types.CategoryDocument
+	if err := s.Tasks.FindOneAndUpdate(ctx, filter, update, opts).Decode(&category); err != nil {
+		return nil, err
+	}
+	return &category, nil
+}
+
+// LogTasks creates and immediately completes one task per entry in the user's
+// "Logged" category, reusing the standard create/complete/delete path so
+// streaks and completed-tasks semantics match normal completion exactly.
+func (s *Service) LogTasks(userID primitive.ObjectID, workspaceName string, contents []string) (*LogTasksResult, error) {
+	category, err := s.FindOrCreateLoggedCategory(userID, workspaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &LogTasksResult{FailedIndices: []int{}}
+	for i, content := range contents {
+		now := time.Now()
+		taskDoc := TaskDocument{
+			ID:         primitive.NewObjectID(),
+			Priority:   1,
+			Content:    content,
+			Value:      1,
+			Active:     true,
+			UserID:     userID,
+			CategoryID: category.ID,
+			StartDate:  &now,
+			Timestamp:  now,
+			LastEdited: now,
+		}
+		if _, err := s.CreateTask(category.ID, &taskDoc); err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		completion, err := s.CompleteTask(userID, taskDoc.ID, category.ID, CompleteTaskDocument{
+			TimeCompleted: now.Format(time.RFC3339),
+			TimeTaken:     "PT0S",
+		})
+		if err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		// CompleteTask only $merges into completed-tasks; the open copy is
+		// removed separately, same as the CompleteTask handler does.
+		if err := s.DeleteTask(category.ID, taskDoc.ID); err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		result.TasksLogged++
+		result.CurrentStreak = completion.CurrentStreak
+	}
+	return result, nil
+}

--- a/backend/internal/handlers/task/log_service_test.go
+++ b/backend/internal/handlers/task/log_service_test.go
@@ -1,0 +1,101 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type LogServiceTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+}
+
+func (s *LogServiceTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+}
+
+func TestLogService(t *testing.T) {
+	suite.Run(t, new(LogServiceTestSuite))
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_CreatesLoggedCategoryAndCompletesTasks() {
+	user := s.GetUser(0)
+
+	result, err := s.service.LogTasks(user.ID, "Personal", []string{"gym", "called mom"})
+	s.NoError(err)
+	s.Equal(2, result.TasksLogged)
+	s.Empty(result.FailedIndices)
+
+	// A "Logged" category exists in the workspace, with no open tasks left in it
+	var category types.CategoryDocument
+	err = s.Collections["categories"].FindOne(s.Ctx, bson.M{
+		"user":          user.ID,
+		"workspaceName": "Personal",
+		"name":          "Logged",
+	}).Decode(&category)
+	s.NoError(err)
+	s.Empty(category.Tasks, "logged tasks must not remain open in the category")
+
+	// Both tasks landed in completed-tasks with a completion timestamp
+	count, err := s.Collections["completed-tasks"].CountDocuments(s.Ctx, bson.M{
+		"user":       user.ID,
+		"categoryID": category.ID,
+	})
+	s.NoError(err)
+	s.Equal(int64(2), count)
+
+	var completed struct {
+		Content       string `bson:"content"`
+		Active        bool   `bson:"active"`
+		TimeCompleted any    `bson:"timeCompleted"`
+	}
+	err = s.Collections["completed-tasks"].FindOne(s.Ctx, bson.M{
+		"user": user.ID, "content": "gym",
+	}).Decode(&completed)
+	s.NoError(err)
+	s.False(completed.Active)
+	s.NotNil(completed.TimeCompleted)
+
+	// User's lifetime completion count moved by 2
+	userAfter, err := s.service.Users.GetUserByID(s.Ctx, user.ID)
+	s.NoError(err)
+	s.Equal(user.TasksComplete+2, userAfter.TasksComplete)
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_ReusesExistingLoggedCategory() {
+	user := s.GetUser(0)
+
+	_, err := s.service.LogTasks(user.ID, "Personal", []string{"first"})
+	s.NoError(err)
+	_, err = s.service.LogTasks(user.ID, "Personal", []string{"second"})
+	s.NoError(err)
+
+	count, err := s.Collections["categories"].CountDocuments(s.Ctx, bson.M{
+		"user":          user.ID,
+		"workspaceName": "Personal",
+		"name":          "Logged",
+	})
+	s.NoError(err)
+	s.Equal(int64(1), count, "second call must reuse the Logged category")
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_SeparateCategoriesPerWorkspace() {
+	user := s.GetUser(0)
+
+	_, err := s.service.LogTasks(user.ID, "Personal", []string{"a"})
+	s.NoError(err)
+	_, err = s.service.LogTasks(user.ID, "Work", []string{"b"})
+	s.NoError(err)
+
+	count, err := s.Collections["categories"].CountDocuments(s.Ctx, bson.M{
+		"user": user.ID,
+		"name": "Logged",
+	})
+	s.NoError(err)
+	s.Equal(int64(2), count)
+}

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -36,6 +36,7 @@ func RegisterTaskOperations(api huma.API, handler *Handler) {
 	RegisterUpdateTaskOperation(api, handler)
 	RegisterCompleteTaskOperation(api, handler)
 	RegisterBulkCompleteTaskOperation(api, handler)
+	RegisterLogTasksOperation(api, handler)
 	RegisterDeleteTaskOperation(api, handler)
 	RegisterBulkDeleteTaskOperation(api, handler)
 	RegisterActivateTaskOperation(api, handler)

--- a/docs/superpowers/plans/2026-06-10-end-of-day-review-card.md
+++ b/docs/superpowers/plans/2026-06-10-end-of-day-review-card.md
@@ -1,0 +1,1263 @@
+# End-of-Day Review Card Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A card pinned to the top of the home feed from 20:00–23:59 local that opens a bottom sheet where the user bulk-checks-off today's open tasks and quick-logs untracked things (created + completed in one go via a new `POST /v1/user/tasks/log` endpoint).
+
+**Architecture:** Backend adds one Huma operation in the existing `task` handler package: find-or-create a "Logged" category (categories embed tasks; the task service's `Tasks` collection IS the categories collection), then per entry reuse `s.CreateTask` → `s.CompleteTask` → `s.DeleteTask` so streak/completed-tasks semantics stay identical to normal completion. Rings (Plan + Do per task) fire in the handler via the same fire-and-forget goroutine pattern as `BulkCompleteTask`. Frontend adds pure time/filter utils (jest-tested), a visibility hook backed by AsyncStorage, a card rendered in the feed's `ListHeaderComponent`, and a `DefaultModal` bottom sheet that calls the existing bulk-complete endpoint plus the new log endpoint.
+
+**Tech Stack:** Go + Huma v2 + MongoDB driver (backend), Expo/React Native + openapi-typescript client + @gorhom/bottom-sheet via `DefaultModal` (frontend). Tests: testify suite (`testpkg.BaseSuite`, real Mongo) and jest.
+
+**Spec:** `docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md`
+
+**Conventions that apply to every task:**
+- Work in worktree `/Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card` (branch `worktree-end-of-day-review-card`).
+- Use `bun` (never `npx`) for all JS tooling.
+- Frontend baseline has 4 pre-existing failing suites: `AboutScreen`, `dragHitTest`, `KudosItem`, `UserInfoEncouragementNotification`. They fail on clean main. Any OTHER failure is a regression you introduced.
+- Backend task-package tests need a real Mongo and take ~90s: `go test ./internal/handlers/task/ -run <Name>` to scope.
+- Comments: 2 lines max, only where the code can't say it.
+
+---
+
+### Task 1: Backend — `LogTasks` service method (TDD)
+
+**Files:**
+- Create: `backend/internal/handlers/task/log_service.go`
+- Create: `backend/internal/handlers/task/log_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/internal/handlers/task/log_service_test.go`:
+
+```go
+package task
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type LogServiceTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+}
+
+func (s *LogServiceTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+}
+
+func TestLogService(t *testing.T) {
+	suite.Run(t, new(LogServiceTestSuite))
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_CreatesLoggedCategoryAndCompletesTasks() {
+	user := s.GetUser(0)
+
+	result, err := s.service.LogTasks(user.ID, "Personal", []string{"gym", "called mom"})
+	s.NoError(err)
+	s.Equal(2, result.TasksLogged)
+	s.Empty(result.FailedIndices)
+
+	// A "Logged" category exists in the workspace, with no open tasks left in it
+	var category types.CategoryDocument
+	err = s.Collections["categories"].FindOne(s.Ctx, bson.M{
+		"user":          user.ID,
+		"workspaceName": "Personal",
+		"name":          "Logged",
+	}).Decode(&category)
+	s.NoError(err)
+	s.Empty(category.Tasks, "logged tasks must not remain open in the category")
+
+	// Both tasks landed in completed-tasks with a completion timestamp
+	count, err := s.Collections["completed-tasks"].CountDocuments(s.Ctx, bson.M{
+		"user":       user.ID,
+		"categoryID": category.ID,
+	})
+	s.NoError(err)
+	s.Equal(int64(2), count)
+
+	var completed struct {
+		Content       string `bson:"content"`
+		Active        bool   `bson:"active"`
+		TimeCompleted any    `bson:"timeCompleted"`
+	}
+	err = s.Collections["completed-tasks"].FindOne(s.Ctx, bson.M{
+		"user": user.ID, "content": "gym",
+	}).Decode(&completed)
+	s.NoError(err)
+	s.False(completed.Active)
+	s.NotNil(completed.TimeCompleted)
+
+	// User's lifetime completion count moved by 2
+	userAfter, err := s.service.Users.GetUserByID(s.Ctx, user.ID)
+	s.NoError(err)
+	s.Equal(user.TasksComplete+2, userAfter.TasksComplete)
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_ReusesExistingLoggedCategory() {
+	user := s.GetUser(0)
+
+	_, err := s.service.LogTasks(user.ID, "Personal", []string{"first"})
+	s.NoError(err)
+	_, err = s.service.LogTasks(user.ID, "Personal", []string{"second"})
+	s.NoError(err)
+
+	count, err := s.Collections["categories"].CountDocuments(s.Ctx, bson.M{
+		"user":          user.ID,
+		"workspaceName": "Personal",
+		"name":          "Logged",
+	})
+	s.NoError(err)
+	s.Equal(int64(1), count, "second call must reuse the Logged category")
+}
+
+func (s *LogServiceTestSuite) TestLogTasks_SeparateCategoriesPerWorkspace() {
+	user := s.GetUser(0)
+
+	_, err := s.service.LogTasks(user.ID, "Personal", []string{"a"})
+	s.NoError(err)
+	_, err = s.service.LogTasks(user.ID, "Work", []string{"b"})
+	s.NoError(err)
+
+	count, err := s.Collections["categories"].CountDocuments(s.Ctx, bson.M{
+		"user": user.ID,
+		"name": "Logged",
+	})
+	s.NoError(err)
+	s.Equal(int64(2), count)
+}
+```
+
+Note: if `user.TasksComplete` doesn't exist on the fixture user type, check what `s.GetUser(0)` returns (look at `backend/internal/testing/` BaseSuite) and read the field from `s.service.Users.GetUserByID(s.Ctx, user.ID)` before calling `LogTasks` instead.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/backend
+go test ./internal/handlers/task/ -run TestLogService -v 2>&1 | tail -20
+```
+
+Expected: compile error — `s.service.LogTasks undefined`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `backend/internal/handlers/task/log_service.go`:
+
+```go
+package task
+
+import (
+	"context"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+const loggedCategoryName = "Logged"
+
+type LogTasksResult struct {
+	TasksLogged   int
+	CurrentStreak int
+	FailedIndices []int
+}
+
+// FindOrCreateLoggedCategory returns the user's "Logged" category for the
+// workspace, creating it atomically (upsert) if absent.
+func (s *Service) FindOrCreateLoggedCategory(userID primitive.ObjectID, workspaceName string) (*types.CategoryDocument, error) {
+	ctx := context.Background()
+	filter := bson.M{
+		"user":          userID,
+		"workspaceName": workspaceName,
+		"name":          loggedCategoryName,
+	}
+	update := bson.M{
+		"$setOnInsert": bson.M{
+			"_id":           primitive.NewObjectID(),
+			"name":          loggedCategoryName,
+			"workspaceName": workspaceName,
+			"lastEdited":    time.Now(),
+			"tasks":         []TaskDocument{},
+			"user":          userID,
+		},
+	}
+	opts := options.FindOneAndUpdate().SetUpsert(true).SetReturnDocument(options.After)
+
+	var category types.CategoryDocument
+	if err := s.Tasks.FindOneAndUpdate(ctx, filter, update, opts).Decode(&category); err != nil {
+		return nil, err
+	}
+	return &category, nil
+}
+
+// LogTasks creates and immediately completes one task per entry in the user's
+// "Logged" category, reusing the standard create/complete/delete path so
+// streaks and completed-tasks semantics match normal completion exactly.
+func (s *Service) LogTasks(userID primitive.ObjectID, workspaceName string, contents []string) (*LogTasksResult, error) {
+	category, err := s.FindOrCreateLoggedCategory(userID, workspaceName)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &LogTasksResult{FailedIndices: []int{}}
+	for i, content := range contents {
+		now := time.Now()
+		taskDoc := TaskDocument{
+			ID:         primitive.NewObjectID(),
+			Priority:   1,
+			Content:    content,
+			Value:      1,
+			Active:     true,
+			UserID:     userID,
+			CategoryID: category.ID,
+			StartDate:  &now,
+			Timestamp:  now,
+			LastEdited: now,
+		}
+		if _, err := s.CreateTask(category.ID, &taskDoc); err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		completion, err := s.CompleteTask(userID, taskDoc.ID, category.ID, CompleteTaskDocument{
+			TimeCompleted: now.Format(time.RFC3339),
+			TimeTaken:     "PT0S",
+		})
+		if err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		// CompleteTask only $merges into completed-tasks; the open copy is
+		// removed separately, same as the CompleteTask handler does.
+		if err := s.DeleteTask(category.ID, taskDoc.ID); err != nil {
+			result.FailedIndices = append(result.FailedIndices, i)
+			continue
+		}
+		result.TasksLogged++
+		result.CurrentStreak = completion.CurrentStreak
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+go test ./internal/handlers/task/ -run TestLogService -v 2>&1 | tail -15
+```
+
+Expected: `PASS` on all three tests. If `types.CategoryDocument` decode fails on the upsert, check the bson field names against `backend/internal/handlers/types/types.go:17` (CategoryDocument).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card
+git add backend/internal/handlers/task/log_service.go backend/internal/handlers/task/log_service_test.go
+git commit -m "feat(tasks): LogTasks service — create+complete entries in a per-workspace Logged category"
+```
+
+---
+
+### Task 2: Backend — handler, Huma operation, route registration
+
+**Files:**
+- Create: `backend/internal/handlers/task/log_handlers.go`
+- Modify: `backend/internal/handlers/task/routes.go` (add one line to `RegisterTaskOperations`)
+
+- [ ] **Step 1: Write the handler and operation**
+
+Create `backend/internal/handlers/task/log_handlers.go`:
+
+```go
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/rings"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type LogTaskEntry struct {
+	Content string `json:"content" example:"Went to the gym" doc:"What the user got done"`
+}
+
+type LogTasksInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Body          struct {
+		WorkspaceName string         `json:"workspaceName" example:"Personal" doc:"Workspace whose Logged category receives the tasks"`
+		Tasks         []LogTaskEntry `json:"tasks" minItems:"1" maxItems:"50" doc:"Things the user did today"`
+	} `json:"body"`
+}
+
+type LogTasksOutput struct {
+	Body struct {
+		Message       string `json:"message" example:"Tasks logged"`
+		TasksLogged   int    `json:"tasksLogged" example:"3" doc:"Number of entries created and completed"`
+		CurrentStreak int    `json:"currentStreak" example:"5" doc:"The user's current streak count"`
+		FailedIndices []int  `json:"failedIndices,omitempty" doc:"Indices of entries that failed"`
+	}
+}
+
+func (h *Handler) LogTasks(ctx context.Context, input *LogTasksInput) (*LogTasksOutput, error) {
+	userIDStr, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(userIDStr)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	if strings.TrimSpace(input.Body.WorkspaceName) == "" {
+		return nil, huma.Error400BadRequest("Workspace name is required", nil)
+	}
+	contents := make([]string, 0, len(input.Body.Tasks))
+	for i, entry := range input.Body.Tasks {
+		content := strings.TrimSpace(entry.Content)
+		if content == "" {
+			return nil, huma.Error400BadRequest(fmt.Sprintf("Entry %d is empty", i), nil)
+		}
+		contents = append(contents, content)
+	}
+
+	result, err := h.service.LogTasks(userObjID, input.Body.WorkspaceName, contents)
+	if err != nil {
+		slog.Error("Failed to log tasks", "userId", userObjID.Hex(), "count", len(contents), "error", err)
+		return nil, huma.Error500InternalServerError("Unable to log tasks due to a server error. Please try again.", err)
+	}
+
+	// Fire-and-forget: each logged task counts as a creation (Plan) and a
+	// completion (Do), matching the BulkCompleteTask pattern.
+	if h.service.RingService != nil && result.TasksLogged > 0 {
+		go func() {
+			tz := auth.GetTimezoneOrDefault(ctx)
+			for i := 0; i < result.TasksLogged; i++ {
+				for _, ring := range []rings.RingType{rings.RingPlan, rings.RingDo} {
+					_, delta, err := h.service.RingService.IncrementRing(context.Background(), userObjID, tz, ring)
+					if err != nil {
+						slog.Error("Failed to increment ring on task log", "user_id", userObjID.Hex(), "ring", ring, "error", err)
+						return
+					}
+					if delta.JustClosedAll {
+						h.service.RingService.NotifyAllRingsClosed(userObjID)
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	resp := &LogTasksOutput{}
+	resp.Body.Message = "Tasks logged"
+	resp.Body.TasksLogged = result.TasksLogged
+	resp.Body.CurrentStreak = result.CurrentStreak
+	if len(result.FailedIndices) > 0 {
+		resp.Body.FailedIndices = result.FailedIndices
+	}
+	return resp, nil
+}
+
+func RegisterLogTasksOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "log-tasks",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/tasks/log",
+		Summary:     "Log completed tasks",
+		Description: "Create and immediately complete tasks in the workspace's Logged category. Used by the end-of-day review card for work that was done but never tracked.",
+		Tags:        []string{"tasks"},
+	}, handler.LogTasks)
+}
+```
+
+Routing note: `/v1/user/tasks/log` overlaps the `POST /v1/user/tasks/{category}` pattern; the router gives static segments priority (same reason `/v1/user/tasks/bulk/complete` coexists with `/{category}/{id}`). Verified at runtime by Step 3.
+
+- [ ] **Step 2: Register the operation**
+
+In `backend/internal/handlers/task/routes.go`, inside `RegisterTaskOperations`, add after `RegisterBulkCompleteTaskOperation(api, handler)`:
+
+```go
+	RegisterLogTasksOperation(api, handler)
+```
+
+- [ ] **Step 3: Build, test, and regenerate the API spec**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/backend
+go build ./... && go test ./internal/handlers/task/ -run TestLogService 2>&1 | tail -3
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card
+make generate-api 2>&1 | tail -10
+```
+
+Expected: build OK, tests pass, and `make generate-api` completes WITHOUT a panic (a panic here means a Huma duplicate-type-name collision — rename the colliding `LogTasks*` type and re-run). It also regenerates `frontend/api/api-spec.yaml` + `frontend/api/generated/types.ts`; confirm with:
+
+```bash
+grep -n "tasks/log" frontend/api/generated/types.ts | head -3
+```
+
+Expected: at least one match (`"/v1/user/tasks/log"`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/internal/handlers/task/log_handlers.go backend/internal/handlers/task/routes.go frontend/api/api-spec.yaml frontend/api/generated/types.ts
+git commit -m "feat(tasks): POST /v1/user/tasks/log endpoint with Plan+Do ring credit"
+```
+
+---
+
+### Task 3: Frontend — API wrappers
+
+**Files:**
+- Modify: `frontend/api/task.ts` (append near the other completion APIs)
+
+- [ ] **Step 1: Add the wrappers**
+
+Append to `frontend/api/task.ts` (after `markAsCompletedAPI` / near other completion helpers; reuse the existing `client` and `withAuthHeaders` imports already at the top of the file):
+
+```ts
+export interface LogTasksResult {
+    message: string;
+    tasksLogged: number;
+    currentStreak: number;
+    failedIndices?: number[];
+}
+
+/**
+ * Log untracked work: creates + completes one task per entry in the
+ * workspace's "Logged" category (end-of-day review card).
+ */
+export const logTasksAPI = async (workspaceName: string, contents: string[]): Promise<LogTasksResult> => {
+    const { data, error } = await client.POST("/v1/user/tasks/log", {
+        params: withAuthHeaders({}),
+        body: { workspaceName, tasks: contents.map((content) => ({ content })) },
+    });
+
+    if (error) {
+        throw new Error(`Failed to log tasks: ${JSON.stringify(error)}`);
+    }
+
+    return data as unknown as LogTasksResult;
+};
+
+export interface BulkCompleteItem {
+    taskId: string;
+    categoryId: string;
+}
+
+export interface BulkCompleteResult {
+    message: string;
+    totalCompleted: number;
+    totalFailed: number;
+    currentStreak: number;
+    failedTaskIds?: string[];
+}
+
+/**
+ * Complete several existing tasks in one request.
+ */
+export const bulkCompleteTasksAPI = async (items: BulkCompleteItem[]): Promise<BulkCompleteResult> => {
+    const timeCompleted = new Date().toISOString();
+    const { data, error } = await client.POST("/v1/user/tasks/bulk/complete", {
+        params: withAuthHeaders({}),
+        body: {
+            tasks: items.map(({ taskId, categoryId }) => ({
+                taskId,
+                categoryId,
+                completeData: { timeCompleted, timeTaken: "PT0S" },
+            })),
+        },
+    });
+
+    if (error) {
+        throw new Error(`Failed to bulk complete tasks: ${JSON.stringify(error)}`);
+    }
+
+    return data as unknown as BulkCompleteResult;
+};
+```
+
+If `withAuthHeaders({})` doesn't typecheck for an endpoint without path params, check how `frontend/api/utils.ts` defines it and follow whatever an existing no-path-param call does (e.g., search `client.POST` calls without `path:` in `frontend/api/`).
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun run tsc --noEmit 2>&1 | grep -E "api/task" | head; echo "exit: $?"
+```
+
+Expected: no errors mentioning `api/task.ts` (the repo may have pre-existing errors elsewhere; only `api/task.ts` matters here). If the project has no `tsc` script, run `bun x tsc --noEmit` from `frontend/`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/api/task.ts
+git commit -m "feat(api): logTasksAPI and bulkCompleteTasksAPI wrappers"
+```
+
+---
+
+### Task 4: Frontend — pure end-of-day utils (TDD)
+
+**Files:**
+- Create: `frontend/utils/endOfDay.ts`
+- Create: `frontend/__tests__/endOfDay.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/__tests__/endOfDay.test.ts`:
+
+```ts
+import { END_OF_DAY_HOUR, endOfDayDismissKey, isEndOfDayWindow, todaysOpenTasks } from "@/utils/endOfDay";
+import { Task } from "@/api/types";
+
+const task = (over: Partial<Task>): Task =>
+    ({ id: "t", content: "", priority: 1, value: 1, categoryID: "cat-1", ...(over as any) }) as Task;
+
+describe("isEndOfDayWindow", () => {
+    it("is false before the trigger hour", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR - 1, 59))).toBe(false);
+    });
+
+    it("is true from the trigger hour until midnight", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR, 0))).toBe(true);
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, 23, 59))).toBe(true);
+    });
+
+    it("resets after midnight", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 11, 0, 1))).toBe(false);
+    });
+});
+
+describe("endOfDayDismissKey", () => {
+    it("encodes the local date", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 10, 21, 0))).toBe("eod-dismissed-2026-06-10");
+    });
+
+    it("differs across days so the card returns the next evening", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 10))).not.toBe(endOfDayDismissKey(new Date(2026, 5, 11)));
+    });
+});
+
+describe("todaysOpenTasks", () => {
+    const now = new Date(2026, 5, 10, 20, 30);
+
+    it("includes tasks starting today, due today, and overdue", () => {
+        const tasks = [
+            task({ id: "starts-today", startDate: new Date(2026, 5, 10, 9).toISOString() }),
+            task({ id: "due-today", deadline: new Date(2026, 5, 10, 22).toISOString() }),
+            task({ id: "overdue", deadline: new Date(2026, 5, 8).toISOString() }),
+            task({ id: "future", startDate: new Date(2026, 5, 12).toISOString() }),
+        ];
+        expect(todaysOpenTasks(tasks, now).map((t) => t.id)).toEqual(["starts-today", "due-today", "overdue"]);
+    });
+
+    it("dedupes a task that both starts and is due today", () => {
+        const both = task({
+            id: "both",
+            startDate: new Date(2026, 5, 10, 9).toISOString(),
+            deadline: new Date(2026, 5, 10, 22).toISOString(),
+        });
+        expect(todaysOpenTasks([both], now)).toHaveLength(1);
+    });
+
+    it("excludes synthetic upcoming categories (not real, not completable)", () => {
+        const synthetic = task({
+            id: "synth",
+            categoryID: "upcoming-Personal",
+            startDate: new Date(2026, 5, 10).toISOString(),
+        });
+        expect(todaysOpenTasks([synthetic], now)).toHaveLength(0);
+    });
+});
+
+describe("runEndOfDaySubmission", () => {
+    const checked = [
+        task({ id: "t1", categoryID: "c1" }),
+        task({ id: "t2", categoryID: "c2" }),
+    ];
+
+    it("bulk-completes checked tasks and logs entries with the right payloads", async () => {
+        const bulkComplete = jest.fn().mockResolvedValue({ totalCompleted: 2, totalFailed: 0, failedTaskIds: [] });
+        const logTasks = jest.fn().mockResolvedValue({ tasksLogged: 1, currentStreak: 3 });
+
+        const result = await runEndOfDaySubmission(checked, ["gym"], "Personal", { bulkComplete, logTasks });
+
+        expect(bulkComplete).toHaveBeenCalledWith([
+            { taskId: "t1", categoryId: "c1" },
+            { taskId: "t2", categoryId: "c2" },
+        ]);
+        expect(logTasks).toHaveBeenCalledWith("Personal", ["gym"]);
+        expect(result).toEqual({
+            completedCount: 2,
+            loggedCount: 1,
+            failedCount: 0,
+            confirmedCompletions: [
+                { taskId: "t1", categoryId: "c1" },
+                { taskId: "t2", categoryId: "c2" },
+            ],
+            remainingEntries: [],
+        });
+    });
+
+    it("keeps failed entries and excludes failed completions from confirmations", async () => {
+        const bulkComplete = jest.fn().mockResolvedValue({ totalCompleted: 1, totalFailed: 1, failedTaskIds: ["t2"] });
+        const logTasks = jest.fn().mockResolvedValue({ tasksLogged: 1, currentStreak: 3, failedIndices: [0] });
+
+        const result = await runEndOfDaySubmission(checked, ["a", "b"], "Personal", { bulkComplete, logTasks });
+
+        expect(result.confirmedCompletions).toEqual([{ taskId: "t1", categoryId: "c1" }]);
+        expect(result.remainingEntries).toEqual(["a"]);
+        expect(result.failedCount).toBe(2);
+    });
+
+    it("skips the APIs entirely for empty inputs", async () => {
+        const bulkComplete = jest.fn();
+        const logTasks = jest.fn();
+
+        const result = await runEndOfDaySubmission([], [], "Personal", { bulkComplete, logTasks });
+
+        expect(bulkComplete).not.toHaveBeenCalled();
+        expect(logTasks).not.toHaveBeenCalled();
+        expect(result.failedCount).toBe(0);
+    });
+});
+```
+
+(Also add `runEndOfDaySubmission` to the import list at the top of the test file.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun run test endOfDay 2>&1 | tail -10
+```
+
+Expected: FAIL — cannot find module `@/utils/endOfDay`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `frontend/utils/endOfDay.ts`:
+
+```ts
+import { isSameDay, startOfDay } from "date-fns";
+import type { Task } from "@/api/types";
+
+export const END_OF_DAY_HOUR = 20;
+
+export function isEndOfDayWindow(now: Date): boolean {
+    return now.getHours() >= END_OF_DAY_HOUR;
+}
+
+export function endOfDayDismissKey(now: Date): string {
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `eod-dismissed-${now.getFullYear()}-${month}-${day}`;
+}
+
+// Open tasks worth reviewing tonight: starting today, due today, or overdue.
+// Synthetic "Upcoming" categories aren't real categories and can't be completed.
+export function todaysOpenTasks(allTasks: Task[], now: Date = new Date()): Task[] {
+    const seen = new Set<string>();
+    const result: Task[] = [];
+    for (const t of allTasks) {
+        if (!t.id || seen.has(t.id)) continue;
+        if (t.categoryID?.startsWith("upcoming-")) continue;
+
+        const startsToday = t.startDate ? isSameDay(new Date(t.startDate), now) : false;
+        const dueToday = t.deadline ? isSameDay(new Date(t.deadline), now) : false;
+        const overdue = t.deadline ? startOfDay(new Date(t.deadline)) < startOfDay(now) : false;
+
+        if (startsToday || dueToday || overdue) {
+            seen.add(t.id);
+            result.push(t);
+        }
+    }
+    return result;
+}
+
+export interface EndOfDaySubmissionDeps {
+    bulkComplete: (items: { taskId: string; categoryId: string }[]) => Promise<BulkCompleteResult>;
+    logTasks: (workspaceName: string, contents: string[]) => Promise<LogTasksResult>;
+}
+
+export interface EndOfDaySubmissionResult {
+    completedCount: number;
+    loggedCount: number;
+    failedCount: number;
+    confirmedCompletions: { taskId: string; categoryId: string }[];
+    remainingEntries: string[];
+}
+
+// The sheet's submit step, kept pure (deps injected) so it's unit-testable
+// without rendering the gorhom bottom sheet.
+export async function runEndOfDaySubmission(
+    checkedTasks: Task[],
+    entries: string[],
+    workspaceName: string | undefined,
+    deps: EndOfDaySubmissionDeps
+): Promise<EndOfDaySubmissionResult> {
+    let completedCount = 0;
+    let loggedCount = 0;
+    let failedCount = 0;
+    const confirmedCompletions: { taskId: string; categoryId: string }[] = [];
+    // Entries are only cleared once the log call confirms them.
+    let remainingEntries: string[] = entries;
+
+    if (checkedTasks.length > 0) {
+        const res = await deps.bulkComplete(
+            checkedTasks.map((t) => ({ taskId: t.id, categoryId: t.categoryID! }))
+        );
+        const failed = new Set(res.failedTaskIds ?? []);
+        for (const t of checkedTasks) {
+            if (!failed.has(t.id)) confirmedCompletions.push({ taskId: t.id, categoryId: t.categoryID! });
+        }
+        completedCount = res.totalCompleted;
+        failedCount += res.totalFailed;
+    }
+
+    if (entries.length > 0 && workspaceName) {
+        const res = await deps.logTasks(workspaceName, entries);
+        loggedCount = res.tasksLogged;
+        const failedIdx = new Set(res.failedIndices ?? []);
+        failedCount += failedIdx.size;
+        remainingEntries = entries.filter((_, i) => failedIdx.has(i));
+    }
+
+    return { completedCount, loggedCount, failedCount, confirmedCompletions, remainingEntries };
+}
+```
+
+Add to the imports at the top of `frontend/utils/endOfDay.ts`:
+
+```ts
+import type { BulkCompleteResult, LogTasksResult } from "@/api/task";
+```
+
+(Type-only import — no runtime cycle. Task 3 must be complete first, which it is in plan order.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+bun run test endOfDay 2>&1 | tail -8
+```
+
+Expected: PASS, all tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/utils/endOfDay.ts frontend/__tests__/endOfDay.test.ts
+git commit -m "feat(eod): pure helpers for end-of-day window, dismissal key, and today's open tasks"
+```
+
+---
+
+### Task 5: Frontend — `useEndOfDayCard` visibility hook
+
+**Files:**
+- Create: `frontend/hooks/useEndOfDayCard.ts`
+
+- [ ] **Step 1: Write the hook**
+
+Create `frontend/hooks/useEndOfDayCard.ts`:
+
+```ts
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { endOfDayDismissKey, isEndOfDayWindow } from "@/utils/endOfDay";
+
+/**
+ * Card is visible from END_OF_DAY_HOUR until local midnight, unless dismissed
+ * (or the review was completed) today. Re-checks every minute so the card
+ * appears if the app stays open across the trigger hour.
+ */
+export const useEndOfDayCard = () => {
+    // Start hidden until storage answers, so the card never flashes.
+    const [dismissedToday, setDismissedToday] = useState(true);
+    const [inWindow, setInWindow] = useState(() => isEndOfDayWindow(new Date()));
+
+    useEffect(() => {
+        let cancelled = false;
+        const check = async () => {
+            const now = new Date();
+            const stored = await AsyncStorage.getItem(endOfDayDismissKey(now));
+            if (cancelled) return;
+            setInWindow(isEndOfDayWindow(now));
+            setDismissedToday(stored != null);
+        };
+        check();
+        const interval = setInterval(check, 60_000);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, []);
+
+    const dismiss = useCallback(() => {
+        setDismissedToday(true);
+        AsyncStorage.setItem(endOfDayDismissKey(new Date()), "1").catch(() => {});
+    }, []);
+
+    return { visible: inWindow && !dismissedToday, dismiss };
+};
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun x tsc --noEmit 2>&1 | grep "useEndOfDayCard" | head; echo "checked"
+```
+
+Expected: no output before "checked".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/hooks/useEndOfDayCard.ts
+git commit -m "feat(eod): useEndOfDayCard visibility hook with per-day AsyncStorage dismissal"
+```
+
+---
+
+### Task 6: Frontend — `EndOfDayReviewSheet` bottom sheet
+
+**Files:**
+- Create: `frontend/components/modals/EndOfDayReviewSheet.tsx`
+
+- [ ] **Step 1: Write the sheet component**
+
+Create `frontend/components/modals/EndOfDayReviewSheet.tsx`. Design constraints from project memory: ThemedText semantic types only (no hardcoded fontFamily), Phosphor icons, left-aligned, no "streak" wording in copy, no render-helper functions (rows are real components).
+
+```tsx
+import React, { useState } from "react";
+import { StyleSheet, TextInput, TouchableOpacity, View, ScrollView } from "react-native";
+import { CheckCircleIcon, CircleIcon, PlusCircleIcon, XCircleIcon } from "phosphor-react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import DefaultModal from "./DefaultModal";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTasks } from "@/contexts/tasksContext";
+import { bulkCompleteTasksAPI, logTasksAPI } from "@/api/task";
+import { runEndOfDaySubmission } from "@/utils/endOfDay";
+import { showToast } from "@/utils/showToast";
+import type { Task } from "@/api/types";
+
+interface OpenTaskRowProps {
+    task: Task;
+    checked: boolean;
+    onToggle: () => void;
+}
+
+function OpenTaskRow({ task, checked, onToggle }: OpenTaskRowProps) {
+    const ThemedColor = useThemeColor();
+    return (
+        <TouchableOpacity style={styles.row} onPress={onToggle} activeOpacity={0.7}>
+            {checked ? (
+                <CheckCircleIcon size={24} weight="fill" color={ThemedColor.primary} />
+            ) : (
+                <CircleIcon size={24} color={ThemedColor.caption} />
+            )}
+            <View style={styles.rowText}>
+                <ThemedText type="default" numberOfLines={1}>
+                    {task.content}
+                </ThemedText>
+                {task.categoryName ? (
+                    <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                        {task.categoryName}
+                    </ThemedText>
+                ) : null}
+            </View>
+        </TouchableOpacity>
+    );
+}
+
+interface PendingEntryRowProps {
+    content: string;
+    onRemove: () => void;
+}
+
+function PendingEntryRow({ content, onRemove }: PendingEntryRowProps) {
+    const ThemedColor = useThemeColor();
+    return (
+        <View style={styles.row}>
+            <CheckCircleIcon size={24} weight="fill" color={ThemedColor.success ?? ThemedColor.primary} />
+            <View style={styles.rowText}>
+                <ThemedText type="default" numberOfLines={1}>
+                    {content}
+                </ThemedText>
+            </View>
+            <TouchableOpacity onPress={onRemove} hitSlop={8}>
+                <XCircleIcon size={22} color={ThemedColor.caption} />
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+interface Props {
+    visible: boolean;
+    setVisible: (visible: boolean) => void;
+    openTasks: Task[];
+    onLogged: () => void;
+}
+
+export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, onLogged }: Props) {
+    const ThemedColor = useThemeColor();
+    const queryClient = useQueryClient();
+    const { workspaces, selected, removeFromCategory, fetchWorkspaces } = useTasks();
+
+    const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+    const [entries, setEntries] = useState<string[]>([]);
+    const [draft, setDraft] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    const workspaceName = selected || workspaces.find((ws) => !ws.isBlueprint)?.name || workspaces[0]?.name;
+
+    const toggleTask = (taskId: string) => {
+        setCheckedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(taskId)) next.delete(taskId);
+            else next.add(taskId);
+            return next;
+        });
+    };
+
+    const addEntry = () => {
+        const content = draft.trim();
+        if (!content) return;
+        setEntries((prev) => [...prev, content]);
+        setDraft("");
+    };
+
+    const removeEntry = (index: number) => {
+        setEntries((prev) => prev.filter((_, i) => i !== index));
+    };
+
+    const canSubmit = !submitting && (checkedIds.size > 0 || entries.length > 0 || draft.trim().length > 0);
+
+    const handleSubmit = async () => {
+        // Pull in an un-added draft so "type and hit Log" works without tapping +.
+        const pendingEntries = draft.trim() ? [...entries, draft.trim()] : entries;
+        const checkedTasks = openTasks.filter((t) => t.id && checkedIds.has(t.id));
+
+        setSubmitting(true);
+        try {
+            const result = await runEndOfDaySubmission(checkedTasks, pendingEntries, workspaceName, {
+                bulkComplete: bulkCompleteTasksAPI,
+                logTasks: logTasksAPI,
+            });
+
+            result.confirmedCompletions.forEach(({ taskId, categoryId }) => removeFromCategory(categoryId, taskId));
+            setEntries(result.remainingEntries);
+            setDraft("");
+            if (result.loggedCount > 0) fetchWorkspaces(true);
+            queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
+
+            const total = result.completedCount + result.loggedCount;
+            if (result.failedCount > 0) {
+                showToast(`${total} logged, ${result.failedCount} failed — try those again`, "warning");
+            } else {
+                showToast(`Nice — ${total} task${total === 1 ? "" : "s"} logged for today`, "success");
+                onLogged();
+                setVisible(false);
+            }
+        } catch (error) {
+            console.error("End of day review failed:", error);
+            showToast("Couldn't log your day. Please try again.", "danger");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <DefaultModal visible={visible} setVisible={setVisible}>
+            <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+                <ThemedText type="fancyFrauncesHeading" style={styles.heading}>
+                    How did today go?
+                </ThemedText>
+
+                {openTasks.length > 0 && (
+                    <View style={styles.section}>
+                        <ThemedText type="defaultSemiBold">Did you finish these?</ThemedText>
+                        {openTasks.map((t) => (
+                            <OpenTaskRow
+                                key={t.id}
+                                task={t}
+                                checked={checkedIds.has(t.id)}
+                                onToggle={() => toggleTask(t.id)}
+                            />
+                        ))}
+                    </View>
+                )}
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Anything else you got done?</ThemedText>
+                    {entries.map((content, index) => (
+                        <PendingEntryRow key={`${content}-${index}`} content={content} onRemove={() => removeEntry(index)} />
+                    ))}
+                    <View style={styles.inputRow}>
+                        <TextInput
+                            style={[styles.input, { color: ThemedColor.text, borderColor: ThemedColor.tertiary }]}
+                            placeholder="e.g. went to the gym"
+                            placeholderTextColor={ThemedColor.caption}
+                            value={draft}
+                            onChangeText={setDraft}
+                            onSubmitEditing={addEntry}
+                            returnKeyType="done"
+                            submitBehavior="submit"
+                        />
+                        <TouchableOpacity onPress={addEntry} hitSlop={8}>
+                            <PlusCircleIcon size={28} color={ThemedColor.primary} />
+                        </TouchableOpacity>
+                    </View>
+                </View>
+
+                <PrimaryButton title={submitting ? "Logging…" : "Log my day"} onPress={handleSubmit} disabled={!canSubmit} />
+            </ScrollView>
+        </DefaultModal>
+    );
+}
+
+const styles = StyleSheet.create({
+    heading: {
+        marginBottom: 16,
+    },
+    section: {
+        marginBottom: 24,
+        gap: 8,
+    },
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        paddingVertical: 8,
+    },
+    rowText: {
+        flex: 1,
+        gap: 2,
+    },
+    inputRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        marginTop: 4,
+    },
+    input: {
+        flex: 1,
+        borderWidth: 1,
+        borderRadius: 12,
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+        fontFamily: "Outfit",
+        fontSize: 16,
+    },
+});
+```
+
+Adaptation notes for the implementer:
+- Check `ThemedColor` actually has `success`; if not, use `ThemedColor.primary` (the `?? ` fallback already handles it, but remove the dead reference if the type errors).
+- Check Phosphor icon names compile (`CheckCircleIcon`, `CircleIcon`, `PlusCircleIcon`, `XCircleIcon` from `phosphor-react-native`); the codebase already imports `HeartStraightIcon` in feed.tsx, so the `*Icon` naming is right.
+- Check `showToast`'s accepted statuses (`grep -rn "showToast(" frontend/ | head`); if `"warning"` isn't supported, use `"info"` or `"danger"`.
+- If `TextInput`'s `submitBehavior` prop isn't in this RN version, use `blurOnSubmit={false}`.
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun x tsc --noEmit 2>&1 | grep "EndOfDayReviewSheet" | head; echo "checked"
+```
+
+Expected: no output before "checked".
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/components/modals/EndOfDayReviewSheet.tsx
+git commit -m "feat(eod): EndOfDayReviewSheet — bulk check-off plus quick-log entries"
+```
+
+---
+
+### Task 7: Frontend — `EndOfDayCard` + feed wiring
+
+**Files:**
+- Create: `frontend/components/cards/EndOfDayCard.tsx`
+- Modify: `frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx` (import + one element in `renderHeader`)
+
+- [ ] **Step 1: Write the card**
+
+Create `frontend/components/cards/EndOfDayCard.tsx`. The card self-manages visibility (renders `null` outside the window or once dismissed), so the feed only mounts it unconditionally.
+
+```tsx
+import React, { useMemo, useState } from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+import { MoonStarsIcon, XIcon } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTasks } from "@/contexts/tasksContext";
+import { useEndOfDayCard } from "@/hooks/useEndOfDayCard";
+import { todaysOpenTasks } from "@/utils/endOfDay";
+import EndOfDayReviewSheet from "@/components/modals/EndOfDayReviewSheet";
+
+export default function EndOfDayCard() {
+    const { visible, dismiss } = useEndOfDayCard();
+    const { allTasks } = useTasks();
+    const [sheetVisible, setSheetVisible] = useState(false);
+    const ThemedColor = useThemeColor();
+
+    const openTasks = useMemo(() => todaysOpenTasks(allTasks), [allTasks]);
+
+    if (!visible) return null;
+
+    const subtitle =
+        openTasks.length > 0
+            ? `You have ${openTasks.length} open task${openTasks.length === 1 ? "" : "s"} from today — check off what you finished and add anything else you got done.`
+            : "Add anything you got done today, even if you never tracked it.";
+
+    return (
+        <View style={[styles.card, { backgroundColor: ThemedColor.lightenedCard, borderColor: ThemedColor.tertiary }]}>
+            <View style={styles.headerRow}>
+                <MoonStarsIcon size={24} weight="duotone" color={ThemedColor.primary} />
+                <TouchableOpacity onPress={dismiss} hitSlop={8}>
+                    <XIcon size={20} color={ThemedColor.caption} />
+                </TouchableOpacity>
+            </View>
+            <ThemedText type="fancyFrauncesHeading">How did today go?</ThemedText>
+            <ThemedText type="lightBody" style={{ color: ThemedColor.caption }}>
+                {subtitle}
+            </ThemedText>
+            <PrimaryButton title="Log my day" onPress={() => setSheetVisible(true)} />
+            <EndOfDayReviewSheet
+                visible={sheetVisible}
+                setVisible={setSheetVisible}
+                openTasks={openTasks}
+                onLogged={dismiss}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    card: {
+        marginHorizontal: 16,
+        marginTop: 16,
+        padding: 20,
+        borderRadius: 16,
+        borderWidth: 1,
+        gap: 12,
+        alignItems: "flex-start",
+    },
+    headerRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignSelf: "stretch",
+        alignItems: "center",
+    },
+});
+```
+
+Adaptation notes: verify `ThemedColor.lightenedCard` exists (it's used in `CompletedTasksBottomSheetModal`); verify `MoonStarsIcon` exists in phosphor-react-native (fallback: `MoonIcon`). Check `ThemedText` `type="fancyFrauncesHeading"` renders at a sensible card size — if it's too large, use `type="subtitle"`... but prefer the Fraunces semantic type per design preferences.
+
+- [ ] **Step 2: Wire into the feed header**
+
+In `frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx`:
+
+Add the import with the other card imports (near `import RingsClosedFeedCard ...`):
+
+```tsx
+import EndOfDayCard from "@/components/cards/EndOfDayCard";
+```
+
+In `renderHeader` (the `ListHeaderComponent`), add `<EndOfDayCard />` as the last child of the `listHeader` View, after the closing `</View>` of `feedTabsContainer`:
+
+```tsx
+    const renderHeader = useCallback(() => {
+        return (
+            <View style={styles.listHeader}>
+                <View style={styles.headerContainer}>
+                    {/* ...unchanged... */}
+                </View>
+
+                <View style={styles.feedTabsContainer}>
+                    {/* ...unchanged... */}
+                </View>
+
+                <EndOfDayCard />
+            </View>
+        );
+    }, [ThemedColor.text, router, availableFeeds, renderFeedTab]);
+```
+
+(Only the `<EndOfDayCard />` line is new; the card pins to the top of the feed because the header renders above all feed items. No `FeedItem` type, keyExtractor, or data changes needed. The card has `marginTop`; if it visually collides with the header's bottom border, add `paddingBottom: 16` to the card's wrapper via the existing `listHeader` style — implementer's judgment, keep it left-aligned.)
+
+- [ ] **Step 3: Verify compile + full frontend test suite**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun x tsc --noEmit 2>&1 | grep -E "EndOfDayCard|feed.tsx" | head; echo "checked"
+bun run test 2>&1 | tail -6
+```
+
+Expected: no new type errors; test summary shows the SAME 4 pre-existing failing suites only (AboutScreen, dragHitTest, KudosItem, UserInfoEncouragementNotification) and `endOfDay.test.ts` passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/cards/EndOfDayCard.tsx "frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx"
+git commit -m "feat(eod): end-of-day review card pinned to feed header after 8pm"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Backend full test run**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/backend
+go build ./... && go vet ./internal/handlers/task/ && go test ./internal/handlers/task/ 2>&1 | tail -3
+```
+
+Expected: build + vet clean, `ok ... internal/handlers/task`.
+
+- [ ] **Step 2: Frontend full test run + lint**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card/frontend
+bun run test 2>&1 | grep -E "^(Tests|Test Suites):"
+bun run lint 2>&1 | tail -5
+```
+
+Expected: exactly 4 failing suites (the pre-existing baseline), everything else passing including `endOfDay.test.ts`; lint introduces no new errors on the new files.
+
+- [ ] **Step 3: Re-verify generated API artifacts are committed**
+
+```bash
+cd /Users/abhik.ray/Kindred/.claude/worktrees/end-of-day-review-card
+git status --short
+```
+
+Expected: clean tree. If `frontend/api/api-spec.yaml` or `generated/types.ts` show as modified, `make generate-api` produced drift — commit it with `chore: regenerate api types`.
+
+- [ ] **Step 4: Final commit check**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: the spec/plan docs commits plus one commit per task above.

--- a/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
+++ b/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
@@ -1,0 +1,162 @@
+# End-of-Day Review Card — Design
+
+**Date:** 2026-06-10
+**Status:** Approved (brainstormed with Abhik)
+
+## Problem
+
+Kindred's feedback loop (rings, streak) only rewards work that goes through the app. Users
+do things all day that were never logged, so their rings under-represent the day and the
+loop weakens exactly when it should reward them. There are two miss cases:
+
+1. **Forgot to check off** — the task existed, the user did it, never tapped complete.
+2. **Never logged** — the work was real but no task was ever created.
+
+## Solution
+
+An **End-of-Day Review card** pinned to the top of the home feed from **20:00 to 23:59
+local time**. Tapping it opens a bottom sheet where the user can, in one pass:
+
+- check off today's still-open tasks (bulk complete), and
+- quick-log untracked things they did (each becomes a created-and-completed task).
+
+Dismissing the card or finishing the review hides it for the rest of the day; it returns
+the next evening.
+
+### Product decisions (settled)
+
+| Decision | Choice |
+| --- | --- |
+| Card scope | Day review: check-off existing + quick-log new |
+| Ring credit for quick-logged tasks | Both rings (Plan on create, Do on complete) — same as normal tasks |
+| Category for quick-logged tasks | Auto find-or-create a **"Logged"** category in the active workspace |
+| Future categorization | Gemini auto-tagging replaces "Logged" later, inside the log endpoint only |
+| Trigger | Fixed 20:00–23:59, no setting |
+| Dismissal | Per-day AsyncStorage key; reset at local midnight |
+| Backdating `timeCompleted` | Out of scope — completions stamp "now" |
+
+## Backend
+
+### New operation: `POST /v1/user/tasks/log`
+
+Lives in `backend/internal/handlers/task/` alongside `BulkCompleteTask`.
+
+**Input body** (`LogTasksInputBody` — name must not collide with types in other handler
+packages; verify with `make generate-api`):
+
+```json
+{
+  "workspaceId": "<id>",
+  "tasks": [{ "content": "gym" }, { "content": "called mom" }]
+}
+```
+
+- `workspaceId` required (categories are workspace-scoped; server must know where the
+  Logged category lives).
+- `tasks`: 1–50 entries; `content` non-empty after trim.
+
+**Behavior:**
+
+1. Find a category named `Logged` in the given workspace owned by the user; create it if
+   absent.
+2. For each entry: create a task (defaults matching the app's quick-create form: priority
+   1, value 1, `public` false, `active` true), then immediately complete it the same way
+   `CompleteTask` does — `timeCompleted = now`, moved to the `CompletedTasks` collection.
+3. Ring increments fire per task (Plan on create, Do on complete) using the same
+   fire-and-forget goroutine pattern as `BulkCompleteTask`. No special-casing — "both
+   rings" falls out of reusing the normal paths.
+4. Streak updates as in `CompleteTask`/`BulkCompleteTask`.
+
+**Output body** (`LogTasksOutputBody`):
+
+```json
+{
+  "message": "...",
+  "tasksLogged": 4,
+  "currentStreak": 7,
+  "failedIndices": [2]
+}
+```
+
+Partial failure: validate everything up front (count, non-empty content); per-entry
+runtime failures are collected into `failedIndices` and do not abort the batch.
+
+## Frontend
+
+### Visibility: `useEndOfDayCard` hook
+
+`frontend/hooks/useEndOfDayCard.ts`
+
+- `visible === true` when local hour ≥ 20 **and** AsyncStorage key
+  `eod-dismissed-<YYYY-MM-DD>` (local date) is unset.
+- `dismiss()` writes the key; used by both the card's ✕ and successful review completion.
+- Card shows even when there are zero open tasks (quick-log is still valid).
+- Recheck on app foreground/focus so the card appears if the app was open across 20:00.
+
+### Card: `EndOfDayCard`
+
+`frontend/components/cards/EndOfDayCard.tsx`
+
+- Prepended as a new typed feed item in `feed.tsx`'s `renderFeedItem` (same pattern as
+  `RingsClosedFeedCard`), pinned at top while visible.
+- Compact, left-aligned: Fraunces heading ("How did today go?"), Outfit subtitle with
+  open-task count, CTA button, dismiss ✕. Phosphor icons, ThemedText semantic types, no
+  hardcoded fontFamily. No "streak" wording in copy.
+
+### Sheet: `EndOfDayReviewSheet`
+
+`frontend/components/modals/EndOfDayReviewSheet.tsx` (bottom sheet — not inline feed
+expansion; text inputs inside FlashList cells fight keyboard avoidance and recycling).
+
+- **Section A — "Did you finish these?"** Today's open tasks (due today + start today +
+  overdue, via existing `useDailyTasks` filters) as multi-select check rows. Tasks come
+  from all workspaces' categories (`workspaces.flatMap(ws => ws.categories)`), not just
+  the selected workspace.
+- **Section B — "Anything else you got done?"** Text input; submit adds a row to a local
+  pending list; rows are removable.
+- **Footer — "Log my day"** (disabled when nothing selected and no entries):
+  1. `bulkCompleteTasksAPI(items)` → existing `POST /v1/user/tasks/bulk/complete` for
+     checked tasks.
+  2. `logTasksAPI(workspaceId, entries)` → new `POST /v1/user/tasks/log` for typed
+     entries.
+  3. **Not optimistic**: await both, then `removeFromCategory` for each confirmed
+     completion, invalidate `["rings", "today"]`, refetch workspaces (so the new Logged
+     category appears), show the existing completion toast, `dismiss()` the card, close
+     the sheet.
+
+### API wrappers
+
+`frontend/api/task.ts`: add `bulkCompleteTasksAPI` (if not already exposed) and
+`logTasksAPI`, typed from regenerated OpenAPI types (`bun run generate-types` after
+backend `make generate-api`).
+
+## Errors & edge cases
+
+- **Partial failure**: toast "N logged, M failed"; failed quick-log entries remain in the
+  sheet for retry; only server-confirmed completions are removed from local state.
+- **Both calls fail**: standard error toast; sheet stays open; card not dismissed.
+- **Empty state**: zero open tasks → Section A hidden, sheet is quick-log only.
+- **Time**: all checks use device-local time; dismissal key uses local date, so the card
+  naturally returns the next evening. Window ends at midnight by construction (hour ≥ 20
+  on the new date is false until that evening).
+
+## Testing
+
+- **Backend** (`task` handler tests): Logged category created once and reused on second
+  call; tasks end up in `CompletedTasks` with `timeCompleted` set; validation rejects
+  empty content / >50 entries; output shape. Run `make generate-api` to catch Huma
+  duplicate-type-name panics.
+- **Frontend** (jest): `useEndOfDayCard` — hidden before 20:00, visible after, dismissal
+  persists for the day and resets on date change (mock Date + AsyncStorage). Sheet submit
+  logic with mocked APIs: bulk-complete + log called with right payloads; failed entries
+  retained. Mock `react-native-worklets` and `react-native-reanimated` if the sheet pulls
+  them in.
+- Pre-existing failing suites on main (AboutScreen, dragHitTest, KudosItem,
+  UserInfoEncouragementNotification) are the baseline and out of scope.
+
+## Out of scope (v1)
+
+- Backdating completion times.
+- Configurable trigger hour.
+- Gemini auto-categorization (future change inside the log endpoint only).
+- Recap-post sharing / day-review screen (possible v2 if the card earns usage).

--- a/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
+++ b/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
@@ -41,18 +41,19 @@ the next evening.
 
 Lives in `backend/internal/handlers/task/` alongside `BulkCompleteTask`.
 
-**Input body** (`LogTasksInputBody` — name must not collide with types in other handler
-packages; verify with `make generate-api`):
+**Input body** (types must not collide with names in other handler packages; verify with
+`make generate-api`):
 
 ```json
 {
-  "workspaceId": "<id>",
+  "workspaceName": "Personal",
   "tasks": [{ "content": "gym" }, { "content": "called mom" }]
 }
 ```
 
-- `workspaceId` required (categories are workspace-scoped; server must know where the
-  Logged category lives).
+- `workspaceName` required — workspaces are identified by name in this codebase (categories
+  carry a `workspaceName` string; there is no workspace ID). The server must know where
+  the Logged category lives.
 - `tasks`: 1–50 entries; `content` non-empty after trim.
 
 **Behavior:**

--- a/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
+++ b/docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md
@@ -118,7 +118,7 @@ expansion; text inputs inside FlashList cells fight keyboard avoidance and recyc
 - **Footer — "Log my day"** (disabled when nothing selected and no entries):
   1. `bulkCompleteTasksAPI(items)` → existing `POST /v1/user/tasks/bulk/complete` for
      checked tasks.
-  2. `logTasksAPI(workspaceId, entries)` → new `POST /v1/user/tasks/log` for typed
+  2. `logTasksAPI(workspaceName, entries)` → new `POST /v1/user/tasks/log` for typed
      entries.
   3. **Not optimistic**: await both, then `removeFromCategory` for each confirmed
      completion, invalidate `["rings", "today"]`, refetch workspaces (so the new Logged

--- a/frontend/__tests__/endOfDay.test.ts
+++ b/frontend/__tests__/endOfDay.test.ts
@@ -1,0 +1,117 @@
+import {
+    END_OF_DAY_HOUR,
+    endOfDayDismissKey,
+    isEndOfDayWindow,
+    todaysOpenTasks,
+    runEndOfDaySubmission,
+} from "@/utils/endOfDay";
+import { Task } from "@/api/types";
+
+const task = (over: Partial<Task>): Task =>
+    ({ id: "t", content: "", priority: 1, value: 1, categoryID: "cat-1", ...(over as any) }) as Task;
+
+describe("isEndOfDayWindow", () => {
+    it("is false before the trigger hour", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR - 1, 59))).toBe(false);
+    });
+
+    it("is true from the trigger hour until midnight", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR, 0))).toBe(true);
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, 23, 59))).toBe(true);
+    });
+
+    it("resets after midnight", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 11, 0, 1))).toBe(false);
+    });
+});
+
+describe("endOfDayDismissKey", () => {
+    it("encodes the local date", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 10, 21, 0))).toBe("eod-dismissed-2026-06-10");
+    });
+
+    it("differs across days so the card returns the next evening", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 10))).not.toBe(endOfDayDismissKey(new Date(2026, 5, 11)));
+    });
+});
+
+describe("todaysOpenTasks", () => {
+    const now = new Date(2026, 5, 10, 20, 30);
+
+    it("includes tasks starting today, due today, and overdue", () => {
+        const tasks = [
+            task({ id: "starts-today", startDate: new Date(2026, 5, 10, 9).toISOString() }),
+            task({ id: "due-today", deadline: new Date(2026, 5, 10, 22).toISOString() }),
+            task({ id: "overdue", deadline: new Date(2026, 5, 8).toISOString() }),
+            task({ id: "future", startDate: new Date(2026, 5, 12).toISOString() }),
+        ];
+        expect(todaysOpenTasks(tasks, now).map((t) => t.id)).toEqual(["starts-today", "due-today", "overdue"]);
+    });
+
+    it("dedupes a task that both starts and is due today", () => {
+        const both = task({
+            id: "both",
+            startDate: new Date(2026, 5, 10, 9).toISOString(),
+            deadline: new Date(2026, 5, 10, 22).toISOString(),
+        });
+        expect(todaysOpenTasks([both], now)).toHaveLength(1);
+    });
+
+    it("excludes synthetic upcoming categories (not real, not completable)", () => {
+        const synthetic = task({
+            id: "synth",
+            categoryID: "upcoming-Personal",
+            startDate: new Date(2026, 5, 10).toISOString(),
+        });
+        expect(todaysOpenTasks([synthetic], now)).toHaveLength(0);
+    });
+});
+
+describe("runEndOfDaySubmission", () => {
+    const checked = [task({ id: "t1", categoryID: "c1" }), task({ id: "t2", categoryID: "c2" })];
+
+    it("bulk-completes checked tasks and logs entries with the right payloads", async () => {
+        const bulkComplete = jest.fn().mockResolvedValue({ totalCompleted: 2, totalFailed: 0, failedTaskIds: [] });
+        const logTasks = jest.fn().mockResolvedValue({ tasksLogged: 1, currentStreak: 3 });
+
+        const result = await runEndOfDaySubmission(checked, ["gym"], "Personal", { bulkComplete, logTasks });
+
+        expect(bulkComplete).toHaveBeenCalledWith([
+            { taskId: "t1", categoryId: "c1" },
+            { taskId: "t2", categoryId: "c2" },
+        ]);
+        expect(logTasks).toHaveBeenCalledWith("Personal", ["gym"]);
+        expect(result).toEqual({
+            completedCount: 2,
+            loggedCount: 1,
+            failedCount: 0,
+            confirmedCompletions: [
+                { taskId: "t1", categoryId: "c1" },
+                { taskId: "t2", categoryId: "c2" },
+            ],
+            remainingEntries: [],
+        });
+    });
+
+    it("keeps failed entries and excludes failed completions from confirmations", async () => {
+        const bulkComplete = jest.fn().mockResolvedValue({ totalCompleted: 1, totalFailed: 1, failedTaskIds: ["t2"] });
+        const logTasks = jest.fn().mockResolvedValue({ tasksLogged: 1, currentStreak: 3, failedIndices: [0] });
+
+        const result = await runEndOfDaySubmission(checked, ["a", "b"], "Personal", { bulkComplete, logTasks });
+
+        expect(result.confirmedCompletions).toEqual([{ taskId: "t1", categoryId: "c1" }]);
+        expect(result.remainingEntries).toEqual(["a"]);
+        expect(result.failedCount).toBe(2);
+    });
+
+    it("skips the APIs entirely for empty inputs", async () => {
+        const bulkComplete = jest.fn();
+        const logTasks = jest.fn();
+
+        const result = await runEndOfDaySubmission([], [], "Personal", { bulkComplete, logTasks });
+
+        expect(bulkComplete).not.toHaveBeenCalled();
+        expect(logTasks).not.toHaveBeenCalled();
+        expect(result.failedCount).toBe(0);
+    });
+});

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -5948,6 +5948,38 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tasks/log:
+        post:
+            tags:
+                - tasks
+            summary: Log completed tasks
+            description: Create and immediately complete tasks in the workspace's Logged category. Used by the end-of-day review card for work that was done but never tracked.
+            operationId: log-tasks
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/LogTasksInputBody'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/LogTasksOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/tasks/natural-language:
         post:
             tags:
@@ -10635,6 +10667,80 @@ components:
                         $ref: '#/components/schemas/CalendarInfo'
             required:
                 - calendars
+        LogTaskEntry:
+            type: object
+            additionalProperties: false
+            properties:
+                content:
+                    type: string
+                    description: What the user got done
+                    examples:
+                        - Went to the gym
+            required:
+                - content
+        LogTasksInputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/LogTasksInputBody.json
+                    readOnly: true
+                tasks:
+                    type: array
+                    description: Things the user did today
+                    items:
+                        $ref: '#/components/schemas/LogTaskEntry'
+                    minItems: 1
+                    maxItems: 50
+                workspaceName:
+                    type: string
+                    description: Workspace whose Logged category receives the tasks
+                    examples:
+                        - Personal
+            required:
+                - workspaceName
+                - tasks
+        LogTasksOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/LogTasksOutputBody.json
+                    readOnly: true
+                currentStreak:
+                    type: integer
+                    description: The user's current streak count
+                    format: int64
+                    examples:
+                        - 5
+                failedIndices:
+                    type: array
+                    description: Indices of entries that failed
+                    items:
+                        type: integer
+                        format: int64
+                message:
+                    type: string
+                    examples:
+                        - Tasks logged
+                tasksLogged:
+                    type: integer
+                    description: Number of entries created and completed
+                    format: int64
+                    examples:
+                        - 3
+            required:
+                - message
+                - tasksLogged
+                - currentStreak
         LoginRequest:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -2856,6 +2856,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/tasks/log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Log completed tasks
+         * @description Create and immediately complete tasks in the workspace's Logged category. Used by the end-of-day review card for work that was done but never tracked.
+         */
+        post: operations["log-tasks"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/tasks/natural-language": {
         parameters: {
             query?: never;
@@ -5643,6 +5663,52 @@ export interface components {
              */
             readonly $schema?: string;
             calendars: components["schemas"]["CalendarInfo"][];
+        };
+        LogTaskEntry: {
+            /**
+             * @description What the user got done
+             * @example Went to the gym
+             */
+            content: string;
+        };
+        LogTasksInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/LogTasksInputBody.json
+             */
+            readonly $schema?: string;
+            /** @description Things the user did today */
+            tasks: components["schemas"]["LogTaskEntry"][];
+            /**
+             * @description Workspace whose Logged category receives the tasks
+             * @example Personal
+             */
+            workspaceName: string;
+        };
+        LogTasksOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/LogTasksOutputBody.json
+             */
+            readonly $schema?: string;
+            /**
+             * Format: int64
+             * @description The user's current streak count
+             * @example 5
+             */
+            currentStreak: number;
+            /** @description Indices of entries that failed */
+            failedIndices?: number[];
+            /** @example Tasks logged */
+            message: string;
+            /**
+             * Format: int64
+             * @description Number of entries created and completed
+             * @example 3
+             */
+            tasksLogged: number;
         };
         LoginRequest: {
             /**
@@ -13374,6 +13440,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["GetCompletedTasksByDateOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "log-tasks": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["LogTasksInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["LogTasksOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/api/task.ts
+++ b/frontend/api/task.ts
@@ -164,6 +164,66 @@ export const markAsCompletedAPI = async (
     return data as unknown as TaskCompletionResult;
 };
 
+export interface LogTasksResult {
+    message: string;
+    tasksLogged: number;
+    currentStreak: number;
+    failedIndices?: number[];
+}
+
+/**
+ * Log untracked work: creates + completes one task per entry in the
+ * workspace's "Logged" category (end-of-day review card).
+ */
+export const logTasksAPI = async (workspaceName: string, contents: string[]): Promise<LogTasksResult> => {
+    const { data, error } = await client.POST("/v1/user/tasks/log", {
+        params: withAuthHeaders({}),
+        body: { workspaceName, tasks: contents.map((content) => ({ content })) },
+    });
+
+    if (error) {
+        throw new Error(`Failed to log tasks: ${JSON.stringify(error)}`);
+    }
+
+    return data as unknown as LogTasksResult;
+};
+
+export interface BulkCompleteItem {
+    taskId: string;
+    categoryId: string;
+}
+
+export interface BulkCompleteResult {
+    message: string;
+    totalCompleted: number;
+    totalFailed: number;
+    currentStreak: number;
+    failedTaskIds?: string[];
+}
+
+/**
+ * Complete several existing tasks in one request.
+ */
+export const bulkCompleteTasksAPI = async (items: BulkCompleteItem[]): Promise<BulkCompleteResult> => {
+    const timeCompleted = new Date().toISOString();
+    const { data, error } = await client.POST("/v1/user/tasks/bulk/complete", {
+        params: withAuthHeaders({}),
+        body: {
+            tasks: items.map(({ taskId, categoryId }) => ({
+                taskId,
+                categoryId,
+                completeData: { timeCompleted, timeTaken: "PT0S" },
+            })),
+        },
+    });
+
+    if (error) {
+        throw new Error(`Failed to bulk complete tasks: ${JSON.stringify(error)}`);
+    }
+
+    return data as unknown as BulkCompleteResult;
+};
+
 /**
  * Activate/deactivate a task
  * API: Makes POST request to change task active status

--- a/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed)/feed.tsx
@@ -10,6 +10,7 @@ import type { PostKudos } from "@/api/types";
 import ReportedPostCard from "@/components/cards/ReportedPostCard";
 import TaskFeedCard from "@/components/cards/TaskFeedCard";
 import RingsClosedFeedCard from "@/components/cards/RingsClosedFeedCard";
+import EndOfDayCard from "@/components/cards/EndOfDayCard";
 import { Icons } from "@/constants/Icons";
 import { Ionicons } from "@expo/vector-icons";
 import { ThemedText } from "@/components/ThemedText";
@@ -618,6 +619,8 @@ export default function Feed() {
                         />
                     </View>
                 </View>
+
+                <EndOfDayCard />
             </View>
         );
     }, [ThemedColor.text, router, availableFeeds, renderFeedTab]);

--- a/frontend/components/cards/EndOfDayCard.tsx
+++ b/frontend/components/cards/EndOfDayCard.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo, useState } from "react";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
+import { MoonStarsIcon, XIcon } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTasks } from "@/contexts/tasksContext";
+import { useEndOfDayCard } from "@/hooks/useEndOfDayCard";
+import { todaysOpenTasks } from "@/utils/endOfDay";
+import EndOfDayReviewSheet from "@/components/modals/EndOfDayReviewSheet";
+
+export default function EndOfDayCard() {
+    const { visible, dismiss } = useEndOfDayCard();
+    const { allTasks } = useTasks();
+    const [sheetVisible, setSheetVisible] = useState(false);
+    const ThemedColor = useThemeColor();
+
+    const openTasks = useMemo(() => todaysOpenTasks(allTasks), [allTasks]);
+
+    if (!visible) return null;
+
+    const subtitle =
+        openTasks.length > 0
+            ? `You have ${openTasks.length} open task${openTasks.length === 1 ? "" : "s"} from today — check off what you finished and add anything else you got done.`
+            : "Add anything you got done today, even if you never tracked it.";
+
+    return (
+        <View style={[styles.card, { backgroundColor: ThemedColor.lightenedCard, borderColor: ThemedColor.tertiary }]}>
+            <View style={styles.headerRow}>
+                <MoonStarsIcon size={24} weight="duotone" color={ThemedColor.primary} />
+                <TouchableOpacity onPress={dismiss} hitSlop={8}>
+                    <XIcon size={20} color={ThemedColor.caption} />
+                </TouchableOpacity>
+            </View>
+            <ThemedText type="fancyFrauncesHeading">How did today go?</ThemedText>
+            <ThemedText type="lightBody" style={{ color: ThemedColor.caption }}>
+                {subtitle}
+            </ThemedText>
+            <PrimaryButton title="Log my day" onPress={() => setSheetVisible(true)} />
+            <EndOfDayReviewSheet
+                visible={sheetVisible}
+                setVisible={setSheetVisible}
+                openTasks={openTasks}
+                onLogged={dismiss}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    card: {
+        marginHorizontal: 16,
+        marginVertical: 16,
+        padding: 20,
+        borderRadius: 16,
+        borderWidth: 1,
+        gap: 12,
+        alignItems: "flex-start",
+    },
+    headerRow: {
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignSelf: "stretch",
+        alignItems: "center",
+    },
+});

--- a/frontend/components/modals/EndOfDayReviewSheet.tsx
+++ b/frontend/components/modals/EndOfDayReviewSheet.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from "react";
+import { ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
+import { CheckCircleIcon, CircleIcon, PlusCircleIcon, XCircleIcon } from "phosphor-react-native";
+import { useQueryClient } from "@tanstack/react-query";
+import DefaultModal from "./DefaultModal";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTasks } from "@/contexts/tasksContext";
+import { bulkCompleteTasksAPI, logTasksAPI } from "@/api/task";
+import { runEndOfDaySubmission } from "@/utils/endOfDay";
+import { showToast } from "@/utils/showToast";
+import type { Task } from "@/api/types";
+
+interface OpenTaskRowProps {
+    task: Task;
+    checked: boolean;
+    onToggle: () => void;
+}
+
+function OpenTaskRow({ task, checked, onToggle }: OpenTaskRowProps) {
+    const ThemedColor = useThemeColor();
+    return (
+        <TouchableOpacity style={styles.row} onPress={onToggle} activeOpacity={0.7}>
+            {checked ? (
+                <CheckCircleIcon size={24} weight="fill" color={ThemedColor.primary} />
+            ) : (
+                <CircleIcon size={24} color={ThemedColor.caption} />
+            )}
+            <View style={styles.rowText}>
+                <ThemedText type="default" numberOfLines={1}>
+                    {task.content}
+                </ThemedText>
+                {task.categoryName ? (
+                    <ThemedText type="caption" style={{ color: ThemedColor.caption }}>
+                        {task.categoryName}
+                    </ThemedText>
+                ) : null}
+            </View>
+        </TouchableOpacity>
+    );
+}
+
+interface PendingEntryRowProps {
+    content: string;
+    onRemove: () => void;
+}
+
+function PendingEntryRow({ content, onRemove }: PendingEntryRowProps) {
+    const ThemedColor = useThemeColor();
+    return (
+        <View style={styles.row}>
+            <CheckCircleIcon size={24} weight="fill" color={ThemedColor.success} />
+            <View style={styles.rowText}>
+                <ThemedText type="default" numberOfLines={1}>
+                    {content}
+                </ThemedText>
+            </View>
+            <TouchableOpacity onPress={onRemove} hitSlop={8}>
+                <XCircleIcon size={22} color={ThemedColor.caption} />
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+interface Props {
+    visible: boolean;
+    setVisible: (visible: boolean) => void;
+    openTasks: Task[];
+    onLogged: () => void;
+}
+
+export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, onLogged }: Props) {
+    const ThemedColor = useThemeColor();
+    const queryClient = useQueryClient();
+    const { workspaces, selected, removeFromCategory, fetchWorkspaces } = useTasks();
+
+    const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
+    const [entries, setEntries] = useState<string[]>([]);
+    const [draft, setDraft] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    const workspaceName = selected || workspaces.find((ws) => !ws.isBlueprint)?.name || workspaces[0]?.name;
+
+    const toggleTask = (taskId: string) => {
+        setCheckedIds((prev) => {
+            const next = new Set(prev);
+            if (next.has(taskId)) next.delete(taskId);
+            else next.add(taskId);
+            return next;
+        });
+    };
+
+    const addEntry = () => {
+        const content = draft.trim();
+        if (!content) return;
+        setEntries((prev) => [...prev, content]);
+        setDraft("");
+    };
+
+    const removeEntry = (index: number) => {
+        setEntries((prev) => prev.filter((_, i) => i !== index));
+    };
+
+    const canSubmit = !submitting && (checkedIds.size > 0 || entries.length > 0 || draft.trim().length > 0);
+
+    const handleSubmit = async () => {
+        // Pull in an un-added draft so "type and hit Log" works without tapping +.
+        const pendingEntries = draft.trim() ? [...entries, draft.trim()] : entries;
+        const checkedTasks = openTasks.filter((t) => t.id && checkedIds.has(t.id));
+
+        setSubmitting(true);
+        try {
+            const result = await runEndOfDaySubmission(checkedTasks, pendingEntries, workspaceName, {
+                bulkComplete: bulkCompleteTasksAPI,
+                logTasks: logTasksAPI,
+            });
+
+            result.confirmedCompletions.forEach(({ taskId, categoryId }) => removeFromCategory(categoryId, taskId));
+            setEntries(result.remainingEntries);
+            setDraft("");
+            if (result.loggedCount > 0) fetchWorkspaces(true);
+            queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
+
+            const total = result.completedCount + result.loggedCount;
+            if (result.failedCount > 0) {
+                showToast(`${total} logged, ${result.failedCount} failed — try those again`, "warning");
+            } else {
+                showToast(`Nice — ${total} task${total === 1 ? "" : "s"} logged for today`, "success");
+                onLogged();
+                setVisible(false);
+            }
+        } catch (error) {
+            console.error("End of day review failed:", error);
+            showToast("Couldn't log your day. Please try again.", "danger");
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <DefaultModal visible={visible} setVisible={setVisible}>
+            <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+                <ThemedText type="fancyFrauncesHeading" style={styles.heading}>
+                    How did today go?
+                </ThemedText>
+
+                {openTasks.length > 0 && (
+                    <View style={styles.section}>
+                        <ThemedText type="defaultSemiBold">Did you finish these?</ThemedText>
+                        {openTasks.map((t) => (
+                            <OpenTaskRow
+                                key={t.id}
+                                task={t}
+                                checked={checkedIds.has(t.id)}
+                                onToggle={() => toggleTask(t.id)}
+                            />
+                        ))}
+                    </View>
+                )}
+
+                <View style={styles.section}>
+                    <ThemedText type="defaultSemiBold">Anything else you got done?</ThemedText>
+                    {entries.map((content, index) => (
+                        <PendingEntryRow
+                            key={`${content}-${index}`}
+                            content={content}
+                            onRemove={() => removeEntry(index)}
+                        />
+                    ))}
+                    <View style={styles.inputRow}>
+                        <TextInput
+                            style={[styles.input, { color: ThemedColor.text, borderColor: ThemedColor.tertiary }]}
+                            placeholder="e.g. went to the gym"
+                            placeholderTextColor={ThemedColor.caption}
+                            value={draft}
+                            onChangeText={setDraft}
+                            onSubmitEditing={addEntry}
+                            returnKeyType="done"
+                            submitBehavior="submit"
+                        />
+                        <TouchableOpacity onPress={addEntry} hitSlop={8}>
+                            <PlusCircleIcon size={28} color={ThemedColor.primary} />
+                        </TouchableOpacity>
+                    </View>
+                </View>
+
+                <PrimaryButton
+                    title={submitting ? "Logging…" : "Log my day"}
+                    onPress={handleSubmit}
+                    disabled={!canSubmit}
+                />
+            </ScrollView>
+        </DefaultModal>
+    );
+}
+
+const styles = StyleSheet.create({
+    heading: {
+        marginBottom: 16,
+    },
+    section: {
+        marginBottom: 24,
+        gap: 8,
+    },
+    row: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        paddingVertical: 8,
+    },
+    rowText: {
+        flex: 1,
+        gap: 2,
+    },
+    inputRow: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 12,
+        marginTop: 4,
+    },
+    input: {
+        flex: 1,
+        borderWidth: 1,
+        borderRadius: 12,
+        paddingHorizontal: 12,
+        paddingVertical: 10,
+        fontFamily: "Outfit",
+        fontSize: 16,
+    },
+});

--- a/frontend/hooks/useEndOfDayCard.ts
+++ b/frontend/hooks/useEndOfDayCard.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { endOfDayDismissKey, isEndOfDayWindow } from "@/utils/endOfDay";
+
+/**
+ * Card is visible from END_OF_DAY_HOUR until local midnight, unless dismissed
+ * (or the review was completed) today. Re-checks every minute so the card
+ * appears if the app stays open across the trigger hour.
+ */
+export const useEndOfDayCard = () => {
+    // Start hidden until storage answers, so the card never flashes.
+    const [dismissedToday, setDismissedToday] = useState(true);
+    const [inWindow, setInWindow] = useState(() => isEndOfDayWindow(new Date()));
+
+    useEffect(() => {
+        let cancelled = false;
+        const check = async () => {
+            const now = new Date();
+            const stored = await AsyncStorage.getItem(endOfDayDismissKey(now));
+            if (cancelled) return;
+            setInWindow(isEndOfDayWindow(now));
+            setDismissedToday(stored != null);
+        };
+        check();
+        const interval = setInterval(check, 60_000);
+        return () => {
+            cancelled = true;
+            clearInterval(interval);
+        };
+    }, []);
+
+    const dismiss = useCallback(() => {
+        setDismissedToday(true);
+        AsyncStorage.setItem(endOfDayDismissKey(new Date()), "1").catch(() => {});
+    }, []);
+
+    return { visible: inWindow && !dismissedToday, dismiss };
+};

--- a/frontend/utils/endOfDay.ts
+++ b/frontend/utils/endOfDay.ts
@@ -1,0 +1,85 @@
+import { isSameDay, startOfDay } from "date-fns";
+import type { Task } from "@/api/types";
+import type { BulkCompleteResult, LogTasksResult } from "@/api/task";
+
+export const END_OF_DAY_HOUR = 20;
+
+export function isEndOfDayWindow(now: Date): boolean {
+    return now.getHours() >= END_OF_DAY_HOUR;
+}
+
+export function endOfDayDismissKey(now: Date): string {
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `eod-dismissed-${now.getFullYear()}-${month}-${day}`;
+}
+
+// Open tasks worth reviewing tonight: starting today, due today, or overdue.
+// Synthetic "Upcoming" categories aren't real categories and can't be completed.
+export function todaysOpenTasks(allTasks: Task[], now: Date = new Date()): Task[] {
+    const seen = new Set<string>();
+    const result: Task[] = [];
+    for (const t of allTasks) {
+        if (!t.id || seen.has(t.id)) continue;
+        if (t.categoryID?.startsWith("upcoming-")) continue;
+
+        const startsToday = t.startDate ? isSameDay(new Date(t.startDate), now) : false;
+        const dueToday = t.deadline ? isSameDay(new Date(t.deadline), now) : false;
+        const overdue = t.deadline ? startOfDay(new Date(t.deadline)) < startOfDay(now) : false;
+
+        if (startsToday || dueToday || overdue) {
+            seen.add(t.id);
+            result.push(t);
+        }
+    }
+    return result;
+}
+
+export interface EndOfDaySubmissionDeps {
+    bulkComplete: (items: { taskId: string; categoryId: string }[]) => Promise<BulkCompleteResult>;
+    logTasks: (workspaceName: string, contents: string[]) => Promise<LogTasksResult>;
+}
+
+export interface EndOfDaySubmissionResult {
+    completedCount: number;
+    loggedCount: number;
+    failedCount: number;
+    confirmedCompletions: { taskId: string; categoryId: string }[];
+    remainingEntries: string[];
+}
+
+// The sheet's submit step, kept pure (deps injected) so it's unit-testable
+// without rendering the gorhom bottom sheet.
+export async function runEndOfDaySubmission(
+    checkedTasks: Task[],
+    entries: string[],
+    workspaceName: string | undefined,
+    deps: EndOfDaySubmissionDeps
+): Promise<EndOfDaySubmissionResult> {
+    let completedCount = 0;
+    let loggedCount = 0;
+    let failedCount = 0;
+    const confirmedCompletions: { taskId: string; categoryId: string }[] = [];
+    // Entries are only cleared once the log call confirms them.
+    let remainingEntries: string[] = entries;
+
+    if (checkedTasks.length > 0) {
+        const res = await deps.bulkComplete(checkedTasks.map((t) => ({ taskId: t.id, categoryId: t.categoryID! })));
+        const failed = new Set(res.failedTaskIds ?? []);
+        for (const t of checkedTasks) {
+            if (!failed.has(t.id)) confirmedCompletions.push({ taskId: t.id, categoryId: t.categoryID! });
+        }
+        completedCount = res.totalCompleted;
+        failedCount += res.totalFailed;
+    }
+
+    if (entries.length > 0 && workspaceName) {
+        const res = await deps.logTasks(workspaceName, entries);
+        loggedCount = res.tasksLogged;
+        const failedIdx = new Set(res.failedIndices ?? []);
+        failedCount += failedIdx.size;
+        remainingEntries = entries.filter((_, i) => failedIdx.has(i));
+    }
+
+    return { completedCount, loggedCount, failedCount, confirmedCompletions, remainingEntries };
+}


### PR DESCRIPTION
## Summary
- New **end-of-day review card** pinned to the top of the home feed from 8pm–midnight (local), dismissible per day via AsyncStorage; returns the next evening
- Tapping it opens a bottom sheet to **check off today's open tasks** (existing bulk-complete endpoint) and **quick-log untracked work** — each entry is created + completed in one go
- New backend endpoint **`POST /v1/user/tasks/log`**: find-or-creates a per-workspace **"Logged"** category (atomic upsert), then reuses the standard create → complete → delete path per entry so completed-tasks records, streaks, and lifetime counts behave exactly like normal completions; Plan + Do rings increment per logged task (future home for Gemini auto-categorization)
- Partial failures are surfaced (`failedIndices` / `failedTaskIds`): confirmed completions are removed locally, failed quick-log entries stay in the sheet for retry

Design spec: `docs/superpowers/specs/2026-06-10-end-of-day-review-card-design.md`
Implementation plan: `docs/superpowers/plans/2026-06-10-end-of-day-review-card.md`

## Test Plan
- [x] Backend: 3 new suite tests for `LogTasks` (Logged category created once and reused, tasks land in `completed-tasks` with timestamps, per-workspace separation); full task package passes
- [x] `make generate-api` runs clean (no Huma type collisions); spec + frontend types regenerated and committed
- [x] Frontend: 11 new jest tests for the pure helpers (time window, dismissal key, today's-open-tasks filter, submission runner incl. partial-failure retention); suite at exact pre-existing baseline (4 known failing suites on main, no new failures)
- [x] `tsc --noEmit` clean for all new/modified files
- [ ] Manual: open the app after 8pm → card appears at top of feed; complete a review → card gone until tomorrow; check Logged category and rings update

Note: `go vet` warnings (`reminder.go`, `task_service.go`) and the `expo lint` crash are pre-existing on `main` — verified, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)