### PR TITLE
feat: tag friends in tasks

### DIFF
--- a/backend/internal/handlers/notifications/types.go
+++ b/backend/internal/handlers/notifications/types.go
@@ -30,6 +30,8 @@ const (
 	NotificationTypePost                  NotificationType = "POST"
 	NotificationTypeRingsClosed           NotificationType = "RINGS_CLOSED"
 	NotificationTypePostTag               NotificationType = "POST_TAG"
+	NotificationTypeTaskTagged            NotificationType = "TASK_TAGGED"
+	NotificationTypeTaskCopied            NotificationType = "TASK_COPIED"
 )
 
 // NotificationDocument represents a notification stored in the database

--- a/backend/internal/handlers/task/flex_service.go
+++ b/backend/internal/handlers/task/flex_service.go
@@ -24,6 +24,7 @@ func (s *Service) createFlexTemplateForTask(
 	recurDetails *RecurDetails,
 	notes string,
 	checklist []ChecklistItem,
+	taggedUsers []TaggedTaskUser,
 ) error {
 	flex := recurDetails.Flex
 
@@ -52,6 +53,7 @@ func (s *Service) createFlexTemplateForTask(
 		NextGenerated:  &now,
 		Notes:          notes,
 		Checklist:      checklist,
+		TaggedUsers:    taggedUsers,
 		FlexState: &FlexTemplateState{
 			Target:            flex.Target,
 			Period:            flex.Period,

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -57,4 +57,5 @@ func RegisterTaskOperations(api huma.API, handler *Handler) {
 	RegisterGetUserTemplatesOperation(api, handler)
 	RegisterGetCompletedTasksOperation(api, handler)
 	RegisterGetCompletedTasksByDateOperation(api, handler)
+	RegisterUpdateTaskTagsOperation(api, handler)
 }

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -59,4 +59,5 @@ func RegisterTaskOperations(api huma.API, handler *Handler) {
 	RegisterGetCompletedTasksByDateOperation(api, handler)
 	RegisterUpdateTaskTagsOperation(api, handler)
 	RegisterGetPendingTaggedTasksOperation(api, handler)
+	RegisterRespondToTaskTagOperation(api, handler)
 }

--- a/backend/internal/handlers/task/routes.go
+++ b/backend/internal/handlers/task/routes.go
@@ -58,4 +58,5 @@ func RegisterTaskOperations(api huma.API, handler *Handler) {
 	RegisterGetCompletedTasksOperation(api, handler)
 	RegisterGetCompletedTasksByDateOperation(api, handler)
 	RegisterUpdateTaskTagsOperation(api, handler)
+	RegisterGetPendingTaggedTasksOperation(api, handler)
 }

--- a/backend/internal/handlers/task/service_test.go
+++ b/backend/internal/handlers/task/service_test.go
@@ -385,6 +385,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_WindowType_WeeklyTuesda
 		nil,        // reminders
 		"",         // notes
 		nil,        // checklist
+		nil,        // taggedUsers
 	)
 
 	s.NoError(err, "Creating a WINDOW-type recurring task should succeed")
@@ -1025,7 +1026,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_Weekly_CreatesCorr
 			Behavior: "ROLLING",
 			Flex:     &FlexDetails{Target: 3, Period: "weekly"},
 		},
-		nil, nil, nil, nil, "", nil,
+		nil, nil, nil, nil, "", nil, nil,
 	)
 	s.NoError(err)
 
@@ -1070,7 +1071,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_Daily_CreatesCorre
 		&RecurDetails{
 			Flex: &FlexDetails{Target: 2, Period: "daily"},
 		},
-		nil, nil, nil, nil, "", nil,
+		nil, nil, nil, nil, "", nil, nil,
 	)
 	s.NoError(err)
 
@@ -1112,7 +1113,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_Monthly_CreatesCor
 		&RecurDetails{
 			Flex: &FlexDetails{Target: 5, Period: "monthly"},
 		},
-		nil, nil, nil, nil, "some notes", nil,
+		nil, nil, nil, nil, "some notes", nil, nil,
 	)
 	s.NoError(err)
 
@@ -1155,7 +1156,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_InvalidPeriod_Retu
 		&RecurDetails{
 			Flex: &FlexDetails{Target: 3, Period: "biweekly"},
 		},
-		nil, nil, nil, nil, "", nil,
+		nil, nil, nil, nil, "", nil, nil,
 	)
 	s.Error(err, "Invalid flex period should return an error")
 }
@@ -1187,7 +1188,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_ZeroTarget_Returns
 		&RecurDetails{
 			Flex: &FlexDetails{Target: 0, Period: "weekly"},
 		},
-		nil, nil, nil, nil, "", nil,
+		nil, nil, nil, nil, "", nil, nil,
 	)
 	s.Error(err, "Zero target flex should return an error")
 }
@@ -1222,7 +1223,7 @@ func (s *TaskServiceTestSuite) TestCreateTemplateForTask_Flex_DoesNotPanic_WithN
 			&RecurDetails{
 				Flex: &FlexDetails{Target: 4, Period: "weekly"},
 			},
-			nil, nil, nil, nil, "", nil,
+			nil, nil, nil, nil, "", nil, nil,
 		)
 	}, "Creating a flex template should not panic even without DaysOfWeek")
 }

--- a/backend/internal/handlers/task/tag_notifications.go
+++ b/backend/internal/handlers/task/tag_notifications.go
@@ -1,0 +1,59 @@
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/abhikaboy/Kindred/xutils"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// NotifyTaggedUsers sends a push + creates a TASK_TAGGED notification record
+// for every pending tagged user on the task. Best-effort: failures are logged,
+// never returned, so they can't fail task creation.
+func (s *Service) NotifyTaggedUsers(task *TaskDocument, taggerID primitive.ObjectID) {
+	ctx := context.Background()
+
+	tagger, err := s.Users.GetUserByID(ctx, taggerID)
+	if err != nil || tagger == nil {
+		slog.Error("NotifyTaggedUsers: failed to load tagger", "error", err)
+		return
+	}
+
+	for _, tu := range task.TaggedUsers {
+		if tu.Status != types.TagStatusPending {
+			continue
+		}
+
+		// DB record (drives the activity tab)
+		content := fmt.Sprintf("tagged you in \"%s\"", task.Content)
+		if err := s.NotificationService.CreateNotification(
+			taggerID, tu.ID, content, notifications.NotificationTypeTaskTagged, task.ID,
+		); err != nil {
+			slog.Error("Failed to create TASK_TAGGED record", "receiver", tu.ID, "error", err)
+		}
+
+		// Push
+		receiver, err := s.Users.GetUserByID(ctx, tu.ID)
+		if err != nil || receiver == nil || receiver.PushToken == "" {
+			continue
+		}
+		notification := xutils.Notification{
+			Token:   receiver.PushToken,
+			Title:   "You've been tagged",
+			Message: fmt.Sprintf("%s tagged you in \"%s\"", tagger.DisplayName, task.Content),
+			Data: map[string]string{
+				"type":      "task_tagged",
+				"task_id":   task.ID.Hex(),
+				"user_id":   taggerID.Hex(),
+				"task_name": task.Content,
+			},
+		}
+		if err := xutils.SendNotification(notification); err != nil {
+			slog.Error("Failed to send task_tagged push", "receiver", tu.ID, "error", err)
+		}
+	}
+}

--- a/backend/internal/handlers/task/tag_notifications.go
+++ b/backend/internal/handlers/task/tag_notifications.go
@@ -58,6 +58,42 @@ func (s *Service) NotifyTaggedUsers(task *TaskDocument, taggerID primitive.Objec
 	}
 }
 
+// NotifyTagWatchersOfCompletion pushes to every tagged user still in pending
+// or watching state. Push-only by design (spec: completion is a ping, not an
+// activity-feed event). copied/untagged users are never pinged.
+func (s *Service) NotifyTagWatchersOfCompletion(task *TaskDocument, ownerID primitive.ObjectID) error {
+	ctx := context.Background()
+
+	owner, err := s.Users.GetUserByID(ctx, ownerID)
+	if err != nil || owner == nil {
+		return err
+	}
+
+	for _, tu := range task.TaggedUsers {
+		if tu.Status != types.TagStatusPending && tu.Status != types.TagStatusWatching {
+			continue
+		}
+		receiver, err := s.Users.GetUserByID(ctx, tu.ID)
+		if err != nil || receiver == nil || receiver.PushToken == "" {
+			continue
+		}
+		notification := xutils.Notification{
+			Token:   receiver.PushToken,
+			Title:   "They did it! 🎉",
+			Message: fmt.Sprintf("%s completed \"%s\" 🎉", owner.DisplayName, task.Content),
+			Data: map[string]string{
+				"type":    "task_completed_watcher",
+				"user_id": ownerID.Hex(),
+				"task_id": task.ID.Hex(),
+			},
+		}
+		if err := xutils.SendNotification(notification); err != nil {
+			slog.Error("Failed to send watcher completion push", "receiver", tu.ID, "error", err)
+		}
+	}
+	return nil
+}
+
 // notifyTaskCopied tells the task owner that a tagged friend copied the task.
 // Push + TASK_COPIED record; best-effort.
 func (s *Service) notifyTaskCopied(taskID, ownerID, copierID primitive.ObjectID, taskName string) {

--- a/backend/internal/handlers/task/tag_notifications.go
+++ b/backend/internal/handlers/task/tag_notifications.go
@@ -43,7 +43,7 @@ func (s *Service) NotifyTaggedUsers(task *TaskDocument, taggerID primitive.Objec
 		}
 		notification := xutils.Notification{
 			Token:   receiver.PushToken,
-			Title:   "You've been tagged",
+			Title:   "You've been tagged 👀",
 			Message: fmt.Sprintf("%s tagged you in \"%s\"", tagger.DisplayName, task.Content),
 			Data: map[string]string{
 				"type":      "task_tagged",

--- a/backend/internal/handlers/task/tag_notifications.go
+++ b/backend/internal/handlers/task/tag_notifications.go
@@ -57,3 +57,36 @@ func (s *Service) NotifyTaggedUsers(task *TaskDocument, taggerID primitive.Objec
 		}
 	}
 }
+
+// notifyTaskCopied tells the task owner that a tagged friend copied the task.
+// Push + TASK_COPIED record; best-effort.
+func (s *Service) notifyTaskCopied(taskID, ownerID, copierID primitive.ObjectID, taskName string) {
+	ctx := context.Background()
+
+	copier, err := s.Users.GetUserByID(ctx, copierID)
+	if err != nil || copier == nil {
+		return
+	}
+
+	content := fmt.Sprintf("copied your task \"%s\" 💪", taskName)
+	if err := s.NotificationService.CreateNotification(
+		copierID, ownerID, content, notifications.NotificationTypeTaskCopied, taskID,
+	); err != nil {
+		slog.Error("Failed to create TASK_COPIED record", "owner", ownerID, "error", err)
+	}
+
+	owner, err := s.Users.GetUserByID(ctx, ownerID)
+	if err != nil || owner == nil || owner.PushToken == "" {
+		return
+	}
+	_ = xutils.SendNotification(xutils.Notification{
+		Token:   owner.PushToken,
+		Title:   "Your task caught on 💪",
+		Message: fmt.Sprintf("%s copied your task \"%s\"", copier.DisplayName, taskName),
+		Data: map[string]string{
+			"type":    "task_copied",
+			"task_id": taskID.Hex(),
+			"user_id": copierID.Hex(),
+		},
+	})
+}

--- a/backend/internal/handlers/task/tag_operations.go
+++ b/backend/internal/handlers/task/tag_operations.go
@@ -94,3 +94,39 @@ func RegisterUpdateTaskTagsOperation(api huma.API, handler *Handler) {
 		Tags:        []string{"tasks"},
 	}, handler.UpdateTaskTags)
 }
+
+type GetPendingTaggedTasksInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+}
+
+type GetPendingTaggedTasksOutput struct {
+	Body []PendingTaggedTask `json:"body"`
+}
+
+func (h *Handler) GetPendingTaggedTasks(ctx context.Context, input *GetPendingTaggedTasksInput) (*GetPendingTaggedTasksOutput, error) {
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	pending, err := h.service.GetPendingTaggedTasks(userObjID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to fetch pending tags", err)
+	}
+	return &GetPendingTaggedTasksOutput{Body: pending}, nil
+}
+
+func RegisterGetPendingTaggedTasksOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-pending-tagged-tasks",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/tagged-tasks",
+		Summary:     "Get pending tagged tasks",
+		Description: "Tasks the signed-in user has been tagged in and not yet responded to",
+		Tags:        []string{"tasks"},
+	}, handler.GetPendingTaggedTasks)
+}

--- a/backend/internal/handlers/task/tag_operations.go
+++ b/backend/internal/handlers/task/tag_operations.go
@@ -2,12 +2,15 @@ package task
 
 import (
 	"context"
+	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/danielgtaylor/huma/v2"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type UpdateTaskTagsInput struct {
@@ -45,15 +48,22 @@ func (h *Handler) UpdateTaskTags(ctx context.Context, input *UpdateTaskTagsInput
 
 	added, err := h.service.UpdateTaskTags(userObjID, categoryID, taskID, input.Body.TaggedUserIDs)
 	if err != nil {
-		return nil, huma.Error500InternalServerError("Unable to update tags", err)
-	}
-
-	// Notify only newly added friends (best-effort)
-	if len(added) > 0 {
-		if task, err := h.service.findTaskInCategory(ctx, categoryID, taskID); err == nil {
-			notifyTask := *task
-			notifyTask.TaggedUsers = added
-			go h.service.NotifyTaggedUsers(&notifyTask, userObjID)
+		switch {
+		case errors.Is(err, ErrTaskNotFound):
+			return nil, huma.Error404NotFound("Task not found in this category", err)
+		// verifyCategoryOwnership returns raw mongo.ErrNoDocuments when the
+		// category is missing or not owned by the caller — treat as 404
+		case errors.Is(err, ErrCategoryNotFound), errors.Is(err, mongo.ErrNoDocuments):
+			return nil, huma.Error404NotFound("Category not found", err)
+		case errors.Is(err, ErrNotCategoryOwner):
+			return nil, huma.Error403Forbidden("You do not have access to this category", err)
+		default:
+			slog.Error("Failed to update task tags",
+				"taskId", taskID.Hex(),
+				"categoryId", categoryID.Hex(),
+				"userId", userObjID.Hex(),
+				"error", err)
+			return nil, huma.Error500InternalServerError("Unable to update tags", err)
 		}
 	}
 
@@ -61,6 +71,14 @@ func (h *Handler) UpdateTaskTags(ctx context.Context, input *UpdateTaskTagsInput
 	if err != nil {
 		return nil, huma.Error500InternalServerError("Unable to fetch updated task", err)
 	}
+
+	// Notify only newly added friends (best-effort)
+	if len(added) > 0 {
+		notifyTask := *task
+		notifyTask.TaggedUsers = added
+		go h.service.NotifyTaggedUsers(&notifyTask, userObjID)
+	}
+
 	resp := &UpdateTaskTagsOutput{}
 	resp.Body.TaggedUsers = task.TaggedUsers
 	return resp, nil

--- a/backend/internal/handlers/task/tag_operations.go
+++ b/backend/internal/handlers/task/tag_operations.go
@@ -130,3 +130,72 @@ func RegisterGetPendingTaggedTasksOperation(api huma.API, handler *Handler) {
 		Tags:        []string{"tasks"},
 	}, handler.GetPendingTaggedTasks)
 }
+
+type RespondToTaskTagInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          struct {
+		Status string `json:"status" enum:"watching,copied,untagged"`
+	} `json:"body"`
+}
+
+type RespondToTaskTagOutput struct {
+	Body struct {
+		Message string `json:"message" example:"Response recorded"`
+	} `json:"body"`
+}
+
+func (h *Handler) RespondToTaskTag(ctx context.Context, input *RespondToTaskTagInput) (*RespondToTaskTagOutput, error) {
+	taskID, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid task ID format", err)
+	}
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	responderID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	// Validate status at handler level (huma enum is schema-level defense; this is defense-in-depth)
+	status := types.TagStatus(input.Body.Status)
+	if status != types.TagStatusWatching && status != types.TagStatusCopied && status != types.TagStatusUntagged {
+		return nil, huma.Error400BadRequest("Status must be one of: watching, copied, untagged", nil)
+	}
+
+	if err := h.service.RespondToTaskTag(taskID, responderID, status); err != nil {
+		switch {
+		case errors.Is(err, mongo.ErrNoDocuments):
+			return nil, huma.Error404NotFound("Task not found", err)
+		default:
+			slog.Error("Failed to respond to task tag",
+				"taskId", taskID.Hex(),
+				"responderId", responderID.Hex(),
+				"error", err)
+			return nil, huma.Error500InternalServerError("Unable to record response", err)
+		}
+	}
+
+	if status == types.TagStatusCopied {
+		if task, ownerID := h.service.lookupTaskAndOwner(taskID); task != nil {
+			go h.service.notifyTaskCopied(taskID, ownerID, responderID, task.Content)
+		}
+	}
+
+	resp := &RespondToTaskTagOutput{}
+	resp.Body.Message = "Response recorded"
+	return resp, nil
+}
+
+func RegisterRespondToTaskTagOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "respond-to-task-tag",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/tagged-tasks/{id}/respond",
+		Summary:     "Respond to a task tag",
+		Description: "Watch, copy, or untag yourself from a task you were tagged in",
+		Tags:        []string{"tasks"},
+	}, handler.RespondToTaskTag)
+}

--- a/backend/internal/handlers/task/tag_operations.go
+++ b/backend/internal/handlers/task/tag_operations.go
@@ -1,0 +1,78 @@
+package task
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type UpdateTaskTagsInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Category      string `path:"category" example:"507f1f77bcf86cd799439011"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          struct {
+		TaggedUserIDs []string `json:"taggedUserIds"`
+	}
+}
+
+type UpdateTaskTagsOutput struct {
+	Body struct {
+		TaggedUsers []types.TaggedTaskUser `json:"taggedUsers"`
+	}
+}
+
+func (h *Handler) UpdateTaskTags(ctx context.Context, input *UpdateTaskTagsInput) (*UpdateTaskTagsOutput, error) {
+	taskID, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid task ID format", err)
+	}
+	categoryID, err := primitive.ObjectIDFromHex(input.Category)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid category ID format", err)
+	}
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	added, err := h.service.UpdateTaskTags(userObjID, categoryID, taskID, input.Body.TaggedUserIDs)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to update tags", err)
+	}
+
+	// Notify only newly added friends (best-effort)
+	if len(added) > 0 {
+		if task, err := h.service.findTaskInCategory(ctx, categoryID, taskID); err == nil {
+			notifyTask := *task
+			notifyTask.TaggedUsers = added
+			go h.service.NotifyTaggedUsers(&notifyTask, userObjID)
+		}
+	}
+
+	task, err := h.service.findTaskInCategory(ctx, categoryID, taskID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to fetch updated task", err)
+	}
+	resp := &UpdateTaskTagsOutput{}
+	resp.Body.TaggedUsers = task.TaggedUsers
+	return resp, nil
+}
+
+func RegisterUpdateTaskTagsOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "update-task-tags",
+		Method:      http.MethodPatch,
+		Path:        "/v1/user/tasks/{category}/{id}/tags",
+		Summary:     "Update task tags",
+		Description: "Replace the set of friends tagged on a task",
+		Tags:        []string{"tasks"},
+	}, handler.UpdateTaskTags)
+}

--- a/backend/internal/handlers/task/tag_operations.go
+++ b/backend/internal/handlers/task/tag_operations.go
@@ -178,12 +178,6 @@ func (h *Handler) RespondToTaskTag(ctx context.Context, input *RespondToTaskTagI
 		}
 	}
 
-	if status == types.TagStatusCopied {
-		if task, ownerID := h.service.lookupTaskAndOwner(taskID); task != nil {
-			go h.service.notifyTaskCopied(taskID, ownerID, responderID, task.Content)
-		}
-	}
-
 	resp := &RespondToTaskTagOutput{}
 	resp.Body.Message = "Response recorded"
 	return resp, nil

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -3,11 +3,37 @@ package task
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// TaggerInfo carries the denormalized display fields of the user who tagged a task.
+type TaggerInfo struct {
+	ID             primitive.ObjectID `bson:"id" json:"id"`
+	DisplayName    string             `bson:"display_name" json:"display_name"`
+	Handle         string             `bson:"handle" json:"handle"`
+	ProfilePicture string             `bson:"profile_picture" json:"profile_picture"`
+}
+
+// PendingTaggedTask carries everything the home banner and the Copy prefill
+// need in one payload.
+type PendingTaggedTask struct {
+	TaskID         primitive.ObjectID `bson:"taskId" json:"taskId"`
+	Content        string             `bson:"content" json:"content"`
+	Value          float64            `bson:"value" json:"value"`
+	Priority       int                `bson:"priority" json:"priority"`
+	Recurring      bool               `bson:"recurring" json:"recurring"`
+	RecurFrequency string             `bson:"recurFrequency,omitempty" json:"recurFrequency,omitempty"`
+	RecurDetails   *RecurDetails      `bson:"recurDetails,omitempty" json:"recurDetails,omitempty"`
+	Deadline       *time.Time         `bson:"deadline,omitempty" json:"deadline,omitempty"`
+	Notes          string             `bson:"notes,omitempty" json:"notes,omitempty"`
+	Checklist      []ChecklistItem    `bson:"checklist,omitempty" json:"checklist,omitempty"`
+	Tagger         TaggerInfo         `bson:"tagger" json:"tagger"`
+}
 
 // BuildTaggedUsers resolves raw user IDs to denormalized pending tag entries.
 // Invalid or unknown IDs are skipped rather than failing the whole create.
@@ -111,4 +137,52 @@ func (s *Service) UpdateTaskTags(
 	}
 
 	return added, nil
+}
+
+// GetPendingTaggedTasks returns every active task where userID is tagged with
+// status pending, joined with the tagger's display info.
+func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTaggedTask, error) {
+	ctx := context.Background()
+	elem := bson.M{"$elemMatch": bson.M{"id": userID, "status": types.TagStatusPending}}
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"tasks.taggedUsers": elem}}},
+		{{Key: "$unwind", Value: "$tasks"}},
+		{{Key: "$match", Value: bson.M{"tasks.taggedUsers": elem}}},
+		{{Key: "$lookup", Value: bson.M{
+			"from": "users", "localField": "user", "foreignField": "_id", "as": "taggerDoc",
+		}}},
+		{{Key: "$unwind", Value: "$taggerDoc"}},
+		{{Key: "$project", Value: bson.M{
+			"taskId":         "$tasks._id",
+			"content":        "$tasks.content",
+			"value":          "$tasks.value",
+			"priority":       "$tasks.priority",
+			"recurring":      "$tasks.recurring",
+			"recurFrequency": "$tasks.recurFrequency",
+			"recurDetails":   "$tasks.recurDetails",
+			"deadline":       "$tasks.deadline",
+			"notes":          "$tasks.notes",
+			"checklist":      "$tasks.checklist",
+			"tagger": bson.M{
+				"id":              "$taggerDoc._id",
+				"display_name":    "$taggerDoc.display_name",
+				"handle":          "$taggerDoc.handle",
+				"profile_picture": "$taggerDoc.profile_picture",
+			},
+		}}},
+		{{Key: "$sort", Value: bson.M{"taskId": -1}}},
+	}
+
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	results := make([]PendingTaggedTask, 0)
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
 }

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -39,4 +40,75 @@ func (s *Service) BuildTaggedUsers(userIDs []string) ([]types.TaggedTaskUser, er
 		})
 	}
 	return tagged, nil
+}
+
+// UpdateTaskTags reconciles the task's tag list against the desired ID set.
+// Entries that already responded (watching/copied/untagged) are never removed
+// (removal-after-response is out of scope). Pending entries not in the new set
+// are dropped. New IDs are added as pending. Returns the newly added entries so
+// the handler can notify them. Mirrors the template when recurring.
+func (s *Service) UpdateTaskTags(
+	userID, categoryID, taskID primitive.ObjectID,
+	taggedUserIDs []string,
+) ([]types.TaggedTaskUser, error) {
+	ctx := context.Background()
+
+	if err := s.verifyCategoryOwnership(ctx, categoryID, userID); err != nil {
+		return nil, err
+	}
+	task, err := s.findTaskInCategory(ctx, categoryID, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	desired := make(map[primitive.ObjectID]bool, len(taggedUserIDs))
+	for _, raw := range taggedUserIDs {
+		if id, err := primitive.ObjectIDFromHex(raw); err == nil {
+			desired[id] = true
+		}
+	}
+
+	next := make([]types.TaggedTaskUser, 0, len(taggedUserIDs))
+	existing := make(map[primitive.ObjectID]bool)
+	for _, tu := range task.TaggedUsers {
+		// Responded entries always survive; pending survives only if still desired
+		if tu.Status != types.TagStatusPending || desired[tu.ID] {
+			next = append(next, tu)
+			existing[tu.ID] = true
+		}
+	}
+
+	newIDs := make([]string, 0)
+	for _, raw := range taggedUserIDs {
+		id, err := primitive.ObjectIDFromHex(raw)
+		if err != nil || existing[id] {
+			continue
+		}
+		newIDs = append(newIDs, raw)
+	}
+	added, err := s.BuildTaggedUsers(newIDs)
+	if err != nil {
+		return nil, err
+	}
+	next = append(next, added...)
+
+	_, err = s.Tasks.UpdateOne(ctx,
+		bson.M{"_id": categoryID, "tasks._id": taskID},
+		bson.M{"$set": bson.M{"tasks.$[t].taggedUsers": next}},
+		getTaskArrayFilterOptions(taskID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if task.TemplateID != nil {
+		if _, err := s.TemplateTasks.UpdateOne(ctx,
+			bson.M{"_id": *task.TemplateID},
+			bson.M{"$set": bson.M{"taggedUsers": next}},
+		); err != nil {
+			slog.Error("Failed to mirror tags to template", "templateID", task.TemplateID.Hex(), "error", err)
+		}
+	}
+
+	return added, nil
 }

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -203,9 +203,9 @@ func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, statu
 	}
 	ctx := context.Background()
 
-	task, ownerID := s.lookupTaskAndOwner(taskID)
-	if task == nil {
-		return mongo.ErrNoDocuments
+	task, ownerID, err := s.lookupTaskAndOwner(taskID)
+	if err != nil {
+		return err // mongo.ErrNoDocuments when the task doesn't exist
 	}
 	var prev types.TagStatus
 	found := false
@@ -258,9 +258,10 @@ func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, statu
 	return nil
 }
 
-// lookupTaskAndOwner fetches a task across all users' categories. Returns the
-// task and its owner's ID (zero ID when not found).
-func (s *Service) lookupTaskAndOwner(taskID primitive.ObjectID) (*TaskDocument, primitive.ObjectID) {
+// lookupTaskAndOwner fetches a task across all users' categories. Returns
+// mongo.ErrNoDocuments when the task doesn't exist; transient DB errors are
+// propagated so callers can map them to 500 rather than a misleading 404.
+func (s *Service) lookupTaskAndOwner(taskID primitive.ObjectID) (*TaskDocument, primitive.ObjectID, error) {
 	ctx := context.Background()
 	pipeline := append(
 		[]bson.D{{{Key: "$match", Value: bson.M{"tasks._id": taskID}}}},
@@ -269,12 +270,15 @@ func (s *Service) lookupTaskAndOwner(taskID primitive.ObjectID) (*TaskDocument, 
 	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"_id": taskID}}})
 	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
 	if err != nil {
-		return nil, primitive.NilObjectID
+		return nil, primitive.NilObjectID, err
 	}
 	defer cursor.Close(ctx)
 	var tasks []TaskDocument
-	if err := cursor.All(ctx, &tasks); err != nil || len(tasks) == 0 {
-		return nil, primitive.NilObjectID
+	if err := cursor.All(ctx, &tasks); err != nil {
+		return nil, primitive.NilObjectID, err
 	}
-	return &tasks[0], tasks[0].UserID
+	if len(tasks) == 0 {
+		return nil, primitive.NilObjectID, mongo.ErrNoDocuments
+	}
+	return &tasks[0], tasks[0].UserID, nil
 }

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -32,6 +32,7 @@ type PendingTaggedTask struct {
 	Deadline       *time.Time         `bson:"deadline,omitempty" json:"deadline,omitempty"`
 	Notes          string             `bson:"notes,omitempty" json:"notes,omitempty"`
 	Checklist      []ChecklistItem    `bson:"checklist,omitempty" json:"checklist,omitempty"`
+	Timestamp      time.Time          `bson:"timestamp" json:"timestamp"`
 	Tagger         TaggerInfo         `bson:"tagger" json:"tagger"`
 }
 
@@ -139,7 +140,7 @@ func (s *Service) UpdateTaskTags(
 	return added, nil
 }
 
-// GetPendingTaggedTasks returns every active task where userID is tagged with
+// GetPendingTaggedTasks returns every task where userID is tagged with
 // status pending, joined with the tagger's display info.
 func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTaggedTask, error) {
 	ctx := context.Background()
@@ -164,6 +165,7 @@ func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTag
 			"deadline":       "$tasks.deadline",
 			"notes":          "$tasks.notes",
 			"checklist":      "$tasks.checklist",
+			"timestamp":      "$tasks.timestamp",
 			"tagger": bson.M{
 				"id":              "$taggerDoc._id",
 				"display_name":    "$taggerDoc.display_name",
@@ -171,7 +173,7 @@ func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTag
 				"profile_picture": "$taggerDoc.profile_picture",
 			},
 		}}},
-		{{Key: "$sort", Value: bson.M{"taskId": -1}}},
+		{{Key: "$sort", Value: bson.M{"timestamp": -1}}},
 	}
 
 	cursor, err := s.Tasks.Aggregate(ctx, pipeline)

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 // TaggerInfo carries the denormalized display fields of the user who tagged a task.
@@ -187,4 +189,68 @@ func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTag
 		return nil, err
 	}
 	return results, nil
+}
+
+// RespondToTaskTag records the tagged user's response on the live task and
+// mirrors it to the template so future recurrences inherit it. The nested
+// array filter scopes the write to the responder's own entry, so a user can
+// never modify someone else's tag state.
+func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, status types.TagStatus) error {
+	if status != types.TagStatusWatching && status != types.TagStatusCopied && status != types.TagStatusUntagged {
+		return fmt.Errorf("invalid tag status: %q", status)
+	}
+	ctx := context.Background()
+
+	res, err := s.Tasks.UpdateOne(ctx,
+		bson.M{"tasks._id": taskID},
+		bson.M{"$set": bson.M{"tasks.$[t].taggedUsers.$[u].status": status}},
+		options.Update().SetArrayFilters(options.ArrayFilters{
+			Filters: bson.A{
+				bson.M{"t._id": taskID},
+				bson.M{"u.id": responderID},
+			},
+		}),
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+
+	// Mirror to template (cross-user fetch: responder doesn't own the category)
+	task, _ := s.lookupTaskAndOwner(taskID)
+	if task != nil && task.TemplateID != nil {
+		if _, err := s.TemplateTasks.UpdateOne(ctx,
+			bson.M{"_id": *task.TemplateID},
+			bson.M{"$set": bson.M{"taggedUsers.$[u].status": status}},
+			options.Update().SetArrayFilters(options.ArrayFilters{
+				Filters: bson.A{bson.M{"u.id": responderID}},
+			}),
+		); err != nil {
+			slog.Error("Failed to mirror tag response to template", "templateID", task.TemplateID.Hex(), "error", err)
+		}
+	}
+	return nil
+}
+
+// lookupTaskAndOwner fetches a task across all users' categories. Returns the
+// task and its owner's ID (zero ID when not found).
+func (s *Service) lookupTaskAndOwner(taskID primitive.ObjectID) (*TaskDocument, primitive.ObjectID) {
+	ctx := context.Background()
+	pipeline := append(
+		[]bson.D{{{Key: "$match", Value: bson.M{"tasks._id": taskID}}}},
+		getBaseTaskPipeline()...,
+	)
+	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"_id": taskID}}})
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, primitive.NilObjectID
+	}
+	defer cursor.Close(ctx)
+	var tasks []TaskDocument
+	if err := cursor.All(ctx, &tasks); err != nil || len(tasks) == 0 {
+		return nil, primitive.NilObjectID
+	}
+	return &tasks[0], tasks[0].UserID
 }

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -1,0 +1,42 @@
+package task
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// BuildTaggedUsers resolves raw user IDs to denormalized pending tag entries.
+// Invalid or unknown IDs are skipped rather than failing the whole create.
+func (s *Service) BuildTaggedUsers(userIDs []string) ([]types.TaggedTaskUser, error) {
+	ctx := context.Background()
+	tagged := make([]types.TaggedTaskUser, 0, len(userIDs))
+	seen := make(map[primitive.ObjectID]bool)
+
+	for _, raw := range userIDs {
+		id, err := primitive.ObjectIDFromHex(raw)
+		if err != nil {
+			slog.Warn("Skipping invalid tagged user ID", "id", raw)
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		user, err := s.Users.GetUserByID(ctx, id)
+		if err != nil || user == nil {
+			slog.Warn("Skipping unknown tagged user", "id", raw)
+			continue
+		}
+		seen[id] = true
+		tagged = append(tagged, types.TaggedTaskUser{
+			ID:             user.ID,
+			Handle:         user.Handle,
+			DisplayName:    user.DisplayName,
+			ProfilePicture: user.ProfilePicture,
+			Status:         types.TagStatusPending,
+		})
+	}
+	return tagged, nil
+}

--- a/backend/internal/handlers/task/tag_service.go
+++ b/backend/internal/handlers/task/tag_service.go
@@ -194,12 +194,33 @@ func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTag
 // RespondToTaskTag records the tagged user's response on the live task and
 // mirrors it to the template so future recurrences inherit it. The nested
 // array filter scopes the write to the responder's own entry, so a user can
-// never modify someone else's tag state.
+// never modify someone else's tag state. Read-then-write (accepted TOCTOU):
+// the pre-read gives a real 404 for non-tagged responders and makes copied
+// re-responds idempotent (no duplicate owner notification).
 func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, status types.TagStatus) error {
 	if status != types.TagStatusWatching && status != types.TagStatusCopied && status != types.TagStatusUntagged {
 		return fmt.Errorf("invalid tag status: %q", status)
 	}
 	ctx := context.Background()
+
+	task, ownerID := s.lookupTaskAndOwner(taskID)
+	if task == nil {
+		return mongo.ErrNoDocuments
+	}
+	var prev types.TagStatus
+	found := false
+	for _, tu := range task.TaggedUsers {
+		if tu.ID == responderID {
+			prev, found = tu.Status, true
+			break
+		}
+	}
+	if !found {
+		return mongo.ErrNoDocuments // task exists but responder isn't tagged
+	}
+	if prev == status {
+		return nil // idempotent re-respond: no write, no notification
+	}
 
 	res, err := s.Tasks.UpdateOne(ctx,
 		bson.M{"tasks._id": taskID},
@@ -218,9 +239,8 @@ func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, statu
 		return mongo.ErrNoDocuments
 	}
 
-	// Mirror to template (cross-user fetch: responder doesn't own the category)
-	task, _ := s.lookupTaskAndOwner(taskID)
-	if task != nil && task.TemplateID != nil {
+	// Mirror to template so future recurrences inherit the response
+	if task.TemplateID != nil {
 		if _, err := s.TemplateTasks.UpdateOne(ctx,
 			bson.M{"_id": *task.TemplateID},
 			bson.M{"$set": bson.M{"taggedUsers.$[u].status": status}},
@@ -230,6 +250,10 @@ func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, statu
 		); err != nil {
 			slog.Error("Failed to mirror tag response to template", "templateID", task.TemplateID.Hex(), "error", err)
 		}
+	}
+
+	if status == types.TagStatusCopied {
+		go s.notifyTaskCopied(taskID, ownerID, responderID, task.Content)
 	}
 	return nil
 }

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -582,3 +582,29 @@ func (s *TagServiceTestSuite) TestRespondToTaskTag_CopiedTwiceNotifiesOnce() {
 	s.Equal(int64(1), s.CountDocuments("notifications", filter),
 		"re-responding copied must not duplicate the TASK_COPIED notification")
 }
+
+func (s *TagServiceTestSuite) TestNotifyTagWatchersOfCompletion_OnlyPendingAndWatching() {
+	owner := s.GetUser(0)
+	watcher := s.GetUser(1)
+	copier := s.GetUser(2)
+
+	task := TaskDocument{
+		ID: primitive.NewObjectID(), Content: "Read 30 mins", UserID: owner.ID,
+		TaggedUsers: []types.TaggedTaskUser{
+			{ID: watcher.ID, Handle: watcher.Handle, DisplayName: watcher.DisplayName, Status: types.TagStatusWatching},
+			{ID: copier.ID, Handle: copier.Handle, DisplayName: copier.DisplayName, Status: types.TagStatusCopied},
+		},
+	}
+
+	err := s.service.NotifyTagWatchersOfCompletion(&task, owner.ID)
+	s.NoError(err)
+
+	// Exactly one push sent — to watcher, NOT copier
+	s.AssertPushNotificationSent(watcher.PushToken, "watcher should receive completion push")
+	s.AssertPushNotificationNotSent(copier.PushToken, "copier must not receive completion push")
+
+	// Push data must carry the correct type
+	notifications := s.GetSentPushNotificationsForToken(watcher.PushToken)
+	s.Len(notifications, 1)
+	s.Equal("task_completed_watcher", notifications[0].Data["type"])
+}

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -263,3 +263,97 @@ func (s *TagServiceTestSuite) TestUpdateTaskTags_RemovesPendingEntry() {
 	s.NoError(err)
 	s.Len(fetched.TaggedUsers, 0)
 }
+
+func (s *TagServiceTestSuite) TestUpdateTaskTags_RespondedUserResuppliedKeepsStatus() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	// Seed: A already responded (watching)
+	tagged, _ := s.service.BuildTaggedUsers([]string{friendA.ID.Hex()})
+	tagged[0].Status = types.TagStatusWatching
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "x",
+		Priority:    1,
+		Value:       1,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	// Re-supplying A must not duplicate the entry or reset it to pending
+	added, err := s.service.UpdateTaskTags(owner.ID, category.ID, created.ID, []string{friendA.ID.Hex()})
+	s.NoError(err)
+	s.Len(added, 0)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 1)
+	s.Equal(friendA.ID, fetched.TaggedUsers[0].ID)
+	s.Equal(types.TagStatusWatching, fetched.TaggedUsers[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestUpdateTaskTags_MirrorsToTemplate() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	templateID := primitive.NewObjectID()
+	template := &types.TemplateTaskDocument{
+		ID:         templateID,
+		UserID:     owner.ID,
+		CategoryID: category.ID,
+		Content:    "x",
+		Priority:   1,
+		Value:      1,
+		RecurType:  "Occurrence",
+	}
+	_, err = s.Collections["template-tasks"].InsertOne(s.Ctx, template)
+	s.NoError(err)
+
+	task := TaskDocument{
+		ID:         primitive.NewObjectID(),
+		Content:    "x",
+		Priority:   1,
+		Value:      1,
+		UserID:     owner.ID,
+		CategoryID: category.ID,
+		Active:     true,
+		Recurring:  true,
+		TemplateID: &templateID,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	_, err = s.service.UpdateTaskTags(owner.ID, category.ID, created.ID, []string{friendA.ID.Hex()})
+	s.NoError(err)
+
+	var tmpl types.TemplateTaskDocument
+	err = s.Collections["template-tasks"].FindOne(s.Ctx, bson.M{"_id": templateID}).Decode(&tmpl)
+	s.NoError(err)
+	s.Len(tmpl.TaggedUsers, 1)
+	s.Equal(friendA.ID, tmpl.TaggedUsers[0].ID)
+	s.Equal(types.TagStatusPending, tmpl.TaggedUsers[0].Status)
+}

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -569,10 +569,12 @@ func (s *TagServiceTestSuite) TestRespondToTaskTag_CopiedTwiceNotifiesOnce() {
 	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusCopied)
 	s.NoError(err)
 
-	// Notification fires in a goroutine; wait for the record to land
+	// Notification fires in a goroutine; the push is its LAST side effect, so
+	// waiting for both record and push guarantees it finished before teardown
 	s.Eventually(func() bool {
-		return s.CountDocuments("notifications", filter) == 1
-	}, 3*time.Second, 50*time.Millisecond, "expected TASK_COPIED record after first copied response")
+		return s.CountDocuments("notifications", filter) == 1 &&
+			s.MockPushSender.AssertNotificationSent(owner.PushToken)
+	}, 3*time.Second, 50*time.Millisecond, "expected TASK_COPIED record + push after first copied response")
 
 	// Idempotent re-respond: returns nil, fires no goroutine, so no second record
 	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusCopied)

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -43,6 +43,16 @@ func (s *TagServiceTestSuite) TestBuildTaggedUsers_SkipsInvalidAndUnknownIDs() {
 	s.Len(tagged, 0)
 }
 
+func (s *TagServiceTestSuite) TestBuildTaggedUsers_DeduplicatesRepeatedIDs() {
+	friend := s.GetUser(1)
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex(), friend.ID.Hex()})
+
+	s.NoError(err)
+	s.Len(tagged, 1)
+	s.Equal(friend.ID, tagged[0].ID)
+}
+
 func (s *TagServiceTestSuite) TestCreateTask_PersistsTaggedUsers() {
 	owner := s.GetUser(0)
 	friend := s.GetUser(1)

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 type TagServiceTestSuite struct {
@@ -422,4 +423,92 @@ func (s *TagServiceTestSuite) TestUpdateTaskTags_MirrorsToTemplate() {
 	s.Len(tmpl.TaggedUsers, 1)
 	s.Equal(friendA.ID, tmpl.TaggedUsers[0].ID)
 	s.Equal(types.TagStatusPending, tmpl.TaggedUsers[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_UpdatesStatusAndTemplate() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+
+	templateID := primitive.NewObjectID()
+	tmplDoc := &types.TemplateTaskDocument{
+		ID:          templateID,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Content:     "Read 30 mins",
+		Priority:    1,
+		Value:       2,
+		RecurType:   "OCCURRENCE",
+		TaggedUsers: tagged,
+	}
+	_, err = s.Collections["template-tasks"].InsertOne(s.Ctx, tmplDoc)
+	s.NoError(err)
+
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "Read 30 mins",
+		Priority:    1,
+		Value:       2,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		Recurring:   true,
+		TemplateID:  &templateID,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusWatching)
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Equal(types.TagStatusWatching, fetched.TaggedUsers[0].Status)
+
+	tmpl, err := s.service.GetTemplateByID(templateID)
+	s.NoError(err)
+	s.Equal(types.TagStatusWatching, tmpl.TaggedUsers[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_RejectsInvalidStatus() {
+	err := s.service.RespondToTaskTag(primitive.NewObjectID(), primitive.NewObjectID(), "bogus")
+	s.Error(err)
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_UnknownTaskReturnsNotFound() {
+	err := s.service.RespondToTaskTag(primitive.NewObjectID(), primitive.NewObjectID(), types.TagStatusWatching)
+	s.ErrorIs(err, mongo.ErrNoDocuments)
+}
+
+func (s *TagServiceTestSuite) TestNotifyTaskCopied_CreatesRecordAndSendsPush() {
+	owner := s.GetUser(0)
+	copier := s.GetUser(1)
+
+	taskID := primitive.NewObjectID()
+	taskName := "Read 30 mins"
+
+	s.service.notifyTaskCopied(taskID, owner.ID, copier.ID, taskName)
+
+	// Assert a TASK_COPIED notification record exists for the owner (receiver)
+	count := s.CountDocuments("notifications", bson.M{
+		"receiver":         owner.ID,
+		"notificationType": "TASK_COPIED",
+		"reference_id":     taskID,
+	})
+	s.Equal(int64(1), count, "expected one TASK_COPIED notification record for the task owner")
+
+	// Assert a push was sent to the owner's push token
+	s.AssertPushNotificationSent(owner.PushToken, "expected push notification sent to task owner")
 }

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"testing"
+	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	testpkg "github.com/abhikaboy/Kindred/internal/testing"
@@ -511,4 +512,71 @@ func (s *TagServiceTestSuite) TestNotifyTaskCopied_CreatesRecordAndSendsPush() {
 
 	// Assert a push was sent to the owner's push token
 	s.AssertPushNotificationSent(owner.PushToken, "expected push notification sent to task owner")
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_NonTaggedResponderReturnsNotFound() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+	stranger := s.GetUser(2)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", Priority: 1, Value: 2,
+		UserID: owner.ID, CategoryID: category.ID, Active: true, TaggedUsers: tagged}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	// Task exists, but the stranger isn't tagged on it — must be a 404, not a silent 200
+	err = s.service.RespondToTaskTag(created.ID, stranger.ID, types.TagStatusWatching)
+	s.ErrorIs(err, mongo.ErrNoDocuments)
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_CopiedTwiceNotifiesOnce() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", Priority: 1, Value: 2,
+		UserID: owner.ID, CategoryID: category.ID, Active: true, TaggedUsers: tagged}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	filter := bson.M{
+		"receiver":         owner.ID,
+		"notificationType": "TASK_COPIED",
+		"reference_id":     created.ID,
+	}
+
+	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusCopied)
+	s.NoError(err)
+
+	// Notification fires in a goroutine; wait for the record to land
+	s.Eventually(func() bool {
+		return s.CountDocuments("notifications", filter) == 1
+	}, 3*time.Second, 50*time.Millisecond, "expected TASK_COPIED record after first copied response")
+
+	// Idempotent re-respond: returns nil, fires no goroutine, so no second record
+	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusCopied)
+	s.NoError(err)
+	s.Equal(int64(1), s.CountDocuments("notifications", filter),
+		"re-responding copied must not duplicate the TASK_COPIED notification")
 }

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	testpkg "github.com/abhikaboy/Kindred/internal/testing"
 	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
@@ -51,6 +52,94 @@ func (s *TagServiceTestSuite) TestBuildTaggedUsers_DeduplicatesRepeatedIDs() {
 	s.NoError(err)
 	s.Len(tagged, 1)
 	s.Equal(friend.ID, tagged[0].ID)
+}
+
+func (s *TagServiceTestSuite) TestNotifyTaggedUsers_CreatesNotificationRecordAndSendsPush() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	// Create a category for the owner
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	s.NoError(err)
+
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "Read 30 mins",
+		Priority:    1,
+		Value:       2,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+
+	s.service.NotifyTaggedUsers(&task, owner.ID)
+
+	// Assert a TASK_TAGGED notification record exists for friend (receiver)
+	count := s.CountDocuments("notifications", bson.M{
+		"receiver":         friend.ID,
+		"notificationType": "TASK_TAGGED",
+		"reference_id":     task.ID,
+	})
+	s.Equal(int64(1), count, "expected one TASK_TAGGED notification record for the tagged friend")
+
+	// Assert a push was sent to friend's push token
+	s.AssertPushNotificationSent(friend.PushToken, "expected push notification sent to tagged friend")
+}
+
+func (s *TagServiceTestSuite) TestNotifyTaggedUsers_SkipsNonPendingUsers() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	// Build tagged user but set status to accepted — should be skipped
+	tagged := []types.TaggedTaskUser{
+		{
+			ID:          friend.ID,
+			Handle:      friend.Handle,
+			DisplayName: friend.DisplayName,
+			Status:      types.TagStatusWatching,
+		},
+	}
+
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "Read 30 mins",
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		TaggedUsers: tagged,
+	}
+
+	s.service.NotifyTaggedUsers(&task, owner.ID)
+
+	// No notification record should exist
+	count := s.CountDocuments("notifications", bson.M{
+		"receiver":         friend.ID,
+		"notificationType": "TASK_TAGGED",
+	})
+	s.Equal(int64(0), count, "non-pending tagged users should not receive notifications")
+
+	// No push should have been sent
+	s.AssertPushNotificationNotSent(friend.PushToken, "non-pending tagged users should not receive push")
 }
 
 func (s *TagServiceTestSuite) TestCreateTask_PersistsTaggedUsers() {

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -608,3 +608,18 @@ func (s *TagServiceTestSuite) TestNotifyTagWatchersOfCompletion_OnlyPendingAndWa
 	s.Len(notifications, 1)
 	s.Equal("task_completed_watcher", notifications[0].Data["type"])
 }
+
+func (s *TagServiceTestSuite) TestConstructTaskFromTemplate_CopiesTaggedUsers() {
+	friend := s.GetUser(1)
+	tmpl := types.TemplateTaskDocument{
+		ID: primitive.NewObjectID(), Content: "Read 30 mins", RecurType: "OCCURRENCE",
+		TaggedUsers: []types.TaggedTaskUser{
+			{ID: friend.ID, Handle: friend.Handle, DisplayName: friend.DisplayName, Status: types.TagStatusWatching},
+		},
+	}
+
+	task := constructTaskFromTemplate(&tmpl)
+
+	s.Len(task.TaggedUsers, 1)
+	s.Equal(types.TagStatusWatching, task.TaggedUsers[0].Status)
+}

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -1,0 +1,81 @@
+package task
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type TagServiceTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+}
+
+func (s *TagServiceTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+}
+
+func TestTagService(t *testing.T) {
+	suite.Run(t, new(TagServiceTestSuite))
+}
+
+func (s *TagServiceTestSuite) TestBuildTaggedUsers_DenormalizesUserInfo() {
+	friend := s.GetUser(1)
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+
+	s.NoError(err)
+	s.Len(tagged, 1)
+	s.Equal(friend.ID, tagged[0].ID)
+	s.Equal(friend.Handle, tagged[0].Handle)
+	s.Equal(friend.DisplayName, tagged[0].DisplayName)
+	s.Equal(types.TagStatusPending, tagged[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestBuildTaggedUsers_SkipsInvalidAndUnknownIDs() {
+	tagged, err := s.service.BuildTaggedUsers([]string{"not-an-objectid", primitive.NewObjectID().Hex()})
+
+	s.NoError(err)
+	s.Len(tagged, 0)
+}
+
+func (s *TagServiceTestSuite) TestCreateTask_PersistsTaggedUsers() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	// Create a category for the owner (mirrors the pattern in service_test.go)
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	s.NoError(err)
+
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "Read 30 mins",
+		Priority:    1,
+		Value:       2,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 1)
+	s.Equal(types.TagStatusPending, fetched.TaggedUsers[0].Status)
+}

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -306,6 +306,72 @@ func (s *TagServiceTestSuite) TestUpdateTaskTags_RespondedUserResuppliedKeepsSta
 	s.Equal(types.TagStatusWatching, fetched.TaggedUsers[0].Status)
 }
 
+func (s *TagServiceTestSuite) TestGetPendingTaggedTasks_ReturnsTaskAndTagger() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", Priority: 1, Value: 2,
+		UserID: owner.ID, CategoryID: category.ID, Active: true, TaggedUsers: tagged}
+	_, err = s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	pending, err := s.service.GetPendingTaggedTasks(friend.ID)
+	s.NoError(err)
+	s.Len(pending, 1)
+	s.Equal("Read 30 mins", pending[0].Content)
+	s.Equal(owner.ID, pending[0].Tagger.ID)
+	s.Equal(owner.DisplayName, pending[0].Tagger.DisplayName)
+
+	// Owner themselves has no pending tags
+	none, err := s.service.GetPendingTaggedTasks(owner.ID)
+	s.NoError(err)
+	s.Len(none, 0)
+}
+
+func (s *TagServiceTestSuite) TestGetPendingTaggedTasks_ExcludesNonPendingStatus() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	// Task where friend already responded (watching) — must NOT appear
+	tagged := []types.TaggedTaskUser{
+		{
+			ID:          friend.ID,
+			Handle:      friend.Handle,
+			DisplayName: friend.DisplayName,
+			Status:      types.TagStatusWatching,
+		},
+	}
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Watched task", Priority: 1, Value: 1,
+		UserID: owner.ID, CategoryID: category.ID, Active: true, TaggedUsers: tagged}
+	_, err = s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	none, err := s.service.GetPendingTaggedTasks(friend.ID)
+	s.NoError(err)
+	s.Len(none, 0, "watching-status entry must not appear in pending results")
+}
+
 func (s *TagServiceTestSuite) TestUpdateTaskTags_MirrorsToTemplate() {
 	owner := s.GetUser(0)
 	friendA := s.GetUser(1)

--- a/backend/internal/handlers/task/tag_service_test.go
+++ b/backend/internal/handlers/task/tag_service_test.go
@@ -111,7 +111,7 @@ func (s *TagServiceTestSuite) TestNotifyTaggedUsers_SkipsNonPendingUsers() {
 	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
 	s.NoError(err)
 
-	// Build tagged user but set status to accepted — should be skipped
+	// Build tagged user but set status to watching — should be skipped
 	tagged := []types.TaggedTaskUser{
 		{
 			ID:          friend.ID,
@@ -177,4 +177,89 @@ func (s *TagServiceTestSuite) TestCreateTask_PersistsTaggedUsers() {
 	s.NoError(err)
 	s.Len(fetched.TaggedUsers, 1)
 	s.Equal(types.TagStatusPending, fetched.TaggedUsers[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestUpdateTaskTags_AddsAndRemovesPendingOnly() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+	friendB := s.GetUser(2)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	// Seed: task tagged with A (already watching) — responded entries must survive removal
+	tagged, _ := s.service.BuildTaggedUsers([]string{friendA.ID.Hex()})
+	tagged[0].Status = types.TagStatusWatching
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "x",
+		Priority:    1,
+		Value:       1,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	// Update to only B: A is watching so must remain; B added as pending
+	added, err := s.service.UpdateTaskTags(owner.ID, category.ID, created.ID, []string{friendB.ID.Hex()})
+	s.NoError(err)
+	s.Len(added, 1)
+	s.Equal(friendB.ID, added[0].ID)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 2)
+
+	byID := map[primitive.ObjectID]types.TagStatus{}
+	for _, tu := range fetched.TaggedUsers {
+		byID[tu.ID] = tu.Status
+	}
+	s.Equal(types.TagStatusWatching, byID[friendA.ID])
+	s.Equal(types.TagStatusPending, byID[friendB.ID])
+}
+
+func (s *TagServiceTestSuite) TestUpdateTaskTags_RemovesPendingEntry() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+
+	category := &types.CategoryDocument{
+		ID:            primitive.NewObjectID(),
+		Name:          "Test Category",
+		User:          owner.ID,
+		WorkspaceName: "Test Workspace",
+		Tasks:         []TaskDocument{},
+	}
+	_, err := s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friendA.ID.Hex()})
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "x",
+		Priority:    1,
+		Value:       1,
+		UserID:      owner.ID,
+		CategoryID:  category.ID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(category.ID, &task)
+	s.NoError(err)
+
+	_, err = s.service.UpdateTaskTags(owner.ID, category.ID, created.ID, []string{})
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 0)
 }

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -227,6 +227,10 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 		return nil, huma.Error500InternalServerError("Unable to create task due to a database error. Please try again.", err)
 	}
 
+	if len(doc.TaggedUsers) > 0 {
+		go h.service.NotifyTaggedUsers(doc, userObjID)
+	}
+
 	// Increment Plan ring synchronously so the response carries the delta.
 	// NotifyAllRingsClosed is already async (2-minute delayed).
 	var ringDelta *rings.RingDelta

--- a/backend/internal/handlers/task/task_handlers.go
+++ b/backend/internal/handlers/task/task_handlers.go
@@ -131,6 +131,16 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 		LastEdited:     time.Now(),
 	}
 
+	// Resolve tagged friends to denormalized pending entries
+	if len(taskParams.TaggedUserIDs) > 0 {
+		tagged, err := h.service.BuildTaggedUsers(taskParams.TaggedUserIDs)
+		if err != nil {
+			slog.Error("Failed to resolve tagged users", "error", err)
+		} else {
+			task.TaggedUsers = tagged
+		}
+	}
+
 	// Auto-inject a FOLLOW_UP reminder if the task has a deadline or startTime
 	followUp := BuildFollowUpReminder(task.Deadline, task.StartTime)
 	if followUp != nil {
@@ -203,6 +213,7 @@ func (h *Handler) CreateTask(ctx context.Context, input *CreateTaskInput) (*Crea
 			taskParams.Reminders,
 			taskParams.Notes,
 			taskParams.Checklist,
+			task.TaggedUsers,
 		)
 		if err != nil {
 			slog.Error("Failed to create recurring task template", "userId", userObjID.Hex(), "categoryId", categoryID.Hex(), "error", err)
@@ -359,6 +370,7 @@ func (h *Handler) UpdateTask(ctx context.Context, input *UpdateTaskInput) (*Upda
 			updateData.Reminders,
 			updateData.Notes,
 			updateData.Checklist,
+			nil, // tagging during edit-to-recurring conversion is out of scope
 		)
 		if err != nil {
 			slog.Error("Failed to create recurring template during task update", "taskId", id.Hex(), "userId", userObjID.Hex(), "error", err)

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
+	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	mongorepo "github.com/abhikaboy/Kindred/internal/repository/mongo"
@@ -67,6 +68,7 @@ func newService(collections map[string]*mongo.Collection, ringService *rings.Rin
 		TemplateTasks:       collections["template-tasks"],
 		EncouragementHelper: encouragement.NewEncouragementService(collections),
 		RingService:         ringService,
+		NotificationService: notifications.NewNotificationService(collections),
 	}
 }
 

--- a/backend/internal/handlers/task/task_service.go
+++ b/backend/internal/handlers/task/task_service.go
@@ -567,6 +567,15 @@ func (s *Service) CompleteTask(
 		}()
 	}
 
+	if len(taskToComplete.TaggedUsers) > 0 {
+		tc := taskToComplete
+		go func() {
+			if err := s.NotifyTagWatchersOfCompletion(&tc, userId); err != nil {
+				slog.Error("Failed to notify tag watchers", "taskID", tc.ID.Hex(), "error", err)
+			}
+		}()
+	}
+
 	s.enqueuePushUpsertIfEnabled(context.Background(), id, categoryId, userId)
 
 	return &TaskCompletionResult{

--- a/backend/internal/handlers/task/template_service.go
+++ b/backend/internal/handlers/task/template_service.go
@@ -341,7 +341,7 @@ func (s *Service) CreateTemplateForTask(
 		return s.createFlexTemplateForTask(
 			userID, categoryID, templateID,
 			content, priority, value, public,
-			recurDetails, notes, checklist,
+			recurDetails, notes, checklist, taggedUsers,
 		)
 	}
 

--- a/backend/internal/handlers/task/template_service.go
+++ b/backend/internal/handlers/task/template_service.go
@@ -326,6 +326,7 @@ func (s *Service) CreateTemplateForTask(
 	reminders []*Reminder,
 	notes string,
 	checklist []ChecklistItem,
+	taggedUsers []TaggedTaskUser,
 ) error {
 
 	if err := ValidateRecurDetails(recurFrequency, recurDetails); err != nil {
@@ -391,6 +392,7 @@ func (s *Service) CreateTemplateForTask(
 		Reminders:     relativeReminders,
 		Notes:         notes,
 		Checklist:     checklist,
+		TaggedUsers:   taggedUsers,
 
 		// Initialize analytics fields
 		TimesGenerated:  0,

--- a/backend/internal/handlers/task/types.go
+++ b/backend/internal/handlers/task/types.go
@@ -37,6 +37,8 @@ type CreateTaskParams struct {
 	Checklist   []ChecklistItem `bson:"checklist,omitempty" json:"checklist,omitempty"`
 	Reminders   []*Reminder     `bson:"reminders,omitempty" json:"reminders,omitempty"`
 	Integration string          `bson:"integration,omitempty" json:"integration,omitempty"`
+
+	TaggedUserIDs []string `bson:"-" json:"taggedUserIds,omitempty"`
 }
 
 type SortParams struct {
@@ -52,6 +54,7 @@ type Reminder = types.Reminder
 type FlexDetails = types.FlexDetails
 type FlexTemplateState = types.FlexTemplateState
 type FlexInstanceInfo = types.FlexInstanceInfo
+type TaggedTaskUser = types.TaggedTaskUser
 
 type UpdateTaskDocument struct {
 	Priority       int           `bson:"priority" json:"priority"`

--- a/backend/internal/handlers/task/types.go
+++ b/backend/internal/handlers/task/types.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"github.com/abhikaboy/Kindred/internal/repository"
@@ -152,6 +153,7 @@ type Service struct {
 	EncouragementHelper EncouragementServiceInterface
 	RingService         *rings.RingService
 	PushEnqueuer        PushEnqueuer // optional; nil disables push hooks
+	NotificationService *notifications.Service
 }
 
 // EncouragementServiceInterface defines the methods we need from the encouragement service

--- a/backend/internal/handlers/task/util.go
+++ b/backend/internal/handlers/task/util.go
@@ -379,6 +379,7 @@ func constructTaskFromTemplate(templateDoc *TemplateTaskDocument) TaskDocument {
 		TemplateID:     &templateDoc.ID,
 		Notes:          templateDoc.Notes,
 		Checklist:      checklist,
+		TaggedUsers:    templateDoc.TaggedUsers,
 	}
 
 	if templateDoc.FlexState != nil {

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -113,11 +113,13 @@ type TaskKudos struct {
 }
 
 // Tag status lifecycle: pending -> watching | copied | untagged.
+type TagStatus string
+
 const (
-	TagStatusPending  = "pending"
-	TagStatusWatching = "watching"
-	TagStatusCopied   = "copied"
-	TagStatusUntagged = "untagged"
+	TagStatusPending  TagStatus = "pending"
+	TagStatusWatching TagStatus = "watching"
+	TagStatusCopied   TagStatus = "copied"
+	TagStatusUntagged TagStatus = "untagged"
 )
 
 // TaggedTaskUser is one friend tagged on a task, denormalized at tag time so
@@ -127,7 +129,7 @@ type TaggedTaskUser struct {
 	Handle         string             `bson:"handle" json:"handle"`
 	DisplayName    string             `bson:"display_name" json:"display_name"`
 	ProfilePicture string             `bson:"profile_picture" json:"profile_picture"`
-	Status         string             `bson:"status" json:"status"` // pending | watching | copied | untagged
+	Status         TagStatus          `bson:"status" json:"status"`
 }
 
 /*

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -88,6 +88,9 @@ type TaskDocument struct {
 
 	// Encouragements recorded on this task (denormalized at encourage time).
 	Encouragements []TaskKudos `bson:"encouragements,omitempty" json:"encouragements,omitempty"`
+
+	// Friends tagged on this task (denormalized at tag time).
+	TaggedUsers []TaggedTaskUser `bson:"taggedUsers,omitempty" json:"taggedUsers,omitempty"`
 }
 
 // KudosSender is an extended reference to the user who sent an encouragement,
@@ -107,6 +110,24 @@ type TaskKudos struct {
 	Message         string             `bson:"message" json:"message"`
 	Timestamp       time.Time          `bson:"timestamp" json:"timestamp"`
 	Type            string             `bson:"type" json:"type"` // "message" | "image"
+}
+
+// Tag status lifecycle: pending -> watching | copied | untagged.
+const (
+	TagStatusPending  = "pending"
+	TagStatusWatching = "watching"
+	TagStatusCopied   = "copied"
+	TagStatusUntagged = "untagged"
+)
+
+// TaggedTaskUser is one friend tagged on a task, denormalized at tag time so
+// the client can render the watcher row without a join.
+type TaggedTaskUser struct {
+	ID             primitive.ObjectID `bson:"id" json:"id"`
+	Handle         string             `bson:"handle" json:"handle"`
+	DisplayName    string             `bson:"display_name" json:"display_name"`
+	ProfilePicture string             `bson:"profile_picture" json:"profile_picture"`
+	Status         string             `bson:"status" json:"status"` // pending | watching | copied | untagged
 }
 
 /*
@@ -164,6 +185,9 @@ type TemplateTaskDocument struct {
 	BlueprintID *primitive.ObjectID `bson:"blueprintId,omitempty" json:"blueprintId,omitempty"`
 
 	FlexState *FlexTemplateState `bson:"flexState,omitempty" json:"flexState,omitempty"`
+
+	// Mirrored from the live task so generated instances inherit tag state.
+	TaggedUsers []TaggedTaskUser `bson:"taggedUsers,omitempty" json:"taggedUsers,omitempty"`
 }
 
 type RecurDetails struct {

--- a/backend/internal/storage/xmongo/indexes.go
+++ b/backend/internal/storage/xmongo/indexes.go
@@ -149,6 +149,13 @@ var Indexes = []Index{
 			Options: options.Index().SetSparse(true),
 		},
 	},
+	// Covers GetPendingTaggedTasks: 'tasks where user X is tagged' lookups
+	{
+		Collection: "categories",
+		Model: mongo.IndexModel{
+			Keys: bson.D{{Key: "tasks.taggedUsers.id", Value: 1}},
+		},
+	},
 	// {
 	// 	Collection: "users",
 	// 	Model: mongo.IndexModel{Keys: bson.D{

--- a/backend/xutils/push_notification.go
+++ b/backend/xutils/push_notification.go
@@ -1,6 +1,8 @@
 package xutils
 
 import (
+	"sync"
+
 	expo "github.com/oliveroneill/exponent-server-sdk-golang/sdk"
 )
 
@@ -85,8 +87,10 @@ func (e *ExpoPushNotificationSender) SendBatchNotification(notifications []Notif
 	return err
 }
 
-// MockPushNotificationSender is a mock implementation for testing
+// MockPushNotificationSender is a mock implementation for testing.
+// Mutex-guarded so tests can poll it while service goroutines send pushes.
 type MockPushNotificationSender struct {
+	mu                         sync.Mutex
 	SentNotifications          []Notification
 	SendNotificationError      error
 	SendBatchNotificationError error
@@ -101,6 +105,8 @@ func NewMockPushNotificationSender() *MockPushNotificationSender {
 
 // SendNotification mocks sending a single push notification
 func (m *MockPushNotificationSender) SendNotification(notification Notification) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.SendNotificationError != nil {
 		return m.SendNotificationError
 	}
@@ -110,6 +116,8 @@ func (m *MockPushNotificationSender) SendNotification(notification Notification)
 
 // SendBatchNotification mocks sending multiple push notifications
 func (m *MockPushNotificationSender) SendBatchNotification(notifications []Notification) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.SendBatchNotificationError != nil {
 		return m.SendBatchNotificationError
 	}
@@ -117,13 +125,19 @@ func (m *MockPushNotificationSender) SendBatchNotification(notifications []Notif
 	return nil
 }
 
-// GetSentNotifications returns all sent notifications
+// GetSentNotifications returns a copy of all sent notifications
 func (m *MockPushNotificationSender) GetSentNotifications() []Notification {
-	return m.SentNotifications
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]Notification, len(m.SentNotifications))
+	copy(result, m.SentNotifications)
+	return result
 }
 
 // GetSentNotificationsForToken returns all notifications sent to a specific token
 func (m *MockPushNotificationSender) GetSentNotificationsForToken(token string) []Notification {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var result []Notification
 	for _, n := range m.SentNotifications {
 		if n.Token == token {
@@ -135,6 +149,8 @@ func (m *MockPushNotificationSender) GetSentNotificationsForToken(token string) 
 
 // GetSentNotificationsByType returns all notifications of a specific type
 func (m *MockPushNotificationSender) GetSentNotificationsByType(notificationType string) []Notification {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var result []Notification
 	for _, n := range m.SentNotifications {
 		if n.Data != nil && n.Data["type"] == notificationType {
@@ -146,6 +162,8 @@ func (m *MockPushNotificationSender) GetSentNotificationsByType(notificationType
 
 // Reset clears all sent notifications
 func (m *MockPushNotificationSender) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.SentNotifications = make([]Notification, 0)
 	m.SendNotificationError = nil
 	m.SendBatchNotificationError = nil
@@ -158,5 +176,7 @@ func (m *MockPushNotificationSender) AssertNotificationSent(token string) bool {
 
 // AssertNotificationCount checks if the expected number of notifications were sent
 func (m *MockPushNotificationSender) AssertNotificationCount(expected int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return len(m.SentNotifications) == expected
 }

--- a/docs/superpowers/plans/2026-06-10-task-tagging.md
+++ b/docs/superpowers/plans/2026-06-10-task-tagging.md
@@ -1,0 +1,2103 @@
+# Task Tagging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Users can tag friends in their tasks; the tagged friend gets a push + a home-screen banner with Watch / Copy / Untag actions, watchers get pinged on every completion, and the tag relationship survives recurrence.
+
+**Architecture:** Tags are a denormalized `taggedUsers` array embedded on `TaskDocument` (and mirrored on `TemplateTaskDocument` so recurrence carries them), following the existing `encouragements` pattern. Tasks live embedded in the `categories` collection — all writes use the `tasks.$[t]` array-filter pattern. Three new endpoints: update tags on a task, list pending tags for the signed-in user, respond to a tag. Pushes go through `xutils.SendNotification`; DB notification records through `notifications.Service`.
+
+**Tech Stack:** Go backend (Huma v2 + Fiber, MongoDB driver, testify suites), React Native/Expo frontend (expo-router, @tanstack/react-query, @gorhom/bottom-sheet, phosphor-react-native).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-task-tagging-design.md`
+
+**One deliberate deviation from the spec:** the spec says the create-flow tag field "opens the existing `tag-people.tsx` screen". That screen is an expo-router route; navigating to it from inside the create bottom-sheet would dismiss the sheet. Instead we extract the picker UI from `tag-people.tsx` into a shared `FriendPicker` component and render it as an in-modal screen (`Screen.COLLABORATORS`), exactly how Deadline/Reminder screens work. Same UX, same code reuse, no sheet dismissal.
+
+**Conventions for all tasks:**
+- Backend tests: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run <TestName> -v`. Test suites use `testpkg.BaseSuite` (see `internal/handlers/task/service_test.go` for the pattern — `s.GetUser(0)` returns fixture users).
+- Frontend verification: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit` (always `bun`, never `npx`).
+- The frontend `handle` field already includes the `@` — never prepend another.
+- Commit after every task. Pre-commit hooks run gofmt/go vet automatically.
+
+---
+
+## Backend
+
+### Task 1: Model groundwork — TaggedTaskUser type, document fields, notification constants
+
+**Files:**
+- Modify: `backend/internal/handlers/types/types.go` (TaskDocument ~line 46-91, TemplateTaskDocument ~line 130-167)
+- Modify: `backend/internal/handlers/task/types.go` (CreateTaskParams ~line 21, type aliases ~line 48)
+- Modify: `backend/internal/handlers/notifications/types.go` (NotificationType consts ~line 24-33)
+
+- [ ] **Step 1: Add the TaggedTaskUser struct and status constants**
+
+In `backend/internal/handlers/types/types.go`, directly below the `TaskKudos` struct (~line 110), add:
+
+```go
+// Tag status lifecycle: pending -> watching | copied | untagged.
+const (
+	TagStatusPending  = "pending"
+	TagStatusWatching = "watching"
+	TagStatusCopied   = "copied"
+	TagStatusUntagged = "untagged"
+)
+
+// TaggedTaskUser is one friend tagged on a task, denormalized at tag time so
+// the client can render the watcher row without a join.
+type TaggedTaskUser struct {
+	ID             primitive.ObjectID `bson:"id" json:"id"`
+	Handle         string             `bson:"handle" json:"handle"`
+	DisplayName    string             `bson:"display_name" json:"display_name"`
+	ProfilePicture string             `bson:"profile_picture" json:"profile_picture"`
+	Status         string             `bson:"status" json:"status"` // pending | watching | copied | untagged
+}
+```
+
+- [ ] **Step 2: Add the field to both document structs**
+
+In `TaskDocument` (same file), after the `Encouragements` field (~line 90), add:
+
+```go
+	// Friends tagged on this task (denormalized at tag time).
+	TaggedUsers []TaggedTaskUser `bson:"taggedUsers,omitempty" json:"taggedUsers,omitempty"`
+```
+
+In `TemplateTaskDocument` (same file), after the `FlexState` field (~line 166), add:
+
+```go
+	// Mirrored from the live task so generated instances inherit tag state.
+	TaggedUsers []TaggedTaskUser `bson:"taggedUsers,omitempty" json:"taggedUsers,omitempty"`
+```
+
+- [ ] **Step 3: Add the create param and type alias**
+
+In `backend/internal/handlers/task/types.go`, add to `CreateTaskParams` after the `Integration` field:
+
+```go
+	TaggedUserIDs []string `bson:"-" json:"taggedUserIds,omitempty"`
+```
+
+(`bson:"-"` — the handler resolves IDs to denormalized entries; raw IDs are never stored.)
+
+In the type-alias block (~line 48, next to `type TaskDocument = types.TaskDocument`), add:
+
+```go
+type TaggedTaskUser = types.TaggedTaskUser
+```
+
+- [ ] **Step 4: Add notification type constants**
+
+In `backend/internal/handlers/notifications/types.go`, add to the const block:
+
+```go
+	NotificationTypeTaskTagged NotificationType = "TASK_TAGGED"
+	NotificationTypeTaskCopied NotificationType = "TASK_COPIED"
+```
+
+- [ ] **Step 5: Verify it compiles**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./...`
+Expected: clean build, no output.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/internal/handlers/types/types.go backend/internal/handlers/task/types.go backend/internal/handlers/notifications/types.go
+git commit -m "feat(tags): TaggedTaskUser model, document fields, notification types"
+```
+
+---
+
+### Task 2: Tag resolution + persistence on task create
+
+**Files:**
+- Create: `backend/internal/handlers/task/tag_service.go`
+- Modify: `backend/internal/handlers/task/task_handlers.go` (CreateTask, ~line 111 task doc construction and ~line 190 CreateTemplateForTask call)
+- Modify: `backend/internal/handlers/task/template_service.go` (CreateTemplateForTask signature, ~line 18 InsertOne)
+- Test: `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/internal/handlers/task/tag_service_test.go`. Mirror the suite setup in `service_test.go`:
+
+```go
+package task
+
+import (
+	"testing"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	testpkg "github.com/abhikaboy/Kindred/internal/testing"
+	"github.com/stretchr/testify/suite"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+type TagServiceTestSuite struct {
+	testpkg.BaseSuite
+	service *Service
+}
+
+func (s *TagServiceTestSuite) SetupTest() {
+	s.BaseSuite.SetupTest()
+	s.service = NewService(s.Collections)
+}
+
+func TestTagService(t *testing.T) {
+	suite.Run(t, new(TagServiceTestSuite))
+}
+
+func (s *TagServiceTestSuite) TestBuildTaggedUsers_DenormalizesUserInfo() {
+	friend := s.GetUser(1)
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+
+	s.NoError(err)
+	s.Len(tagged, 1)
+	s.Equal(friend.ID, tagged[0].ID)
+	s.Equal(friend.Handle, tagged[0].Handle)
+	s.Equal(friend.DisplayName, tagged[0].DisplayName)
+	s.Equal(types.TagStatusPending, tagged[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestBuildTaggedUsers_SkipsInvalidAndUnknownIDs() {
+	tagged, err := s.service.BuildTaggedUsers([]string{"not-an-objectid", primitive.NewObjectID().Hex()})
+
+	s.NoError(err)
+	s.Len(tagged, 0)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `s.service.BuildTaggedUsers undefined`.
+
+- [ ] **Step 3: Implement BuildTaggedUsers**
+
+Create `backend/internal/handlers/task/tag_service.go`:
+
+```go
+package task
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// BuildTaggedUsers resolves raw user IDs to denormalized pending tag entries.
+// Invalid or unknown IDs are skipped rather than failing the whole create.
+func (s *Service) BuildTaggedUsers(userIDs []string) ([]types.TaggedTaskUser, error) {
+	ctx := context.Background()
+	tagged := make([]types.TaggedTaskUser, 0, len(userIDs))
+	seen := make(map[primitive.ObjectID]bool)
+
+	for _, raw := range userIDs {
+		id, err := primitive.ObjectIDFromHex(raw)
+		if err != nil {
+			slog.Warn("Skipping invalid tagged user ID", "id", raw)
+			continue
+		}
+		if seen[id] {
+			continue
+		}
+		user, err := s.Users.GetUserByID(ctx, id)
+		if err != nil || user == nil {
+			slog.Warn("Skipping unknown tagged user", "id", raw)
+			continue
+		}
+		seen[id] = true
+		tagged = append(tagged, types.TaggedTaskUser{
+			ID:             user.ID,
+			Handle:         user.Handle,
+			DisplayName:    user.DisplayName,
+			ProfilePicture: user.ProfilePicture,
+			Status:         types.TagStatusPending,
+		})
+	}
+	return tagged, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Wire into CreateTask handler**
+
+In `backend/internal/handlers/task/task_handlers.go`, in `CreateTask`, after the `task := TaskDocument{...}` construction (~line 132) and before the recurring-template block, add:
+
+```go
+	// Resolve tagged friends to denormalized pending entries
+	if len(taskParams.TaggedUserIDs) > 0 {
+		tagged, err := h.service.BuildTaggedUsers(taskParams.TaggedUserIDs)
+		if err != nil {
+			slog.Error("Failed to resolve tagged users", "error", err)
+		} else {
+			task.TaggedUsers = tagged
+		}
+	}
+```
+
+- [ ] **Step 6: Carry tags onto the recurring template**
+
+In `backend/internal/handlers/task/template_service.go`, add a `taggedUsers []types.TaggedTaskUser` parameter to `CreateTemplateForTask` (last position) and set it on the template document before `s.TemplateTasks.InsertOne(ctx, r)` (~line 18). Find the struct construction inside that function and add `TaggedUsers: taggedUsers,`. Check the import block includes `"github.com/abhikaboy/Kindred/internal/handlers/types"` (it may already via the alias — the alias `TaggedTaskUser` from `task/types.go` also works; prefer the alias for consistency with the rest of the file).
+
+Update both call sites in `task_handlers.go` (lines ~190 and ~346 — `grep -n "CreateTemplateForTask" task_handlers.go`) to pass `task.TaggedUsers` (create path) and the existing task's `TaggedUsers` or `nil` (update path at ~346: pass `nil` — tagging during edit-to-recurring conversion is out of scope).
+
+- [ ] **Step 7: Write a persistence test**
+
+Add to `tag_service_test.go`:
+
+```go
+func (s *TagServiceTestSuite) TestCreateTask_PersistsTaggedUsers() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	categoryID := s.GetCategoryID(owner.ID) // see service_test.go for how existing tests obtain a category; mirror that helper/fixture access exactly
+
+	tagged, err := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	s.NoError(err)
+
+	task := TaskDocument{
+		ID:          primitive.NewObjectID(),
+		Content:     "Read 30 mins",
+		Priority:    1,
+		Value:       2,
+		UserID:      owner.ID,
+		CategoryID:  categoryID,
+		Active:      true,
+		TaggedUsers: tagged,
+	}
+	created, err := s.service.CreateTask(categoryID, &task)
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 1)
+	s.Equal(types.TagStatusPending, fetched.TaggedUsers[0].Status)
+}
+```
+
+Note: if `s.GetCategoryID` doesn't exist as written, open `service_test.go` and copy how an existing CreateTask/CompleteTask test obtains a category ID for a fixture user — use that exact mechanism.
+
+- [ ] **Step 8: Run tests, verify pass**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): resolve and persist taggedUsers on task create"
+```
+
+---
+
+### Task 3: Tag notifications on create (push + DB record)
+
+**Files:**
+- Create: `backend/internal/handlers/task/tag_notifications.go`
+- Modify: `backend/internal/handlers/task/task_service.go` (Service struct ~line 60-72 in newService; struct definition — `grep -n "type Service struct" task_service.go` or it may live in `types.go`)
+- Modify: `backend/internal/handlers/task/task_handlers.go` (CreateTask, after successful `h.service.CreateTask`)
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Add NotificationService to the task Service**
+
+Find the `Service` struct (`grep -rn "type Service struct" backend/internal/handlers/task/`). Add the field:
+
+```go
+	NotificationService *notifications.Service
+```
+
+(Check the concrete return type of `notifications.NewNotificationService` in `backend/internal/handlers/notifications/service.go` and use that exact type.)
+
+In `newService` (`task_service.go` ~line 60), add to the constructed struct, mirroring `encouragement/service.go:40`:
+
+```go
+		NotificationService: notifications.NewNotificationService(collections),
+```
+
+Add the import `"github.com/abhikaboy/Kindred/internal/handlers/notifications"`.
+
+- [ ] **Step 2: Write the failing test**
+
+Existing push-notification tests live in `backend/internal/handlers/encouragement/service_test.go:648` (`TestNotifyEncouragersOfCompletion_Success`). Open that test, see how it stubs `xutils.DefaultPushSender` (there will be a mock sender in the test utilities), and mirror the same stubbing here.
+
+Add to `tag_service_test.go`:
+
+```go
+func (s *TagServiceTestSuite) TestNotifyTaggedUsers_CreatesNotificationRecords() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", UserID: owner.ID, TaggedUsers: tagged}
+
+	s.service.NotifyTaggedUsers(&task, owner.ID)
+
+	// A TASK_TAGGED notification record should exist for the friend
+	count, err := s.Collections["notifications"].CountDocuments(
+		s.T().Context(),
+		map[string]interface{}{"receiver": friend.ID, "notificationType": "TASK_TAGGED"},
+	)
+	s.NoError(err)
+	s.Equal(int64(1), count)
+}
+```
+
+(Adjust the raw collection access to whatever `BaseSuite` exposes — existing tests in `encouragement/service_test.go` show the idiom for asserting on notification records; copy it.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `NotifyTaggedUsers undefined`.
+
+- [ ] **Step 4: Implement NotifyTaggedUsers**
+
+Create `backend/internal/handlers/task/tag_notifications.go`:
+
+```go
+package task
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/abhikaboy/Kindred/xutils"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// NotifyTaggedUsers sends a push + creates a TASK_TAGGED notification record
+// for every pending tagged user on the task. Best-effort: failures are logged,
+// never returned, so they can't fail task creation.
+func (s *Service) NotifyTaggedUsers(task *TaskDocument, taggerID primitive.ObjectID) {
+	ctx := context.Background()
+
+	tagger, err := s.Users.GetUserByID(ctx, taggerID)
+	if err != nil || tagger == nil {
+		slog.Error("NotifyTaggedUsers: failed to load tagger", "error", err)
+		return
+	}
+
+	for _, tu := range task.TaggedUsers {
+		if tu.Status != types.TagStatusPending {
+			continue
+		}
+
+		// DB record (drives the activity tab)
+		content := fmt.Sprintf("tagged you in \"%s\"", task.Content)
+		if err := s.NotificationService.CreateNotification(
+			taggerID, tu.ID, content, notifications.NotificationTypeTaskTagged, task.ID,
+		); err != nil {
+			slog.Error("Failed to create TASK_TAGGED record", "receiver", tu.ID, "error", err)
+		}
+
+		// Push
+		receiver, err := s.Users.GetUserByID(ctx, tu.ID)
+		if err != nil || receiver == nil || receiver.PushToken == "" {
+			continue
+		}
+		notification := xutils.Notification{
+			Token:   receiver.PushToken,
+			Title:   "You've been tagged 👀",
+			Message: fmt.Sprintf("%s tagged you in \"%s\"", tagger.DisplayName, task.Content),
+			Data: map[string]string{
+				"type":      "task_tagged",
+				"task_id":   task.ID.Hex(),
+				"user_id":   taggerID.Hex(),
+				"task_name": task.Content,
+			},
+		}
+		if err := xutils.SendNotification(notification); err != nil {
+			slog.Error("Failed to send task_tagged push", "receiver", tu.ID, "error", err)
+		}
+	}
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+- [ ] **Step 6: Call it from the CreateTask handler**
+
+In `task_handlers.go` `CreateTask`, after `doc, err := h.service.CreateTask(categoryID, &task)` succeeds (~line 213), add:
+
+```go
+	if len(doc.TaggedUsers) > 0 {
+		go h.service.NotifyTaggedUsers(doc, userObjID)
+	}
+```
+
+- [ ] **Step 7: Build + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... && go test ./internal/handlers/task/... -v -run TestTagService`
+Expected: PASS.
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): push + notification record when friends are tagged"
+```
+
+---
+
+### Task 4: Update tags on an existing task — PATCH endpoint
+
+**Files:**
+- Modify: `backend/internal/handlers/task/tag_service.go` (add UpdateTaskTags)
+- Create: `backend/internal/handlers/task/tag_operations.go` (input/output types + registration + handler)
+- Modify: `backend/internal/handlers/task/routes.go` (register)
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func (s *TagServiceTestSuite) TestUpdateTaskTags_AddsAndRemovesPendingOnly() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+	friendB := s.GetUser(2)
+	categoryID := s.GetCategoryID(owner.ID)
+
+	// Seed: task tagged with A (already watching) — responded entries must survive removal
+	tagged, _ := s.service.BuildTaggedUsers([]string{friendA.ID.Hex()})
+	tagged[0].Status = types.TagStatusWatching
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "x", Priority: 1, Value: 1,
+		UserID: owner.ID, CategoryID: categoryID, Active: true, TaggedUsers: tagged}
+	created, err := s.service.CreateTask(categoryID, &task)
+	s.NoError(err)
+
+	// Update to only B: A is watching so must remain; B added as pending
+	added, err := s.service.UpdateTaskTags(owner.ID, categoryID, created.ID, []string{friendB.ID.Hex()})
+	s.NoError(err)
+	s.Len(added, 1)
+	s.Equal(friendB.ID, added[0].ID)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 2)
+
+	byID := map[primitive.ObjectID]string{}
+	for _, tu := range fetched.TaggedUsers {
+		byID[tu.ID] = tu.Status
+	}
+	s.Equal(types.TagStatusWatching, byID[friendA.ID])
+	s.Equal(types.TagStatusPending, byID[friendB.ID])
+}
+
+func (s *TagServiceTestSuite) TestUpdateTaskTags_RemovesPendingEntry() {
+	owner := s.GetUser(0)
+	friendA := s.GetUser(1)
+	categoryID := s.GetCategoryID(owner.ID)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friendA.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "x", Priority: 1, Value: 1,
+		UserID: owner.ID, CategoryID: categoryID, Active: true, TaggedUsers: tagged}
+	created, err := s.service.CreateTask(categoryID, &task)
+	s.NoError(err)
+
+	_, err = s.service.UpdateTaskTags(owner.ID, categoryID, created.ID, []string{})
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Len(fetched.TaggedUsers, 0)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `UpdateTaskTags undefined`.
+
+- [ ] **Step 3: Implement UpdateTaskTags**
+
+Add to `tag_service.go`:
+
+```go
+// UpdateTaskTags reconciles the task's tag list against the desired ID set.
+// Entries that already responded (watching/copied/untagged) are never removed
+// (spec: removal-after-response is out of scope). Pending entries not in the
+// new set are dropped. New IDs are added as pending. Returns the newly added
+// entries so the handler can notify them. Mirrors the template when recurring.
+func (s *Service) UpdateTaskTags(
+	userID, categoryID, taskID primitive.ObjectID,
+	taggedUserIDs []string,
+) ([]types.TaggedTaskUser, error) {
+	ctx := context.Background()
+
+	if err := s.verifyCategoryOwnership(ctx, categoryID, userID); err != nil {
+		return nil, err
+	}
+	task, err := s.findTaskInCategory(ctx, categoryID, taskID)
+	if err != nil {
+		return nil, err
+	}
+
+	desired := make(map[primitive.ObjectID]bool, len(taggedUserIDs))
+	for _, raw := range taggedUserIDs {
+		if id, err := primitive.ObjectIDFromHex(raw); err == nil {
+			desired[id] = true
+		}
+	}
+
+	next := make([]types.TaggedTaskUser, 0, len(taggedUserIDs))
+	existing := make(map[primitive.ObjectID]bool)
+	for _, tu := range task.TaggedUsers {
+		// Responded entries always survive; pending survives only if still desired
+		if tu.Status != types.TagStatusPending || desired[tu.ID] {
+			next = append(next, tu)
+			existing[tu.ID] = true
+		}
+	}
+
+	newIDs := make([]string, 0)
+	for _, raw := range taggedUserIDs {
+		id, err := primitive.ObjectIDFromHex(raw)
+		if err != nil || existing[id] {
+			continue
+		}
+		newIDs = append(newIDs, raw)
+	}
+	added, err := s.BuildTaggedUsers(newIDs)
+	if err != nil {
+		return nil, err
+	}
+	next = append(next, added...)
+
+	_, err = s.Tasks.UpdateOne(ctx,
+		bson.M{"_id": categoryID, "tasks._id": taskID},
+		bson.M{"$set": bson.M{"tasks.$[t].taggedUsers": next}},
+		getTaskArrayFilterOptions(taskID),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if task.TemplateID != nil {
+		if _, err := s.TemplateTasks.UpdateOne(ctx,
+			bson.M{"_id": *task.TemplateID},
+			bson.M{"$set": bson.M{"taggedUsers": next}},
+		); err != nil {
+			slog.Error("Failed to mirror tags to template", "templateID", task.TemplateID.Hex(), "error", err)
+		}
+	}
+
+	return added, nil
+}
+```
+
+Add the missing imports (`go.mongodb.org/mongo-driver/bson`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+- [ ] **Step 5: Add the HTTP operation**
+
+Create `backend/internal/handlers/task/tag_operations.go`:
+
+```go
+package task
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/abhikaboy/Kindred/internal/xutils/auth"
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// NOTE: check the auth import path used at the top of task_handlers.go and use
+// that exact path — it may be "github.com/abhikaboy/Kindred/internal/auth".
+
+type UpdateTaskTagsInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	Category      string `path:"category" example:"507f1f77bcf86cd799439011"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          struct {
+		TaggedUserIDs []string `json:"taggedUserIds"`
+	} `json:"body"`
+}
+
+type UpdateTaskTagsOutput struct {
+	Body struct {
+		TaggedUsers []types.TaggedTaskUser `json:"taggedUsers"`
+	} `json:"body"`
+}
+
+func (h *Handler) UpdateTaskTags(ctx context.Context, input *UpdateTaskTagsInput) (*UpdateTaskTagsOutput, error) {
+	taskID, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid task ID format", err)
+	}
+	categoryID, err := primitive.ObjectIDFromHex(input.Category)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid category ID format", err)
+	}
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	added, err := h.service.UpdateTaskTags(userObjID, categoryID, taskID, input.Body.TaggedUserIDs)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to update tags", err)
+	}
+
+	// Notify newly added friends (best-effort)
+	if len(added) > 0 {
+		task, err := h.service.findTaskInCategory(ctx, categoryID, taskID)
+		if err == nil {
+			notifyTask := *task
+			notifyTask.TaggedUsers = added
+			go h.service.NotifyTaggedUsers(&notifyTask, userObjID)
+		}
+	}
+
+	task, err := h.service.findTaskInCategory(ctx, categoryID, taskID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to fetch updated task", err)
+	}
+	resp := &UpdateTaskTagsOutput{}
+	resp.Body.TaggedUsers = task.TaggedUsers
+	return resp, nil
+}
+
+func RegisterUpdateTaskTagsOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "update-task-tags",
+		Method:      http.MethodPatch,
+		Path:        "/v1/user/tasks/{category}/{id}/tags",
+		Summary:     "Update task tags",
+		Description: "Replace the set of friends tagged on a task",
+		Tags:        []string{"tasks"},
+	}, handler.UpdateTaskTags)
+}
+```
+
+- [ ] **Step 6: Register the route**
+
+In `backend/internal/handlers/task/routes.go`, find `RegisterTaskOperations` and add:
+
+```go
+	RegisterUpdateTaskTagsOperation(api, handler)
+```
+
+- [ ] **Step 7: Build, test, commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): PATCH endpoint to update tags on an existing task"
+```
+
+---
+
+### Task 5: Pending tagged-tasks endpoint (feeds the home banner)
+
+**Files:**
+- Modify: `backend/internal/handlers/task/tag_service.go` (add GetPendingTaggedTasks)
+- Modify: `backend/internal/handlers/task/tag_operations.go` (add operation)
+- Modify: `backend/internal/handlers/task/routes.go`
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func (s *TagServiceTestSuite) TestGetPendingTaggedTasks_ReturnsTaskAndTagger() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+	categoryID := s.GetCategoryID(owner.ID)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", Priority: 1, Value: 2,
+		UserID: owner.ID, CategoryID: categoryID, Active: true, TaggedUsers: tagged}
+	_, err := s.service.CreateTask(categoryID, &task)
+	s.NoError(err)
+
+	pending, err := s.service.GetPendingTaggedTasks(friend.ID)
+	s.NoError(err)
+	s.Len(pending, 1)
+	s.Equal("Read 30 mins", pending[0].Content)
+	s.Equal(owner.ID, pending[0].Tagger.ID)
+	s.Equal(owner.DisplayName, pending[0].Tagger.DisplayName)
+
+	// Owner themselves has no pending tags
+	none, err := s.service.GetPendingTaggedTasks(owner.ID)
+	s.NoError(err)
+	s.Len(none, 0)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `GetPendingTaggedTasks undefined`.
+
+- [ ] **Step 3: Implement the aggregation**
+
+Add to `tag_service.go`:
+
+```go
+type TaggerInfo struct {
+	ID             primitive.ObjectID `bson:"id" json:"id"`
+	DisplayName    string             `bson:"display_name" json:"display_name"`
+	Handle         string             `bson:"handle" json:"handle"`
+	ProfilePicture string             `bson:"profile_picture" json:"profile_picture"`
+}
+
+// PendingTaggedTask carries everything the home banner and the Copy prefill
+// need in one payload.
+type PendingTaggedTask struct {
+	TaskID         primitive.ObjectID    `bson:"taskId" json:"taskId"`
+	Content        string                `bson:"content" json:"content"`
+	Value          float64               `bson:"value" json:"value"`
+	Priority       int                   `bson:"priority" json:"priority"`
+	Recurring      bool                  `bson:"recurring" json:"recurring"`
+	RecurFrequency string                `bson:"recurFrequency,omitempty" json:"recurFrequency,omitempty"`
+	RecurDetails   *RecurDetails         `bson:"recurDetails,omitempty" json:"recurDetails,omitempty"`
+	Deadline       *time.Time            `bson:"deadline,omitempty" json:"deadline,omitempty"`
+	Notes          string                `bson:"notes,omitempty" json:"notes,omitempty"`
+	Checklist      []ChecklistItem       `bson:"checklist,omitempty" json:"checklist,omitempty"`
+	Tagger         TaggerInfo            `bson:"tagger" json:"tagger"`
+}
+
+// GetPendingTaggedTasks returns every active task where userID is tagged with
+// status pending, joined with the tagger's display info.
+func (s *Service) GetPendingTaggedTasks(userID primitive.ObjectID) ([]PendingTaggedTask, error) {
+	ctx := context.Background()
+	elem := bson.M{"$elemMatch": bson.M{"id": userID, "status": types.TagStatusPending}}
+
+	pipeline := mongo.Pipeline{
+		{{Key: "$match", Value: bson.M{"tasks.taggedUsers": elem}}},
+		{{Key: "$unwind", Value: "$tasks"}},
+		{{Key: "$match", Value: bson.M{"tasks.taggedUsers": elem}}},
+		{{Key: "$lookup", Value: bson.M{
+			"from": "users", "localField": "user", "foreignField": "_id", "as": "taggerDoc",
+		}}},
+		{{Key: "$unwind", Value: "$taggerDoc"}},
+		{{Key: "$project", Value: bson.M{
+			"taskId":         "$tasks._id",
+			"content":        "$tasks.content",
+			"value":          "$tasks.value",
+			"priority":       "$tasks.priority",
+			"recurring":      "$tasks.recurring",
+			"recurFrequency": "$tasks.recurFrequency",
+			"recurDetails":   "$tasks.recurDetails",
+			"deadline":       "$tasks.deadline",
+			"notes":          "$tasks.notes",
+			"checklist":      "$tasks.checklist",
+			"tagger": bson.M{
+				"id":              "$taggerDoc._id",
+				"display_name":    "$taggerDoc.display_name",
+				"handle":          "$taggerDoc.handle",
+				"profile_picture": "$taggerDoc.profile_picture",
+			},
+		}}},
+		{{Key: "$sort", Value: bson.M{"taskId": -1}}}, // newest first (ObjectID encodes time)
+	}
+
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	results := make([]PendingTaggedTask, 0)
+	if err := cursor.All(ctx, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+```
+
+Add imports as needed (`time`, `go.mongodb.org/mongo-driver/mongo`).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS. If the tagger join comes back empty, check the categories collection's owner field name — `getBaseTaskPipeline` (task_service.go:42) references `"$user"`, so the field is `user`; verify the test fixture writes it the same way.
+
+- [ ] **Step 5: Add the HTTP operation**
+
+Add to `tag_operations.go`:
+
+```go
+type GetPendingTaggedTasksInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+}
+
+type GetPendingTaggedTasksOutput struct {
+	Body []PendingTaggedTask `json:"body"`
+}
+
+func (h *Handler) GetPendingTaggedTasks(ctx context.Context, input *GetPendingTaggedTasksInput) (*GetPendingTaggedTasksOutput, error) {
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	userObjID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	pending, err := h.service.GetPendingTaggedTasks(userObjID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("Unable to fetch pending tags", err)
+	}
+	return &GetPendingTaggedTasksOutput{Body: pending}, nil
+}
+
+func RegisterGetPendingTaggedTasksOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-pending-tagged-tasks",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/tagged-tasks",
+		Summary:     "Get pending tagged tasks",
+		Description: "Tasks the signed-in user has been tagged in and not yet responded to",
+		Tags:        []string{"tasks"},
+	}, handler.GetPendingTaggedTasks)
+}
+```
+
+Register in `routes.go`: `RegisterGetPendingTaggedTasksOperation(api, handler)`.
+
+- [ ] **Step 6: Build + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... && go test ./internal/handlers/task/... -run TestTagService -v`
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): GET /v1/user/tagged-tasks pending-tags endpoint"
+```
+
+---
+
+### Task 6: Respond to a tag (watch / copied / untagged) — POST endpoint
+
+**Files:**
+- Modify: `backend/internal/handlers/task/tag_service.go` (RespondToTaskTag)
+- Modify: `backend/internal/handlers/task/tag_notifications.go` (notifyTaskCopied)
+- Modify: `backend/internal/handlers/task/tag_operations.go`, `routes.go`
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing tests**
+
+```go
+func (s *TagServiceTestSuite) TestRespondToTaskTag_UpdatesStatusAndTemplate() {
+	owner := s.GetUser(0)
+	friend := s.GetUser(1)
+	categoryID := s.GetCategoryID(owner.ID)
+
+	tagged, _ := s.service.BuildTaggedUsers([]string{friend.ID.Hex()})
+
+	// Recurring task with a template so we can assert the mirror
+	templateID := primitive.NewObjectID()
+	s.InsertTemplate(types.TemplateTaskDocument{ // mirror however service_test.go seeds template-tasks; if no helper exists, insert directly into s.Collections["template-tasks"]
+		ID: templateID, UserID: owner.ID, CategoryID: categoryID,
+		Content: "Read 30 mins", RecurType: "OCCURRENCE", TaggedUsers: tagged,
+	})
+
+	task := TaskDocument{ID: primitive.NewObjectID(), Content: "Read 30 mins", Priority: 1, Value: 2,
+		UserID: owner.ID, CategoryID: categoryID, Active: true,
+		TemplateID: &templateID, TaggedUsers: tagged}
+	created, err := s.service.CreateTask(categoryID, &task)
+	s.NoError(err)
+
+	err = s.service.RespondToTaskTag(created.ID, friend.ID, types.TagStatusWatching)
+	s.NoError(err)
+
+	fetched, err := s.service.GetTaskByID(created.ID, owner.ID)
+	s.NoError(err)
+	s.Equal(types.TagStatusWatching, fetched.TaggedUsers[0].Status)
+
+	tmpl, err := s.service.GetTemplateByID(templateID)
+	s.NoError(err)
+	s.Equal(types.TagStatusWatching, tmpl.TaggedUsers[0].Status)
+}
+
+func (s *TagServiceTestSuite) TestRespondToTaskTag_RejectsInvalidStatus() {
+	err := s.service.RespondToTaskTag(primitive.NewObjectID(), primitive.NewObjectID(), "bogus")
+	s.Error(err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `RespondToTaskTag undefined`.
+
+- [ ] **Step 3: Implement RespondToTaskTag**
+
+Add to `tag_service.go`:
+
+```go
+// RespondToTaskTag records the tagged user's response on the live task and
+// mirrors it to the template so future recurrences inherit it. The nested
+// array filter scopes the write to the responder's own entry, so a user can
+// never modify someone else's tag state.
+func (s *Service) RespondToTaskTag(taskID, responderID primitive.ObjectID, status string) error {
+	if status != types.TagStatusWatching && status != types.TagStatusCopied && status != types.TagStatusUntagged {
+		return fmt.Errorf("invalid tag status: %q", status)
+	}
+	ctx := context.Background()
+
+	res, err := s.Tasks.UpdateOne(ctx,
+		bson.M{"tasks._id": taskID},
+		bson.M{"$set": bson.M{"tasks.$[t].taggedUsers.$[u].status": status}},
+		options.Update().SetArrayFilters(options.ArrayFilters{
+			Filters: bson.A{
+				bson.M{"t._id": taskID},
+				bson.M{"u.id": responderID},
+			},
+		}),
+	)
+	if err != nil {
+		return err
+	}
+	if res.MatchedCount == 0 {
+		return mongo.ErrNoDocuments
+	}
+
+	// Mirror to template (cross-user fetch: responder doesn't own the category)
+	pipeline := append(
+		[]bson.D{{{Key: "$match", Value: bson.M{"tasks._id": taskID}}}},
+		getBaseTaskPipeline()...,
+	)
+	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"_id": taskID}}})
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil // status already saved; mirror is best-effort
+	}
+	defer cursor.Close(ctx)
+	var tasks []TaskDocument
+	if err := cursor.All(ctx, &tasks); err != nil || len(tasks) == 0 {
+		return nil
+	}
+	task := tasks[0]
+	if task.TemplateID != nil {
+		if _, err := s.TemplateTasks.UpdateOne(ctx,
+			bson.M{"_id": *task.TemplateID},
+			bson.M{"$set": bson.M{"taggedUsers.$[u].status": status}},
+			options.Update().SetArrayFilters(options.ArrayFilters{
+				Filters: bson.A{bson.M{"u.id": responderID}},
+			}),
+		); err != nil {
+			slog.Error("Failed to mirror tag response to template", "templateID", task.TemplateID.Hex(), "error", err)
+		}
+	}
+	return nil
+}
+```
+
+Add imports (`fmt`, `go.mongodb.org/mongo-driver/mongo/options`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+- [ ] **Step 5: Implement notifyTaskCopied**
+
+Add to `tag_notifications.go`:
+
+```go
+// notifyTaskCopied tells the task owner that a tagged friend copied the task.
+// Push + TASK_COPIED record; best-effort.
+func (s *Service) notifyTaskCopied(taskID, ownerID, copierID primitive.ObjectID, taskName string) {
+	ctx := context.Background()
+
+	copier, err := s.Users.GetUserByID(ctx, copierID)
+	if err != nil || copier == nil {
+		return
+	}
+
+	content := fmt.Sprintf("copied your task \"%s\" 💪", taskName)
+	if err := s.NotificationService.CreateNotification(
+		copierID, ownerID, content, notifications.NotificationTypeTaskCopied, taskID,
+	); err != nil {
+		slog.Error("Failed to create TASK_COPIED record", "owner", ownerID, "error", err)
+	}
+
+	owner, err := s.Users.GetUserByID(ctx, ownerID)
+	if err != nil || owner == nil || owner.PushToken == "" {
+		return
+	}
+	_ = xutils.SendNotification(xutils.Notification{
+		Token:   owner.PushToken,
+		Title:   "Your task caught on 💪",
+		Message: fmt.Sprintf("%s copied your task \"%s\"", copier.DisplayName, taskName),
+		Data: map[string]string{
+			"type":    "task_copied",
+			"task_id": taskID.Hex(),
+			"user_id": copierID.Hex(),
+		},
+	})
+}
+```
+
+- [ ] **Step 6: Add the HTTP operation**
+
+Add to `tag_operations.go`:
+
+```go
+type RespondToTaskTagInput struct {
+	Authorization string `header:"Authorization" required:"true"`
+	ID            string `path:"id" example:"507f1f77bcf86cd799439011"`
+	Body          struct {
+		Status string `json:"status" enum:"watching,copied,untagged"`
+	} `json:"body"`
+}
+
+type RespondToTaskTagOutput struct {
+	Body struct {
+		Message string `json:"message" example:"Response recorded"`
+	} `json:"body"`
+}
+
+func (h *Handler) RespondToTaskTag(ctx context.Context, input *RespondToTaskTagInput) (*RespondToTaskTagOutput, error) {
+	taskID, err := primitive.ObjectIDFromHex(input.ID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid task ID format", err)
+	}
+	contextID, err := auth.RequireAuth(ctx)
+	if err != nil {
+		return nil, huma.Error401Unauthorized("Please log in to continue", err)
+	}
+	responderID, err := primitive.ObjectIDFromHex(contextID)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID format", err)
+	}
+
+	if err := h.service.RespondToTaskTag(taskID, responderID, input.Body.Status); err != nil {
+		return nil, huma.Error500InternalServerError("Unable to record response", err)
+	}
+
+	if input.Body.Status == types.TagStatusCopied {
+		// Fetch owner + name for the notification (cross-user pipeline)
+		if task, owner := h.service.lookupTaskAndOwner(taskID); task != nil {
+			go h.service.notifyTaskCopied(taskID, owner, responderID, task.Content)
+		}
+	}
+
+	resp := &RespondToTaskTagOutput{}
+	resp.Body.Message = "Response recorded"
+	return resp, nil
+}
+
+func RegisterRespondToTaskTagOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "respond-to-task-tag",
+		Method:      http.MethodPost,
+		Path:        "/v1/user/tagged-tasks/{id}/respond",
+		Summary:     "Respond to a task tag",
+		Description: "Watch, copy, or untag yourself from a task you were tagged in",
+		Tags:        []string{"tasks"},
+	}, handler.RespondToTaskTag)
+}
+```
+
+And the small lookup helper in `tag_service.go`:
+
+```go
+// lookupTaskAndOwner fetches a task across all users' categories. Returns the
+// task and its owner's ID (zero ID when not found).
+func (s *Service) lookupTaskAndOwner(taskID primitive.ObjectID) (*TaskDocument, primitive.ObjectID) {
+	ctx := context.Background()
+	pipeline := append(
+		[]bson.D{{{Key: "$match", Value: bson.M{"tasks._id": taskID}}}},
+		getBaseTaskPipeline()...,
+	)
+	pipeline = append(pipeline, bson.D{{Key: "$match", Value: bson.M{"_id": taskID}}})
+	cursor, err := s.Tasks.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, primitive.NilObjectID
+	}
+	defer cursor.Close(ctx)
+	var tasks []TaskDocument
+	if err := cursor.All(ctx, &tasks); err != nil || len(tasks) == 0 {
+		return nil, primitive.NilObjectID
+	}
+	return &tasks[0], tasks[0].UserID
+}
+```
+
+Register in `routes.go`: `RegisterRespondToTaskTagOperation(api, handler)`.
+
+- [ ] **Step 7: Build, test, commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): respond endpoint (watch/copy/untag) with copied notification"
+```
+
+---
+
+### Task 7: Watcher pushes on task completion
+
+**Files:**
+- Modify: `backend/internal/handlers/task/tag_notifications.go` (NotifyTagWatchersOfCompletion)
+- Modify: `backend/internal/handlers/task/task_service.go` (CompleteTask, ~line 508 next to the `NotifyEncouragersOfCompletion` call)
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Mirror the push-sender stubbing from `encouragement/service_test.go:651` (`TestNotifyEncouragersOfCompletion_Success`) — same mock, same assertion style:
+
+```go
+func (s *TagServiceTestSuite) TestNotifyTagWatchersOfCompletion_OnlyPendingAndWatching() {
+	owner := s.GetUser(0)
+	watcher := s.GetUser(1)
+	copier := s.GetUser(2)
+
+	task := TaskDocument{
+		ID: primitive.NewObjectID(), Content: "Read 30 mins", UserID: owner.ID,
+		TaggedUsers: []types.TaggedTaskUser{
+			{ID: watcher.ID, Handle: watcher.Handle, DisplayName: watcher.DisplayName, Status: types.TagStatusWatching},
+			{ID: copier.ID, Handle: copier.Handle, DisplayName: copier.DisplayName, Status: types.TagStatusCopied},
+		},
+	}
+
+	err := s.service.NotifyTagWatchersOfCompletion(&task, owner.ID)
+	s.NoError(err)
+	// Assert exactly one push was sent (to the watcher) using the mock sender,
+	// following the assertion pattern in encouragement/service_test.go.
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: compile error — `NotifyTagWatchersOfCompletion undefined`.
+
+- [ ] **Step 3: Implement**
+
+Add to `tag_notifications.go`:
+
+```go
+// NotifyTagWatchersOfCompletion pushes to every tagged user still in pending
+// or watching state. Push-only by design (spec: completion is a ping, not an
+// activity-feed event). copied/untagged users are never pinged.
+func (s *Service) NotifyTagWatchersOfCompletion(task *TaskDocument, ownerID primitive.ObjectID) error {
+	ctx := context.Background()
+
+	owner, err := s.Users.GetUserByID(ctx, ownerID)
+	if err != nil || owner == nil {
+		return err
+	}
+
+	for _, tu := range task.TaggedUsers {
+		if tu.Status != types.TagStatusPending && tu.Status != types.TagStatusWatching {
+			continue
+		}
+		receiver, err := s.Users.GetUserByID(ctx, tu.ID)
+		if err != nil || receiver == nil || receiver.PushToken == "" {
+			continue
+		}
+		notification := xutils.Notification{
+			Token:   receiver.PushToken,
+			Title:   "They did it! 🎉",
+			Message: fmt.Sprintf("%s completed \"%s\" 🎉", owner.DisplayName, task.Content),
+			Data: map[string]string{
+				"type":    "task_completed_watcher",
+				"user_id": ownerID.Hex(),
+				"task_id": task.ID.Hex(),
+			},
+		}
+		if err := xutils.SendNotification(notification); err != nil {
+			slog.Error("Failed to send watcher completion push", "receiver", tu.ID, "error", err)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+- [ ] **Step 5: Hook into CompleteTask**
+
+In `task_service.go` `CompleteTask`, find the `NotifyEncouragersOfCompletion` call (`grep -n "NotifyEncouragersOfCompletion" task_service.go`). Directly after it, add:
+
+```go
+	if len(taskToComplete.TaggedUsers) > 0 {
+		go func() {
+			if err := s.NotifyTagWatchersOfCompletion(&taskToComplete, userId); err != nil {
+				slog.Error("Failed to notify tag watchers", "taskID", taskToComplete.ID.Hex(), "error", err)
+			}
+		}()
+	}
+```
+
+(Note: `BulkCompleteTask` intentionally does not ping watchers in v1 — single completion is the accountability moment. If bulk-complete pings are wanted later, hook the same helper there.)
+
+- [ ] **Step 6: Build, run the full task test suite, commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go build ./... && go test ./internal/handlers/task/... -v`
+Expected: all task package tests PASS (including pre-existing ones).
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): push watchers when a tagged task is completed"
+```
+
+---
+
+### Task 8: Tags survive recurrence
+
+**Files:**
+- Modify: `backend/internal/handlers/task/util.go` (constructTaskFromTemplate, ~line 353)
+- Test: extend `backend/internal/handlers/task/tag_service_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+```go
+func (s *TagServiceTestSuite) TestConstructTaskFromTemplate_CopiesTaggedUsers() {
+	friend := s.GetUser(1)
+	tmpl := types.TemplateTaskDocument{
+		ID: primitive.NewObjectID(), Content: "Read 30 mins", RecurType: "OCCURRENCE",
+		TaggedUsers: []types.TaggedTaskUser{
+			{ID: friend.ID, Handle: friend.Handle, DisplayName: friend.DisplayName, Status: types.TagStatusWatching},
+		},
+	}
+
+	task := constructTaskFromTemplate(&tmpl)
+
+	s.Len(task.TaggedUsers, 1)
+	s.Equal(types.TagStatusWatching, task.TaggedUsers[0].Status)
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: FAIL — `task.TaggedUsers` empty.
+
+- [ ] **Step 3: Implement**
+
+In `util.go` `constructTaskFromTemplate` (~line 363), add to the `TaskDocument{...}` literal:
+
+```go
+		TaggedUsers:    templateDoc.TaggedUsers,
+```
+
+- [ ] **Step 4: Run test to verify it passes, commit**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go test ./internal/handlers/task/... -run TestTagService -v`
+Expected: PASS.
+
+```bash
+git add backend/internal/handlers/task/
+git commit -m "feat(tags): recurring instances inherit tag state from template"
+```
+
+---
+
+## Frontend
+
+### Task 9: Frontend types + API client functions
+
+**Files:**
+- Modify: `frontend/api/types.ts` (Task interface ~line 92)
+- Modify: `frontend/api/task.ts`
+
+- [ ] **Step 1: Add types**
+
+In `frontend/api/types.ts`, above the `Task` interface, add:
+
+```typescript
+export type TagStatus = "pending" | "watching" | "copied" | "untagged";
+
+export interface TaggedTaskUser {
+    id: string;
+    handle: string;
+    display_name: string;
+    profile_picture?: string;
+    status: TagStatus;
+}
+
+export interface PendingTaggedTask {
+    taskId: string;
+    content: string;
+    value: number;
+    priority: number;
+    recurring: boolean;
+    recurFrequency?: string;
+    recurDetails?: RecurDetails;
+    deadline?: string;
+    notes?: string;
+    checklist?: ChecklistItem[];
+    tagger: {
+        id: string;
+        display_name: string;
+        handle: string;
+        profile_picture?: string;
+    };
+}
+```
+
+In the `Task` interface, after `encouragements?: TaskKudos[];`, add:
+
+```typescript
+    taggedUsers?: TaggedTaskUser[];
+```
+
+- [ ] **Step 2: Add API functions**
+
+In `frontend/api/task.ts` (match the file's existing style — it uses `request` from `@/hooks/useRequest` and a logger), add:
+
+```typescript
+import type { PendingTaggedTask, TaggedTaskUser, TagStatus } from "./types";
+
+export const updateTaskTagsAPI = async (
+    categoryId: string,
+    taskId: string,
+    taggedUserIds: string[]
+): Promise<{ taggedUsers: TaggedTaskUser[] }> => {
+    return await request("PATCH", `/user/tasks/${categoryId}/${taskId}/tags`, { taggedUserIds });
+};
+
+export const getPendingTaggedTasksAPI = async (): Promise<PendingTaggedTask[]> => {
+    return await request("GET", "/user/tagged-tasks");
+};
+
+export const respondToTaskTagAPI = async (
+    taskId: string,
+    status: Exclude<TagStatus, "pending">
+): Promise<void> => {
+    await request("POST", `/user/tagged-tasks/${taskId}/respond`, { status });
+};
+```
+
+Check the top of `task.ts` for how `request` is imported (it may be `const { request } = useRequest()` pattern or a direct import like `api/notifications.ts:4` uses — copy `notifications.ts`'s direct `import { request } from "@/hooks/useRequest"` if `task.ts` doesn't already import it).
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+Expected: no new errors (pre-existing errors, if any, are unchanged — note them before starting).
+
+```bash
+git add frontend/api/types.ts frontend/api/task.ts
+git commit -m "feat(tags): frontend types and API client for task tagging"
+```
+
+---
+
+### Task 10: Extract shared FriendPicker from tag-people
+
+**Files:**
+- Create: `frontend/components/inputs/FriendPicker.tsx`
+- Modify: `frontend/app/(logged-in)/posting/tag-people.tsx` (refactor to use it — zero behavior change)
+
+- [ ] **Step 1: Create FriendPicker**
+
+Move the search input + FlatList + FriendRow out of `tag-people.tsx` into `frontend/components/inputs/FriendPicker.tsx`:
+
+```typescript
+import React, { useMemo, useState } from "react";
+import { FlatList, TouchableOpacity, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import ThemedInput from "@/components/inputs/ThemedInput";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+import { Ionicons } from "@expo/vector-icons";
+import { formatHandle } from "@/utils/handle";
+
+type Props = {
+    selectedIds: Set<string>;
+    onToggle: (candidate: MentionCandidate) => void;
+    /** Friend IDs that can't be toggled off (e.g. tags already responded to). */
+    lockedIds?: Set<string>;
+};
+
+const FriendPicker = ({ selectedIds, onToggle, lockedIds }: Props) => {
+    const ThemedColor = useThemeColor();
+    const [query, setQuery] = useState("");
+    const { filter } = useFriendsForMention();
+    const matches = useMemo(() => filter(query), [query, filter]);
+
+    return (
+        <View style={{ flex: 1, gap: 12 }}>
+            <ThemedInput value={query} setValue={setQuery} placeHolder="Search friends" />
+            <FlatList
+                data={matches}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                    <FriendRow
+                        item={item}
+                        checked={selectedIds.has(item.id)}
+                        locked={lockedIds?.has(item.id) ?? false}
+                        onToggle={onToggle}
+                        primaryColor={ThemedColor.primary}
+                        captionColor={ThemedColor.caption}
+                    />
+                )}
+            />
+        </View>
+    );
+};
+
+type FriendRowProps = {
+    item: MentionCandidate;
+    checked: boolean;
+    locked: boolean;
+    onToggle: (c: MentionCandidate) => void;
+    primaryColor: string;
+    captionColor: string;
+};
+
+function FriendRow({ item, checked, locked, onToggle, primaryColor, captionColor }: FriendRowProps) {
+    return (
+        <TouchableOpacity
+            disabled={locked}
+            onPress={() => onToggle(item)}
+            style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, gap: 12, opacity: locked ? 0.5 : 1 }}>
+            <View style={{ flex: 1 }}>
+                <ThemedText type="defaultSemiBold">{item.display_name}</ThemedText>
+                <ThemedText type="caption">{formatHandle(item.handle)}</ThemedText>
+            </View>
+            <Ionicons
+                name={checked ? "checkmark-circle" : "ellipse-outline"}
+                size={22}
+                color={checked ? primaryColor : captionColor}
+            />
+        </TouchableOpacity>
+    );
+}
+
+export default FriendPicker;
+```
+
+- [ ] **Step 2: Refactor tag-people.tsx to use it**
+
+Replace the body of `tag-people.tsx` so the search/list portion renders `<FriendPicker selectedIds={...} onToggle={toggle} />` while keeping the header (back arrow, "Tag people" title, Done button) and the `usePostComposer` wiring identical. `selectedIds` is derived: `new Set(selected.keys())`. The `toggle` and `done` functions stay as they are.
+
+- [ ] **Step 3: Verify no behavior change**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+Expected: clean. Manually confirm `tag-people.tsx` no longer defines its own FriendRow/FlatList (the only render path is FriendPicker).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/components/inputs/FriendPicker.tsx "frontend/app/(logged-in)/posting/tag-people.tsx"
+git commit -m "refactor: extract FriendPicker from tag-people for reuse"
+```
+
+---
+
+### Task 11: Tagging in the create flow
+
+**Files:**
+- Modify: `frontend/contexts/taskCreationContext.tsx`
+- Modify: `frontend/components/modals/create/Collaborators.tsx` (replace placeholder)
+- Modify: `frontend/components/modals/create/Standard.tsx` (advanced option + postBody + copy-respond)
+
+- [ ] **Step 1: Extend TaskCreationContext**
+
+In `frontend/contexts/taskCreationContext.tsx`:
+
+Add to the type (after `integration`/`setIntegration`):
+
+```typescript
+    taggedUsers: TaggedUser[];
+    setTaggedUsers: (users: TaggedUser[]) => void;
+    /** Notes/checklist prefill — used by the tag Copy flow; create otherwise sends empty. */
+    notes: string;
+    setNotes: (notes: string) => void;
+    checklist: ChecklistItem[];
+    setChecklist: (items: ChecklistItem[]) => void;
+    /** When set, a successful create marks this original task's tag as "copied". */
+    copySourceTaskId: string | null;
+    setCopySourceTaskId: (id: string | null) => void;
+```
+
+Imports: `import type { TaggedUser } from "@/components/inputs/TaggedUsersChips";` and `import type { ChecklistItem } from "@/api/types";` (check the exact exported name in `api/types.ts` — adjust if it differs).
+
+Add state in the provider:
+
+```typescript
+    const [taggedUsers, setTaggedUsers] = useState<TaggedUser[]>([]);
+    const [notes, setNotes] = useState("");
+    const [checklist, setChecklist] = useState<ChecklistItem[]>([]);
+    const [copySourceTaskId, setCopySourceTaskId] = useState<string | null>(null);
+```
+
+In `resetTaskCreation`, add:
+
+```typescript
+        setTaggedUsers([]);
+        setNotes("");
+        setChecklist([]);
+        setCopySourceTaskId(null);
+```
+
+In `loadTaskData`, add:
+
+```typescript
+        setNotes(taskData.notes || "");
+        setChecklist(taskData.checklist || []);
+        setTaggedUsers([]);
+```
+
+Add all eight new values to `contextValue` and the new state to the `useMemo` dependency array.
+
+- [ ] **Step 2: Replace the Collaborators placeholder screen**
+
+Rewrite `frontend/components/modals/create/Collaborators.tsx`:
+
+```typescript
+import React from "react";
+import { View, TouchableOpacity } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import Feather from "@expo/vector-icons/Feather";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
+import FriendPicker from "@/components/inputs/FriendPicker";
+import TaggedUsersChips from "@/components/inputs/TaggedUsersChips";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
+
+type Props = {
+    goToStandard: () => void;
+};
+
+const Collaborators = ({ goToStandard }: Props) => {
+    const ThemedColor = useThemeColor();
+    const { taggedUsers, setTaggedUsers } = useTaskCreation();
+
+    const toggle = (c: MentionCandidate) => {
+        if (taggedUsers.some((u) => u.id === c.id)) {
+            setTaggedUsers(taggedUsers.filter((u) => u.id !== c.id));
+        } else {
+            setTaggedUsers([...taggedUsers, { id: c.id, handle: c.handle, display_name: c.display_name }]);
+        }
+    };
+
+    return (
+        <View style={{ gap: 16, flex: 1 }}>
+            <View style={{ flexDirection: "row", gap: 16, alignItems: "center" }}>
+                <TouchableOpacity onPress={goToStandard}>
+                    <Feather name="arrow-left" size={24} color={ThemedColor.text} />
+                </TouchableOpacity>
+                <ThemedText type="defaultSemiBold">Tag friends</ThemedText>
+            </View>
+            <TaggedUsersChips users={taggedUsers} onRemove={(id) => setTaggedUsers(taggedUsers.filter((u) => u.id !== id))} />
+            <FriendPicker selectedIds={new Set(taggedUsers.map((u) => u.id))} onToggle={toggle} />
+        </View>
+    );
+};
+
+export default Collaborators;
+```
+
+(Note: `TaggedUsersChips` has `paddingHorizontal: 16` baked in; if it looks double-padded inside the modal, pass-through styling fix is acceptable but don't restructure the component.)
+
+- [ ] **Step 3: Wire Standard.tsx**
+
+In `frontend/components/modals/create/Standard.tsx`:
+
+1. Pull the new fields in the `useTaskCreation()` destructure: `taggedUsers`, `notes`, `checklist`, `copySourceTaskId`, `setCopySourceTaskId`.
+2. In `createPost`, in `postBody`, replace the hardcoded `checklist: []` and `notes: ""` with `checklist: checklist`, `notes: notes`, and add:
+
+```typescript
+            taggedUserIds: taggedUsers.length > 0 ? taggedUsers.map((u) => u.id) : undefined,
+```
+
+3. Also update the `optimisticTask` to carry `notes` and `checklist` (same values) so the optimistic card matches.
+4. After the successful `request("POST", ...)` (right after `addToCategory(selectedCategory.id, response)`), add:
+
+```typescript
+            if (copySourceTaskId) {
+                const { respondToTaskTagAPI } = await import("@/api/task");
+                respondToTaskTagAPI(copySourceTaskId, "copied").catch(() => {});
+                setCopySourceTaskId(null);
+                queryClient.invalidateQueries({ queryKey: ["taskTags", "pending"] });
+            }
+```
+
+5. In `AdvancedOptionList`, replace the commented-out Collaborators block (~line 859-866) with a live option, create-mode only. `AdvancedOptionList` needs an `edit` prop passed down from `Standard` (`<AdvancedOptionList goTo={goTo} showUnconfigured={...} edit={edit} />` at both call sites, ~line 515 and ~536):
+
+```typescript
+            {!edit && (
+                <AdvancedOption
+                    icon="people"
+                    label={
+                        taggedUsers.length > 0
+                            ? `Tagged: ${taggedUsers.map((u) => u.handle).join(", ")}`
+                            : "Tag friends"
+                    }
+                    screen={Screen.COLLABORATORS}
+                    goTo={goTo}
+                    showUnconfigured={showUnconfigured}
+                    configured={taggedUsers.length > 0}
+                />
+            )}
+```
+
+(`taggedUsers` comes from adding it to the `useTaskCreation()` destructure inside `AdvancedOptionList`. Handles already contain `@` — join them as-is.)
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+Expected: clean.
+
+```bash
+git add frontend/contexts/taskCreationContext.tsx frontend/components/modals/create/
+git commit -m "feat(tags): tag friends from the create-task flow"
+```
+
+---
+
+### Task 12: Home-screen tag banner (V2-B design)
+
+**Files:**
+- Create: `frontend/hooks/usePendingTaskTags.ts`
+- Create: `frontend/components/dashboard/TaggedTaskBanner.tsx`
+- Modify: `frontend/components/dashboard/HomescrollContent.tsx` (~line 336, first child of the MotiView)
+
+- [ ] **Step 1: Create the query hook**
+
+`frontend/hooks/usePendingTaskTags.ts`:
+
+```typescript
+import { useQuery } from "@tanstack/react-query";
+import { getPendingTaggedTasksAPI } from "@/api/task";
+
+export const PENDING_TAGS_KEY = ["taskTags", "pending"] as const;
+
+export const usePendingTaskTags = () => {
+    return useQuery({
+        queryKey: PENDING_TAGS_KEY,
+        queryFn: getPendingTaggedTasksAPI,
+        staleTime: 60_000,
+    });
+};
+```
+
+- [ ] **Step 2: Create the banner component**
+
+`frontend/components/dashboard/TaggedTaskBanner.tsx`. Design locked during brainstorming (V2-B): hairline top border in brand purple, avatar + "**[Name]** tagged you in a task" with task name · points below, three text actions in one row — **Watch** (purple, primary), **Copy**, **Untag me** (both caption gray). No card background, no nesting.
+
+```typescript
+import React from "react";
+import { View, TouchableOpacity } from "react-native";
+import { Image } from "expo-image";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
+import { useCreateModal } from "@/contexts/createModalContext";
+import { respondToTaskTagAPI } from "@/api/task";
+import { usePendingTaskTags, PENDING_TAGS_KEY } from "@/hooks/usePendingTaskTags";
+import type { PendingTaggedTask } from "@/api/types";
+
+const HORIZONTAL_PADDING = 16; // match HomescrollContent's constant — check its value and import/duplicate accordingly
+
+export const TaggedTaskBanners = () => {
+    const { data } = usePendingTaskTags();
+    if (!data || data.length === 0) return null;
+    return (
+        <View style={{ gap: 4, marginHorizontal: HORIZONTAL_PADDING }}>
+            {data.map((tag) => (
+                <TaggedTaskBannerRow key={tag.taskId} tag={tag} />
+            ))}
+        </View>
+    );
+};
+
+const TaggedTaskBannerRow = ({ tag }: { tag: PendingTaggedTask }) => {
+    const ThemedColor = useThemeColor();
+    const queryClient = useQueryClient();
+    const { loadTaskData, setCopySourceTaskId } = useTaskCreation();
+    const { openModal } = useCreateModal();
+
+    const respond = useMutation({
+        mutationFn: (status: "watching" | "untagged") => respondToTaskTagAPI(tag.taskId, status),
+        onMutate: async () => {
+            await queryClient.cancelQueries({ queryKey: PENDING_TAGS_KEY });
+            const prev = queryClient.getQueryData<PendingTaggedTask[]>(PENDING_TAGS_KEY);
+            queryClient.setQueryData<PendingTaggedTask[]>(PENDING_TAGS_KEY, (old) =>
+                (old ?? []).filter((t) => t.taskId !== tag.taskId)
+            );
+            return { prev };
+        },
+        onError: (_err, _status, ctx) => {
+            if (ctx?.prev) queryClient.setQueryData(PENDING_TAGS_KEY, ctx.prev);
+        },
+    });
+
+    // v1 scope note: openModal() presents the create sheet with the category
+    // dropdown scoped to the user's currently selected workspace (that's how
+    // useTasks().categories works). The spec's "pick workspace and category"
+    // is satisfied for the common case; a pre-modal workspace picker is a
+    // deliberate fast-follow, not part of this plan.
+    const handleCopy = () => {
+        setCopySourceTaskId(tag.taskId);
+        loadTaskData({
+            content: tag.content,
+            value: tag.value,
+            priority: tag.priority,
+            recurring: tag.recurring,
+            recurFrequency: tag.recurFrequency,
+            recurDetails: tag.recurDetails,
+            deadline: tag.deadline,
+            notes: tag.notes,
+            checklist: tag.checklist,
+        });
+        openModal();
+    };
+
+    return (
+        <View style={{ borderTopWidth: 1, borderTopColor: ThemedColor.primary, paddingTop: 10, paddingBottom: 6, gap: 9 }}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+                <Image
+                    source={tag.tagger.profile_picture ? { uri: tag.tagger.profile_picture } : undefined}
+                    style={{ width: 32, height: 32, borderRadius: 16, backgroundColor: ThemedColor.primary }}
+                />
+                <View style={{ flex: 1 }}>
+                    <ThemedText type="default">
+                        <ThemedText type="defaultSemiBold">{tag.tagger.display_name}</ThemedText> tagged you in a task
+                    </ThemedText>
+                    <ThemedText type="caption">
+                        {tag.content} · {tag.value} pts
+                    </ThemedText>
+                </View>
+            </View>
+            <View style={{ flexDirection: "row", gap: 24 }}>
+                <TouchableOpacity onPress={() => respond.mutate("watching")} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>Watch</ThemedText>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={handleCopy} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.caption }}>Copy</ThemedText>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={() => respond.mutate("untagged")} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.caption, opacity: 0.6 }}>Untag me</ThemedText>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+};
+```
+
+(Memory note applies: `expo-image` ignores RN `shadow*` props — this design has no shadow, so nothing to work around. Check how `HORIZONTAL_PADDING` is defined in HomescrollContent.tsx and reuse the same value/import.)
+
+- [ ] **Step 3: Mount in HomescrollContent**
+
+In `frontend/components/dashboard/HomescrollContent.tsx`, import `{ TaggedTaskBanners } from "./TaggedTaskBanner"` and render it as the first child inside the `<MotiView style={{ gap: 16, marginTop: 0 }}>` (~line 336), above the DashboardStats block:
+
+```tsx
+            <MotiView style={{ gap: 16, marginTop: 0 }}>
+                <TaggedTaskBanners />
+                {/* Dashboard Stats - always visible */}
+```
+
+Also wire pull-to-refresh: find where `onRefresh` is composed (in the home screen `index.tsx` or wherever the prop originates) and add `queryClient.invalidateQueries({ queryKey: ["taskTags", "pending"] })` alongside the existing refresh invalidations. If `onRefresh` lives outside this file, make the change where the other query invalidations already happen.
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+Expected: clean.
+
+```bash
+git add frontend/hooks/usePendingTaskTags.ts frontend/components/dashboard/
+git commit -m "feat(tags): home-screen banner with Watch/Copy/Untag actions"
+```
+
+---
+
+### Task 13: Tag entry point on the task detail screen
+
+**Files:**
+- Create: `frontend/components/modals/TagFriendsModal.tsx`
+- Modify: `frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx` (header row ~line 571-585, next to the PencilSimple edit button)
+
+- [ ] **Step 1: Create TagFriendsModal**
+
+```typescript
+import React, { useMemo, useState } from "react";
+import { Modal, View, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ThemedView } from "@/components/ThemedView";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import FriendPicker from "@/components/inputs/FriendPicker";
+import { updateTaskTagsAPI } from "@/api/task";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
+import type { Task } from "@/api/types";
+
+type Props = {
+    visible: boolean;
+    onClose: () => void;
+    task: Task;
+    onTagsUpdated: (taggedUsers: Task["taggedUsers"]) => void;
+};
+
+const TagFriendsModal = ({ visible, onClose, task, onTagsUpdated }: Props) => {
+    const insets = useSafeAreaInsets();
+    const ThemedColor = useThemeColor();
+
+    // Responded entries are locked: spec keeps removal-after-response out of scope
+    const lockedIds = useMemo(
+        () => new Set((task.taggedUsers ?? []).filter((t) => t.status !== "pending").map((t) => t.id)),
+        [task.taggedUsers]
+    );
+    const [selected, setSelected] = useState<Set<string>>(
+        () => new Set((task.taggedUsers ?? []).filter((t) => t.status !== "untagged").map((t) => t.id))
+    );
+
+    const toggle = (c: MentionCandidate) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(c.id)) next.delete(c.id);
+            else next.add(c.id);
+            return next;
+        });
+    };
+
+    const save = async () => {
+        try {
+            const result = await updateTaskTagsAPI(task.categoryID!, task.id, Array.from(selected));
+            onTagsUpdated(result.taggedUsers);
+        } catch (error) {
+            console.error("Failed to update tags:", error);
+        }
+        onClose();
+    };
+
+    return (
+        <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+            <ThemedView style={{ flex: 1, paddingTop: insets.top, paddingHorizontal: 16, gap: 12 }}>
+                <View style={{ flexDirection: "row", alignItems: "center", paddingVertical: 12 }}>
+                    <TouchableOpacity onPress={onClose} hitSlop={8}>
+                        <ThemedText style={{ color: ThemedColor.caption }}>Cancel</ThemedText>
+                    </TouchableOpacity>
+                    <ThemedText type="subtitle" style={{ flex: 1, textAlign: "center" }}>Tag friends</ThemedText>
+                    <TouchableOpacity onPress={save} hitSlop={8}>
+                        <ThemedText style={{ color: ThemedColor.primary }}>Done</ThemedText>
+                    </TouchableOpacity>
+                </View>
+                <FriendPicker selectedIds={selected} onToggle={toggle} lockedIds={lockedIds} />
+            </ThemedView>
+        </Modal>
+    );
+};
+
+export default TagFriendsModal;
+```
+
+- [ ] **Step 2: Add the trigger to the detail screen**
+
+In `[id].tsx`, in the header row containing the `PencilSimple` edit button (~line 581), wrap the two icons in a row and add a `UserPlus` (phosphor) button before the pencil:
+
+```tsx
+                        <View style={{ flexDirection: "row", gap: 16, alignItems: "center" }}>
+                            <TouchableOpacity onPress={() => setShowTagModal(true)}>
+                                <UserPlus size={24} color={ThemedColor.text} weight="regular" />
+                            </TouchableOpacity>
+                            <TouchableOpacity onPress={handleEditPress}>
+                                <PencilSimple size={24} color={ThemedColor.text} weight="regular" />
+                            </TouchableOpacity>
+                        </View>
+```
+
+Add `const [showTagModal, setShowTagModal] = useState(false);`, import `UserPlus` from `phosphor-react-native` (alongside the existing `PencilSimple` import) and `TagFriendsModal`. Render at the bottom of the screen's JSX (only when a task is loaded):
+
+```tsx
+            {task && (
+                <TagFriendsModal
+                    visible={showTagModal}
+                    onClose={() => setShowTagModal(false)}
+                    task={task}
+                    onTagsUpdated={(taggedUsers) => updateTask(task.categoryID!, task.id, { taggedUsers })}
+                />
+            )}
+```
+
+(`task` and `updateTask` come from `useTasks()` — check how `[id].tsx` already obtains the task object and its update helper, and use those exact names. If `updateTask`'s signature doesn't accept partials, refresh via the screen's existing task re-fetch path instead.)
+
+- [ ] **Step 3: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+
+```bash
+git add frontend/components/modals/TagFriendsModal.tsx "frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx"
+git commit -m "feat(tags): tag friends from the task detail screen"
+```
+
+---
+
+### Task 14: Watcher glow on the task card
+
+**Files:**
+- Modify: `frontend/components/cards/encouragedTask.ts`
+- Modify: `frontend/components/cards/TaskCard.tsx` (~line 98 and the EncouragerAvatars usage ~line 511)
+- Modify: `frontend/components/cards/EncouragerAvatars.tsx`
+
+- [ ] **Step 1: Extend the glow predicate**
+
+In `encouragedTask.ts`, add:
+
+```typescript
+// A task is "watched" when a tagged friend is pending or actively watching.
+export const isTaskWatched = (task?: Task | null): boolean =>
+    (task?.taggedUsers ?? []).some((t) => t.status === "pending" || t.status === "watching");
+```
+
+- [ ] **Step 2: Apply in TaskCard**
+
+In `TaskCard.tsx` line 98, change:
+
+```typescript
+    const encouraged = isTaskEncouraged(task) || isTaskWatched(task);
+```
+
+(import `isTaskWatched` alongside `isTaskEncouraged`). The glow, border, and text color now also light up for watched tasks — exactly the spec's "existing encouragements glow-icon treatment".
+
+- [ ] **Step 3: Merge watchers into the avatar stack**
+
+In `EncouragerAvatars.tsx`, add an optional `taggedUsers?: TaggedTaskUser[]` prop. Merge avatar sources before rendering: kudos senders (existing `encouragements[].sender.icon`) plus tagged users with status `pending`/`watching` (`profile_picture`), de-duplicated by user id, still capped at the existing max (3). Follow the component's existing avatar-rendering markup exactly — only the input list changes.
+
+In `TaskCard.tsx` (~line 511), pass the new prop:
+
+```tsx
+    <EncouragerAvatars
+        encouragements={task?.encouragements ?? []}
+        taggedUsers={task?.taggedUsers ?? []}
+        ringColor={ThemedColor.background}
+        placeholderColor={ThemedColor.primary}
+    />
+```
+
+And update the render condition from `encouraged` to the same merged flag used at line 98 (the variable already covers both after Step 2).
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+
+```bash
+git add frontend/components/cards/
+git commit -m "feat(tags): watcher glow + avatars on task cards"
+```
+
+---
+
+### Task 15: Notification plumbing (frontend)
+
+**Files:**
+- Modify: `frontend/utils/notifications.ts`
+- Modify: `frontend/components/notifications/NotificationsView.tsx` (~line 341 nav switch, ~line 438 type cast)
+- Modify: `frontend/app/(logged-in)/_layout.tsx` (NotificationType union ~line 50-62, getNotificationRoute ~line 93)
+
+- [ ] **Step 1: Extend ProcessedNotification types**
+
+In `frontend/utils/notifications.ts`, add to the `type` union:
+
+```typescript
+        | "task_tagged"
+        | "task_copied"
+```
+
+Add `"task_tagged"` and `"task_copied"` to `SUPPORTED_TYPES`.
+
+- [ ] **Step 2: NotificationsView navigation cases**
+
+In `NotificationsView.tsx`, find the navigation `switch` (~line 341) and add:
+
+```typescript
+            case "task_tagged":
+                // Banner lives on home — send them there
+                router.push("/(logged-in)/(tabs)/(task)");
+                break;
+            case "task_copied":
+                router.push(`/(logged-in)/(tabs)/(task)/task/${notification.referenceId}`);
+                break;
+```
+
+(Match the file's exact navigation idiom — if surrounding cases use `router.push(... as Href)` or a typed helper, do the same. Routes must be typed against `Href`, never `as any`.)
+
+The `rawType.toLowerCase()` mapping (~line 404) converts `TASK_TAGGED` → `task_tagged` automatically; extend the union cast at ~line 438 to include the two new literals.
+
+- [ ] **Step 3: Push deep-link routes**
+
+In `_layout.tsx`:
+
+1. Add `"task_tagged" | "task_copied" | "task_completed_watcher"` to the `NotificationType` union (~line 50-62).
+2. In `getNotificationRoute`, add cases:
+
+```typescript
+        case "task_tagged":
+            // Response banner lives on the home screen
+            return "/(logged-in)/(tabs)/(task)";
+        case "task_copied":
+            if (data.task_id) {
+                return `/(logged-in)/(tabs)/(task)/task/${data.task_id}`;
+            }
+            return "/(logged-in)/(tabs)/(task)";
+        case "task_completed_watcher":
+            if (data.user_id) {
+                return `/(logged-in)/(tabs)/(feed,search,profile)/account/${data.user_id}`;
+            }
+            return "/(logged-in)/(tabs)/(task)";
+```
+
+- [ ] **Step 4: Typecheck + commit**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+
+```bash
+git add frontend/utils/notifications.ts frontend/components/notifications/NotificationsView.tsx "frontend/app/(logged-in)/_layout.tsx"
+git commit -m "feat(tags): notification types and deep-link routes for tagging"
+```
+
+---
+
+### Task 16: Full verification
+
+- [ ] **Step 1: Backend full test run**
+
+Run: `cd /Users/abhik.ray/Kindred/backend && go vet ./... && go test ./...`
+Expected: all packages PASS, vet clean.
+
+- [ ] **Step 2: Frontend typecheck**
+
+Run: `cd /Users/abhik.ray/Kindred/frontend && bun x tsc --noEmit`
+Expected: no errors beyond any noted pre-existing baseline.
+
+- [ ] **Step 3: Manual smoke checklist (two simulator accounts / TestFlight)**
+
+1. User A creates a task, tags User B from the create sheet → B receives push; banner appears on B's home.
+2. B taps **Watch** → banner dismisses; A's task card shows the glow + B's avatar.
+3. A completes the task → B receives the "They did it! 🎉" push.
+4. Repeat with **Copy** → create sheet opens pre-filled (content, points, deadline, recurrence, notes, checklist); B picks a workspace/category, saves → A receives "copied your task 💪" push; B's banner is gone.
+5. Repeat with **Untag me** → banner gone silently; A gets nothing; A's glow/avatar for B disappears.
+6. Tag from the task detail screen (UserPlus icon) → same push/banner behavior; already-responded friends show locked in the picker.
+7. Recurring task: tag → B watches → A completes → next instance generated still carries B as watching (complete it again, B pinged again).
+
+- [ ] **Step 4: Final commit if any fixups, then report**
+
+```bash
+git status   # confirm clean tree, all work committed
+```

--- a/docs/superpowers/specs/2026-06-10-task-tagging-design.md
+++ b/docs/superpowers/specs/2026-06-10-task-tagging-design.md
@@ -1,0 +1,117 @@
+# Task Tagging Design
+
+**Date:** 2026-06-10
+**Status:** Approved
+
+## Overview
+
+Users can tag friends in their tasks. The tagged person becomes an accountability witness — they're notified when the task is created, can choose to Watch or Copy the task, and are pinged on completion. The tagger sees watchers reflected on their task using the existing encouragements glow-icon UI.
+
+---
+
+## Data Model
+
+One new field on the `Task` type:
+
+```ts
+taggedUsers: {
+  id: string
+  handle: string
+  display_name: string
+  status: 'pending' | 'watching' | 'copied' | 'untagged'
+}[]
+```
+
+**Status meanings:**
+- `pending` — tagged, no response yet
+- `watching` — responded Watch; receives completion pings
+- `copied` — responded Copy; has their own task, no further prompts or pings on the original
+- `untagged` — dismissed; never re-prompted, never pinged
+
+The backend excludes `untagged` entries from all social display and notification logic.
+
+### New Notification Types
+
+Added alongside existing `post_tag`:
+
+| Type | Recipient | Trigger |
+|---|---|---|
+| `task_tagged` | Tagged user | Tagger saves a task with them tagged |
+| `task_copied` | Tagger | Tagged user responds Copy |
+| `task_completed_watcher` | All `watching` users | Task marked complete |
+
+---
+
+## Tagger Flow
+
+### Entry point 1 — During task creation
+A "Tag a friend" field at the bottom of the create task sheet, styled consistently with existing deadline/reminder fields. Tapping opens the existing `tag-people.tsx` screen (reused from posts). Multiple friends can be tagged. Selected friends render as avatar chips inline in the create sheet.
+
+### Entry point 2 — On an existing task
+A tag icon (person+) in the task detail action row. Tapping opens `tag-people.tsx` with already-tagged users pre-selected. Adding or removing tags from here updates `taggedUsers` in place.
+
+### Visibility after tagging
+Watchers are reflected using the existing encouragements glow-icon treatment on the task row, right-aligned. No new UI is added — the existing social signal accumulates watchers alongside encouragements. `pending` and `watching` users contribute to the count. `untagged` users do not.
+
+---
+
+## Tagged Person Flow
+
+1. Tagged person receives a `task_tagged` push notification.
+2. Opening the app shows a persistent banner at the top of the Home screen:
+   - Top hairline in brand purple
+   - Avatar + **"[Name] tagged you in a task"** + task name/points beneath
+   - Three text actions: **Watch** (purple, primary) · Copy · Untag me
+3. The banner persists until the user responds. Multiple pending tags stack, most recent first. For recurring tasks, the banner is tied to the tag relationship — it shows once, not once per recurrence.
+
+### Watch
+- Status → `watching`
+- Banner dismissed
+- User receives a `task_completed_watcher` push on every future completion of the task
+
+### Copy
+- Opens the create task sheet pre-filled with the original task's `content`, `value`, `deadline`, `notes`, `checklist`, and recurrence settings
+- User selects their own workspace and category
+- On save: status → `copied`, tagger receives `task_copied` push: *"[Name] copied your task 💪"*
+- No further banners or pings from the original task — they have their own version
+
+### Untag me
+- Status → `untagged`
+- Banner dismissed silently
+- Tagger is not notified
+- User is never re-prompted or pinged for this task, including future recurrences
+
+---
+
+## Completion Flow
+
+When a task is marked complete, the backend:
+1. Finds all `taggedUsers` with status `watching`
+2. Sends each a `task_completed_watcher` push: *"[Tagger] completed '[Task name]' 🎉"*
+
+### Recurring task rules
+- `watching` → pinged on every completion, indefinitely
+- `copied` → never pinged on the original's completions; their own recurring task runs independently
+- `untagged` → never pinged, ever
+- `pending` (never responded) → pinged on every completion; banner persists on home screen
+
+---
+
+## Reused Infrastructure
+
+| Existing piece | Reused for |
+|---|---|
+| `tag-people.tsx` + `useFriendsForMention()` | Friend picker for tagging |
+| `TaggedUsersChips` | Avatar chips in create task sheet |
+| Encouragements glow-icon on task row | Watcher count display |
+| Push notification system (`notificationService.ts`) | All three new notification types |
+| Create task sheet (FAB flow) | Pre-filled copy flow |
+
+---
+
+## Out of Scope (v1)
+
+- A dedicated "tasks I'm watching" feed
+- Tagging non-friends (public tasks)
+- Removing a tag after the tagged person has already responded
+- Group tags (tagging a whole friend group at once)

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -5157,6 +5157,74 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tagged-tasks:
+        get:
+            tags:
+                - tasks
+            summary: Get pending tagged tasks
+            description: Tasks the signed-in user has been tagged in and not yet responded to
+            operationId: get-pending-tagged-tasks
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                type: array
+                                items:
+                                    $ref: '#/components/schemas/PendingTaggedTask'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tagged-tasks/{id}/respond:
+        post:
+            tags:
+                - tasks
+            summary: Respond to a task tag
+            description: Watch, copy, or untag yourself from a task you were tagged in
+            operationId: respond-to-task-tag
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                  example: 507f1f77bcf86cd799439011
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/RespondToTaskTagInputBody'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/RespondToTaskTagOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/tags:
         get:
             tags:
@@ -5515,6 +5583,54 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/UpdateTaskNotesOutputBody'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+    /v1/user/tasks/{category}/{id}/tags:
+        patch:
+            tags:
+                - tasks
+            summary: Update task tags
+            description: Replace the set of friends tagged on a task
+            operationId: update-task-tags
+            parameters:
+                - name: Authorization
+                  in: header
+                  required: true
+                  schema:
+                    type: string
+                - name: category
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                  example: 507f1f77bcf86cd799439011
+                - name: id
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                    examples:
+                        - 507f1f77bcf86cd799439011
+                  example: 507f1f77bcf86cd799439011
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/UpdateTaskTagsInputBody'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/UpdateTaskTagsOutputBody'
                 default:
                     description: Error
                     content:
@@ -8573,6 +8689,10 @@ components:
                 startTime:
                     type: string
                     format: date-time
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaggedTaskUser'
                 templateID:
                     type: string
                 timeCompleted:
@@ -8650,6 +8770,10 @@ components:
                 startTime:
                     type: string
                     format: date-time
+                taggedUserIds:
+                    type: array
+                    items:
+                        type: string
                 value:
                     type: number
                     format: double
@@ -10851,6 +10975,48 @@ components:
                 - encouragements
                 - congratulations
                 - friend_requests
+        PendingTaggedTask:
+            type: object
+            additionalProperties: false
+            properties:
+                checklist:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/ChecklistItem'
+                content:
+                    type: string
+                deadline:
+                    type: string
+                    format: date-time
+                notes:
+                    type: string
+                priority:
+                    type: integer
+                    format: int64
+                recurDetails:
+                    $ref: '#/components/schemas/RecurDetails'
+                recurFrequency:
+                    type: string
+                recurring:
+                    type: boolean
+                tagger:
+                    $ref: '#/components/schemas/TaggerInfo'
+                taskId:
+                    type: string
+                timestamp:
+                    type: string
+                    format: date-time
+                value:
+                    type: number
+                    format: double
+            required:
+                - taskId
+                - content
+                - value
+                - priority
+                - recurring
+                - timestamp
+                - tagger
         PostDocumentAPI:
             type: object
             additionalProperties: false
@@ -11780,6 +11946,42 @@ components:
                         - Template metrics reset successfully
             required:
                 - message
+        RespondToTaskTagInputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RespondToTaskTagInputBody.json
+                    readOnly: true
+                status:
+                    type: string
+                    enum:
+                        - watching
+                        - copied
+                        - untagged
+            required:
+                - status
+        RespondToTaskTagOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/RespondToTaskTagOutputBody.json
+                    readOnly: true
+                message:
+                    type: string
+                    examples:
+                        - Response recorded
+            required:
+                - message
         RevenueCatEvent:
             type: object
             additionalProperties: false
@@ -12299,6 +12501,43 @@ components:
                 - events_total
                 - categories_synced
                 - workspace_name
+        TaggedTaskUser:
+            type: object
+            additionalProperties: false
+            properties:
+                display_name:
+                    type: string
+                handle:
+                    type: string
+                id:
+                    type: string
+                profile_picture:
+                    type: string
+                status:
+                    type: string
+            required:
+                - id
+                - handle
+                - display_name
+                - profile_picture
+                - status
+        TaggerInfo:
+            type: object
+            additionalProperties: false
+            properties:
+                display_name:
+                    type: string
+                handle:
+                    type: string
+                id:
+                    type: string
+                profile_picture:
+                    type: string
+            required:
+                - id
+                - display_name
+                - handle
+                - profile_picture
         TaskDocument:
             type: object
             additionalProperties: false
@@ -12371,6 +12610,10 @@ components:
                 startTime:
                     type: string
                     format: date-time
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaggedTaskUser'
                 templateID:
                     type: string
                 timeCompleted:
@@ -12557,6 +12800,10 @@ components:
                 streak:
                     type: integer
                     format: int64
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaggedTaskUser'
                 timesCompleted:
                     type: integer
                     format: int64
@@ -12661,6 +12908,10 @@ components:
                 streak:
                     type: integer
                     format: int64
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaggedTaskUser'
                 timesCompleted:
                     type: integer
                     format: int64
@@ -13481,6 +13732,40 @@ components:
                         - Task start date/time updated successfully
             required:
                 - message
+        UpdateTaskTagsInputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/UpdateTaskTagsInputBody.json
+                    readOnly: true
+                taggedUserIds:
+                    type: array
+                    items:
+                        type: string
+            required:
+                - taggedUserIds
+        UpdateTaskTagsOutputBody:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/UpdateTaskTagsOutputBody.json
+                    readOnly: true
+                taggedUsers:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/TaggedTaskUser'
+            required:
+                - taggedUsers
         UpdateTemplateDocument:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -2512,6 +2512,46 @@ export interface paths {
         patch: operations["update-user-settings"];
         trace?: never;
     };
+    "/v1/user/tagged-tasks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get pending tagged tasks
+         * @description Tasks the signed-in user has been tagged in and not yet responded to
+         */
+        get: operations["get-pending-tagged-tasks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/v1/user/tagged-tasks/{id}/respond": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Respond to a task tag
+         * @description Watch, copy, or untag yourself from a task you were tagged in
+         */
+        post: operations["respond-to-task-tag"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/tags": {
         parameters: {
             query?: never;
@@ -2654,6 +2694,26 @@ export interface paths {
         options?: never;
         head?: never;
         patch?: never;
+        trace?: never;
+    };
+    "/v1/user/tasks/{category}/{id}/tags": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Update task tags
+         * @description Replace the set of friends tagged on a task
+         */
+        patch: operations["update-task-tags"];
         trace?: never;
     };
     "/v1/user/tasks/active/{category}/{id}": {
@@ -4450,6 +4510,7 @@ export interface components {
             startDate: string;
             /** Format: date-time */
             startTime?: string;
+            taggedUsers?: components["schemas"]["TaggedTaskUser"][];
             templateID?: string;
             /** Format: date-time */
             timeCompleted?: string;
@@ -4487,6 +4548,7 @@ export interface components {
             startDate?: string;
             /** Format: date-time */
             startTime?: string;
+            taggedUserIds?: string[];
             /** Format: double */
             value: number;
         };
@@ -5735,6 +5797,24 @@ export interface components {
             near_deadlines: boolean;
             reactions: boolean;
         };
+        PendingTaggedTask: {
+            checklist?: components["schemas"]["ChecklistItem"][];
+            content: string;
+            /** Format: date-time */
+            deadline?: string;
+            notes?: string;
+            /** Format: int64 */
+            priority: number;
+            recurDetails?: components["schemas"]["RecurDetails"];
+            recurFrequency?: string;
+            recurring: boolean;
+            tagger: components["schemas"]["TaggerInfo"];
+            taskId: string;
+            /** Format: date-time */
+            timestamp: string;
+            /** Format: double */
+            value: number;
+        };
         PostDocumentAPI: {
             /**
              * Format: uri
@@ -6217,6 +6297,26 @@ export interface components {
             /** @example Template metrics reset successfully */
             message: string;
         };
+        RespondToTaskTagInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RespondToTaskTagInputBody.json
+             */
+            readonly $schema?: string;
+            /** @enum {string} */
+            status: "watching" | "copied" | "untagged";
+        };
+        RespondToTaskTagOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/RespondToTaskTagOutputBody.json
+             */
+            readonly $schema?: string;
+            /** @example Response recorded */
+            message: string;
+        };
         RevenueCatEvent: {
             app_user_id: string;
             currency: string;
@@ -6481,6 +6581,19 @@ export interface components {
             tasks_skipped: number;
             workspace_name: string;
         };
+        TaggedTaskUser: {
+            display_name: string;
+            handle: string;
+            id: string;
+            profile_picture: string;
+            status: string;
+        };
+        TaggerInfo: {
+            display_name: string;
+            handle: string;
+            id: string;
+            profile_picture: string;
+        };
         TaskDocument: {
             /**
              * Format: uri
@@ -6518,6 +6631,7 @@ export interface components {
             startDate: string;
             /** Format: date-time */
             startTime?: string;
+            taggedUsers?: components["schemas"]["TaggedTaskUser"][];
             templateID?: string;
             /** Format: date-time */
             timeCompleted?: string;
@@ -6629,6 +6743,7 @@ export interface components {
             startTime?: string;
             /** Format: int64 */
             streak: number;
+            taggedUsers?: components["schemas"]["TaggedTaskUser"][];
             /** Format: int64 */
             timesCompleted: number;
             /** Format: int64 */
@@ -6676,6 +6791,7 @@ export interface components {
             startTime?: string;
             /** Format: int64 */
             streak: number;
+            taggedUsers?: components["schemas"]["TaggedTaskUser"][];
             /** Format: int64 */
             timesCompleted: number;
             /** Format: int64 */
@@ -7199,6 +7315,24 @@ export interface components {
             readonly $schema?: string;
             /** @example Task start date/time updated successfully */
             message: string;
+        };
+        UpdateTaskTagsInputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/UpdateTaskTagsInputBody.json
+             */
+            readonly $schema?: string;
+            taggedUserIds: string[];
+        };
+        UpdateTaskTagsOutputBody: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/UpdateTaskTagsOutputBody.json
+             */
+            readonly $schema?: string;
+            taggedUsers: components["schemas"]["TaggedTaskUser"][];
         };
         UpdateTemplateDocument: {
             /**
@@ -12512,6 +12646,75 @@ export interface operations {
             };
         };
     };
+    "get-pending-tagged-tasks": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PendingTaggedTask"][];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "respond-to-task-tag": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path: {
+                /** @example 507f1f77bcf86cd799439011 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["RespondToTaskTagInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RespondToTaskTagOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
     "get-user-tags": {
         parameters: {
             query?: never;
@@ -12813,6 +13016,46 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["UpdateTaskNotesOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "update-task-tags": {
+        parameters: {
+            query?: never;
+            header: {
+                Authorization: string;
+            };
+            path: {
+                /** @example 507f1f77bcf86cd799439011 */
+                category: string;
+                /** @example 507f1f77bcf86cd799439011 */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateTaskTagsInputBody"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UpdateTaskTagsOutputBody"];
                 };
             };
             /** @description Error */

--- a/frontend/api/task.ts
+++ b/frontend/api/task.ts
@@ -3,6 +3,8 @@ import type { paths, components } from "./generated/types";
 import { withAuthHeaders } from "./utils";
 import { logger } from "@/utils/logger";
 import { combineDateAndTime } from "@/utils/timeUtils";
+import { request } from "@/hooks/useRequest";
+import type { TaggedTaskUser, PendingTaggedTask, TagStatus } from "./types";
 
 // Extract the type definitions from the generated types
 type TaskDocument = components["schemas"]["TaskDocument"];
@@ -766,5 +768,39 @@ export const moveTaskAPI = async (
 
     if (error) {
         throw new Error(`Failed to move task: ${JSON.stringify(error)}`);
+    }
+};
+
+export const updateTaskTagsAPI = async (
+    categoryId: string,
+    taskId: string,
+    taggedUserIds: string[]
+): Promise<{ taggedUsers: TaggedTaskUser[] }> => {
+    try {
+        return await request("PATCH", `/user/tasks/${categoryId}/${taskId}/tags`, { taggedUserIds });
+    } catch (error) {
+        logger.error("Error updating task tags", error);
+        throw new Error("Failed to update task tags. Please try again later.");
+    }
+};
+
+export const getPendingTaggedTasksAPI = async (): Promise<PendingTaggedTask[]> => {
+    try {
+        return await request("GET", "/user/tagged-tasks");
+    } catch (error) {
+        logger.error("Error fetching pending tagged tasks", error);
+        throw new Error("Failed to fetch pending tagged tasks. Please try again later.");
+    }
+};
+
+export const respondToTaskTagAPI = async (
+    taskId: string,
+    status: Exclude<TagStatus, "pending">
+): Promise<void> => {
+    try {
+        await request("POST", `/user/tagged-tasks/${taskId}/respond`, { status });
+    } catch (error) {
+        logger.error("Error responding to task tag", error);
+        throw new Error("Failed to respond to task tag. Please try again later.");
     }
 };

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -89,6 +89,36 @@ export interface PostKudos {
     private?: boolean;
 }
 
+export type TagStatus = "pending" | "watching" | "copied" | "untagged";
+
+export interface TaggedTaskUser {
+    id: string;
+    handle: string;
+    display_name: string;
+    profile_picture?: string;
+    status: TagStatus;
+}
+
+export interface PendingTaggedTask {
+    taskId: string;
+    content: string;
+    value: number;
+    priority: number;
+    recurring: boolean;
+    recurFrequency?: string;
+    recurDetails?: RecurDetails;
+    deadline?: string;
+    notes?: string;
+    checklist?: ChecklistItem[];
+    timestamp?: string;
+    tagger: {
+        id: string;
+        display_name: string;
+        handle: string;
+        profile_picture?: string;
+    };
+}
+
 export interface Task {
     id: string;
     priority: number;
@@ -125,6 +155,7 @@ export interface Task {
     timeTaken?: string;
     posted?: boolean; // Whether a post has been created for this task
     encouragements?: TaskKudos[];
+    taggedUsers?: TaggedTaskUser[];
     isPhantom?: boolean;
     nextGenerated?: string;
 }

--- a/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
@@ -30,7 +30,8 @@ import { updateNotesAPI, updateChecklistAPI, getTemplateByIDAPI, removeFromCateg
 import Checklist from "@/components/task/Checklist";
 import { formatLocalDate, formatLocalTime } from "@/utils/timeUtils";
 import { RecurDetails } from "@/api/types";
-import { Note, ListChecks, Calendar, Flag, Repeat, Bell, PencilSimple, Plugs, Trash, Sparkle } from "phosphor-react-native";
+import { Note, ListChecks, Calendar, Flag, Repeat, Bell, PencilSimple, Plugs, Trash, Sparkle, UserPlus } from "phosphor-react-native";
+import TagFriendsModal from "@/components/modals/TagFriendsModal";
 import UserInfoEncouragementNotification from "@/components/UserInfo/UserInfoEncouragementNotification";
 import { getIntegrationIcon, getIntegrationName, openIntegrationApp } from "@/utils/integrationUtils";
 // import PagerView from "react-native-pager-view"; // Removed - was causing modal issue
@@ -85,6 +86,8 @@ export default function Task() {
 
     // Query task from local context instead of relying on passed state
     const task = getTaskById(categoryId as string, id as string);
+
+    const [showTagModal, setShowTagModal] = useState(false);
 
     // Alert state
     const [alertVisible, setAlertVisible] = useState(false);
@@ -578,9 +581,14 @@ export default function Task() {
                             {name}
                             {isRunning ? <MaterialIcons name="timer" size={24} color={ThemedColor.text} /> : ""}
                         </ThemedText>
-                        <TouchableOpacity onPress={handleEditPress}>
-                            <PencilSimple size={24} color={ThemedColor.text} weight="regular" />
-                        </TouchableOpacity>
+                        <View style={{ flexDirection: "row", gap: 16, alignItems: "center" }}>
+                            <TouchableOpacity onPress={() => setShowTagModal(true)}>
+                                <UserPlus size={24} color={ThemedColor.text} weight="regular" />
+                            </TouchableOpacity>
+                            <TouchableOpacity onPress={handleEditPress}>
+                                <PencilSimple size={24} color={ThemedColor.text} weight="regular" />
+                            </TouchableOpacity>
+                        </View>
                     </View>
                     <View style={{ paddingBottom: 16 }} />
                 </View>
@@ -816,6 +824,17 @@ export default function Task() {
                     </View>
                 </KeyboardAvoidingView>
             </ScrollView>
+
+            {task && (
+                <TagFriendsModal
+                    visible={showTagModal}
+                    onClose={() => setShowTagModal(false)}
+                    task={task}
+                    onTagsUpdated={(taggedUsers) =>
+                        updateTask(categoryId as string, id as string, { taggedUsers })
+                    }
+                />
+            )}
 
             {showDeadlineModal && (
                 <DeadlineBottomSheetModal

--- a/frontend/app/(logged-in)/_layout.tsx
+++ b/frontend/app/(logged-in)/_layout.tsx
@@ -54,6 +54,9 @@ type NotificationType =
     | "comment"
     | "post_tag"
     | "rings_closed"
+    | "task_tagged"
+    | "task_copied"
+    | "task_completed_watcher"
     | "TASK_MISSED"
     | "TASK_REGENERATED"
     | "ABSOLUTE"
@@ -135,6 +138,19 @@ function getNotificationRoute(data: NotificationData | undefined): string | null
                 return `/(logged-in)/(tabs)/(feed,search,profile)/account/${data.user_id}`;
             }
             return "/(logged-in)/(tabs)/(profile)/profile";
+        case "task_tagged":
+            // Response banner lives on the home screen
+            return "/(logged-in)/(tabs)/(task)";
+        case "task_copied":
+            if (data.task_id) {
+                return `/(logged-in)/(tabs)/(task)/task/${data.task_id}`;
+            }
+            return "/(logged-in)/(tabs)/(task)";
+        case "task_completed_watcher":
+            if (data.user_id) {
+                return `/(logged-in)/(tabs)/(feed,search,profile)/account/${data.user_id}`;
+            }
+            return "/(logged-in)/(tabs)/(task)";
         case "TASK_MISSED":
         case "TASK_REGENERATED":
         case "ABSOLUTE":

--- a/frontend/app/(logged-in)/posting/tag-people.tsx
+++ b/frontend/app/(logged-in)/posting/tag-people.tsx
@@ -1,16 +1,15 @@
 import React, { useState, useMemo } from "react";
-import { View, FlatList, TouchableOpacity } from "react-native";
+import { View, TouchableOpacity } from "react-native";
 import { router } from "expo-router";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ThemedView } from "@/components/ThemedView";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+import { MentionCandidate } from "@/hooks/useFriendsForMention";
 import { usePostComposer } from "@/contexts/PostComposerContext";
 import { Ionicons } from "@expo/vector-icons";
-import ThemedInput from "@/components/inputs/ThemedInput";
 import type { TaggedUser } from "@/components/inputs/TaggedUsersChips";
-import { formatHandle } from "@/utils/handle";
+import FriendPicker from "@/components/inputs/FriendPicker";
 
 export default function TagPeople() {
     const insets = useSafeAreaInsets();
@@ -19,9 +18,6 @@ export default function TagPeople() {
     const [selected, setSelected] = useState<Map<string, TaggedUser>>(
         () => new Map(taggedUsers.map((u) => [u.id, u])),
     );
-    const [query, setQuery] = useState("");
-    const { filter } = useFriendsForMention();
-    const matches = useMemo(() => filter(query), [query, filter]);
 
     const toggle = (c: MentionCandidate) => {
         setSelected((prev) => {
@@ -37,6 +33,8 @@ export default function TagPeople() {
         router.back();
     };
 
+    const selectedIds = useMemo(() => new Set(selected.keys()), [selected]);
+
     return (
         <ThemedView style={{ flex: 1, paddingTop: insets.top }}>
             <View style={{ flexDirection: "row", alignItems: "center", paddingHorizontal: 16, paddingVertical: 12 }}>
@@ -48,55 +46,9 @@ export default function TagPeople() {
                     <ThemedText style={{ color: ThemedColor.primary }}>Done</ThemedText>
                 </TouchableOpacity>
             </View>
-            <View style={{ marginHorizontal: 16 }}>
-                <ThemedInput
-                    value={query}
-                    setValue={setQuery}
-                    placeHolder="Search friends"
-                />
+            <View style={{ flex: 1, marginHorizontal: 16 }}>
+                <FriendPicker selectedIds={selectedIds} onToggle={toggle} />
             </View>
-            <FlatList
-                data={matches}
-                keyExtractor={(item) => item.id}
-                renderItem={({ item }) => {
-                    const checked = selected.has(item.id);
-                    return (
-                        <FriendRow
-                            item={item}
-                            checked={checked}
-                            onToggle={toggle}
-                            primaryColor={ThemedColor.primary}
-                            captionColor={ThemedColor.caption}
-                        />
-                    );
-                }}
-            />
         </ThemedView>
-    );
-}
-
-type FriendRowProps = {
-    item: MentionCandidate;
-    checked: boolean;
-    onToggle: (c: MentionCandidate) => void;
-    primaryColor: string;
-    captionColor: string;
-};
-
-function FriendRow({ item, checked, onToggle, primaryColor, captionColor }: FriendRowProps) {
-    return (
-        <TouchableOpacity
-            onPress={() => onToggle(item)}
-            style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, paddingHorizontal: 16, gap: 12 }}>
-            <View style={{ flex: 1 }}>
-                <ThemedText type="defaultSemiBold">{item.display_name}</ThemedText>
-                <ThemedText type="caption">{formatHandle(item.handle)}</ThemedText>
-            </View>
-            <Ionicons
-                name={checked ? "checkmark-circle" : "ellipse-outline"}
-                size={22}
-                color={checked ? primaryColor : captionColor}
-            />
-        </TouchableOpacity>
     );
 }

--- a/frontend/components/UserInfo/UserInfoTaskCopiedNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoTaskCopiedNotification.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { router } from "expo-router";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
+import { getNotificationTimeLabel } from "./notificationTime";
+
+type Props = {
+    name: string;
+    userId: string;
+    content: string;
+    icon: string;
+    time: number;
+    /** The copied task's id — body tap deep-links to it. */
+    referenceId: string;
+};
+
+const UserInfoTaskCopiedNotification = ({ name, userId, content, icon, time, referenceId }: Props) => {
+    const ThemedColor = useThemeColor();
+    const message = content.startsWith(`${name} `) ? content.slice(name.length + 1) : content;
+
+    return (
+        <SpeechBubbleCard
+            sender={{ name, picture: icon, id: userId }}
+            header={
+                <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.text, fontSize: 15 }}>
+                    Task copied 💪
+                </ThemedText>
+            }
+            message={message}
+            timeLabel={getNotificationTimeLabel(time)}
+            read
+            onPress={() => router.push(`/(logged-in)/(tabs)/(task)/task/${referenceId}`)}
+            onAvatarPress={() => router.push(`/account/${userId}`)}
+            visible
+        />
+    );
+};
+
+export default UserInfoTaskCopiedNotification;

--- a/frontend/components/UserInfo/UserInfoTaskTaggedNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoTaskTaggedNotification.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { router } from "expo-router";
+import { ThemedText } from "../ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
+import { getNotificationTimeLabel } from "./notificationTime";
+
+type Props = {
+    name: string;
+    userId: string;
+    icon: string;
+    time: number;
+    /** Task thumbnail. Suppressed when it's just the actor avatar again. */
+    image?: string;
+};
+
+const UserInfoTaskTaggedNotification = ({ name, userId, icon, time, image }: Props) => {
+    const ThemedColor = useThemeColor();
+    const showThumbnail = !!image && image !== icon;
+
+    return (
+        <SpeechBubbleCard
+            sender={{ name, picture: icon, id: userId }}
+            header={
+                <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.text, fontSize: 15 }}>
+                    tagged you in a task
+                </ThemedText>
+            }
+            thumbnailUri={showThumbnail ? image : undefined}
+            timeLabel={getNotificationTimeLabel(time)}
+            read
+            // Response banner lives on home
+            onPress={() => router.push("/(logged-in)/(tabs)/(task)")}
+            onAvatarPress={() => router.push(`/account/${userId}`)}
+            visible
+        />
+    );
+};
+
+export default UserInfoTaskTaggedNotification;

--- a/frontend/components/cards/EncouragerAvatars.tsx
+++ b/frontend/components/cards/EncouragerAvatars.tsx
@@ -1,24 +1,46 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import CachedImage from "../CachedImage";
-import type { TaskKudos } from "@/api/types";
+import type { TaskKudos, TaggedTaskUser } from "@/api/types";
 
 // A small overlapping stack of the avatars of users who encouraged a task,
 // shown on the encouraged task card. Caps at MAX to bound width.
 const SIZE = 22;
 const MAX = 3;
 
+type AvatarEntry = { key: string; uri?: string };
+
 type Props = {
     encouragements: TaskKudos[];
+    taggedUsers?: TaggedTaskUser[];
     ringColor: string;
     placeholderColor: string;
 };
 
-const EncouragerAvatars = ({ encouragements, ringColor, placeholderColor }: Props) => {
-    const shown = encouragements.slice(0, MAX);
+const EncouragerAvatars = ({ encouragements, taggedUsers = [], ringColor, placeholderColor }: Props) => {
+    // Build a merged, de-duplicated avatar list. Kudos senders win on conflict.
+    const seenIds = new Set<string>();
+    const merged: AvatarEntry[] = [];
+
+    for (const k of encouragements) {
+        const id = k.sender.id;
+        if (!seenIds.has(id)) {
+            seenIds.add(id);
+            merged.push({ key: k.encouragementId, uri: k.sender.icon ?? undefined });
+        }
+    }
+
+    for (const t of taggedUsers) {
+        if ((t.status === "pending" || t.status === "watching") && !seenIds.has(t.id)) {
+            seenIds.add(t.id);
+            merged.push({ key: t.id, uri: t.profile_picture ?? undefined });
+        }
+    }
+
+    const shown = merged.slice(0, MAX);
     return (
         <View style={styles.row}>
-            {shown.map((k, i) => {
+            {shown.map((entry, i) => {
                 const style = [
                     styles.avatar,
                     {
@@ -27,16 +49,16 @@ const EncouragerAvatars = ({ encouragements, ringColor, placeholderColor }: Prop
                         zIndex: shown.length - i,
                     },
                 ];
-                return k.sender.icon ? (
+                return entry.uri ? (
                     <CachedImage
-                        key={k.encouragementId}
-                        source={{ uri: k.sender.icon }}
+                        key={entry.key}
+                        source={{ uri: entry.uri }}
                         style={style}
                         variant="thumbnail"
                         cachePolicy="memory-disk"
                     />
                 ) : (
-                    <View key={k.encouragementId} style={[style, { backgroundColor: placeholderColor }]} />
+                    <View key={entry.key} style={[style, { backgroundColor: placeholderColor }]} />
                 );
             })}
         </View>

--- a/frontend/components/cards/TaskCard.tsx
+++ b/frontend/components/cards/TaskCard.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "expo-router";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import EditPost from "../modals/edit/EditPost";
 import { Task } from "@/api/types";
-import { isTaskEncouraged, encouragedCardColors } from "./encouragedTask";
+import { isTaskEncouraged, isTaskWatched, encouragedCardColors } from "./encouragedTask";
 import EncouragerAvatars from "./EncouragerAvatars";
 import Svg, { Circle, Rect, Path } from "react-native-svg";
 import ConditionalView from "../ui/ConditionalView";
@@ -95,7 +95,7 @@ const TaskCard = ({
     const [showEncourageModal, setShowEncourageModal] = useState(false);
     const [showCongratulateModal, setShowCongratulateModal] = useState(false);
     const ThemedColor = useThemeColor();
-    const encouraged = isTaskEncouraged(task);
+    const encouraged = isTaskEncouraged(task) || isTaskWatched(task);
     const encColors = encouragedCardColors(ThemedColor.primary);
     const { setTask, updateTask } = useTasks();
     const [isRunningState, setIsRunningState] = useState(false);
@@ -511,6 +511,7 @@ const TaskCard = ({
                     <ConditionalView condition={encouraged}>
                         <EncouragerAvatars
                             encouragements={task?.encouragements ?? []}
+                            taggedUsers={task?.taggedUsers ?? []}
                             ringColor={ThemedColor.background}
                             placeholderColor={ThemedColor.primary}
                         />

--- a/frontend/components/cards/encouragedTask.ts
+++ b/frontend/components/cards/encouragedTask.ts
@@ -4,6 +4,10 @@ import type { Task } from "@/api/types";
 export const isTaskEncouraged = (task?: Task | null): boolean =>
     (task?.encouragements?.length ?? 0) > 0;
 
+// A task is "watched" when a tagged friend is pending or actively watching.
+export const isTaskWatched = (task?: Task | null): boolean =>
+    (task?.taggedUsers ?? []).some((t) => t.status === "pending" || t.status === "watching");
+
 // Color overrides for the encouraged task-card state: a faint primary tint
 // fill with a solid primary border, purple text (never gray — too low
 // contrast on the light fill), and a soft static glow. `primary` is

--- a/frontend/components/dashboard/HomescrollContent.tsx
+++ b/frontend/components/dashboard/HomescrollContent.tsx
@@ -27,6 +27,7 @@ import CalendarSetupBottomSheet from "@/components/modals/CalendarSetupBottomShe
 import { useUserSettings, useUpdateDashboardConfiguration, settingsKeys } from "@/hooks/useSettings";
 import type { DashboardConfiguration, UserSettings } from "@/api/settings";
 import { useQueryClient } from "@tanstack/react-query";
+import { TaggedTaskBanners } from "@/components/dashboard/TaggedTaskBanner";
 
 interface HomeScrollContentProps {
     encouragementCount: number;
@@ -334,6 +335,8 @@ export const HomeScrollContent: React.FC<HomeScrollContentProps> = ({
             }
         >
             <MotiView style={{ gap: 16, marginTop: 0 }}>
+
+                <TaggedTaskBanners />
 
                 {/* Dashboard Stats - always visible */}
                 <View style={{ marginHorizontal: HORIZONTAL_PADDING, marginBottom: 8, gap: 10 }}>

--- a/frontend/components/dashboard/TaggedTaskBanner.tsx
+++ b/frontend/components/dashboard/TaggedTaskBanner.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { View, TouchableOpacity } from "react-native";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
+import { useCreateModal } from "@/contexts/createModalContext";
+import { respondToTaskTagAPI } from "@/api/task";
+import { usePendingTaskTags, PENDING_TAGS_KEY } from "@/hooks/usePendingTaskTags";
+import { HORIZONTAL_PADDING } from "@/constants/spacing";
+import CachedImage from "@/components/CachedImage";
+import type { PendingTaggedTask } from "@/api/types";
+
+export const TaggedTaskBanners = () => {
+    const { data } = usePendingTaskTags();
+    if (!data || data.length === 0) return null;
+    return (
+        <View style={{ gap: 4, marginHorizontal: HORIZONTAL_PADDING }}>
+            {data.map((tag) => (
+                <TaggedTaskBannerRow key={tag.taskId} tag={tag} />
+            ))}
+        </View>
+    );
+};
+
+const AVATAR_SIZE = 32;
+
+const TaggedTaskBannerRow = ({ tag }: { tag: PendingTaggedTask }) => {
+    const ThemedColor = useThemeColor();
+    const queryClient = useQueryClient();
+    const { loadTaskData, setCopySourceTaskId } = useTaskCreation();
+    const { openModal } = useCreateModal();
+
+    const respond = useMutation({
+        mutationFn: (status: "watching" | "untagged") => respondToTaskTagAPI(tag.taskId, status),
+        onMutate: async () => {
+            await queryClient.cancelQueries({ queryKey: PENDING_TAGS_KEY });
+            const prev = queryClient.getQueryData<PendingTaggedTask[]>(PENDING_TAGS_KEY);
+            queryClient.setQueryData<PendingTaggedTask[]>(PENDING_TAGS_KEY, (old) =>
+                (old ?? []).filter((t) => t.taskId !== tag.taskId)
+            );
+            return { prev };
+        },
+        onError: (_err, _status, ctx) => {
+            if (ctx?.prev) queryClient.setQueryData(PENDING_TAGS_KEY, ctx.prev);
+        },
+    });
+
+    // v1 scope: openModal() presents the create sheet scoped to the currently
+    // selected workspace; a pre-modal workspace picker is a deliberate fast-follow.
+    const handleCopy = () => {
+        setCopySourceTaskId(tag.taskId);
+        loadTaskData({
+            content: tag.content,
+            value: tag.value,
+            priority: tag.priority,
+            recurring: tag.recurring,
+            recurFrequency: tag.recurFrequency,
+            recurDetails: tag.recurDetails,
+            deadline: tag.deadline,
+            notes: tag.notes,
+            checklist: tag.checklist,
+        });
+        openModal();
+    };
+
+    return (
+        <View style={{ borderTopWidth: 1, borderTopColor: ThemedColor.primary, paddingTop: 10, paddingBottom: 6, gap: 9 }}>
+            <View style={{ flexDirection: "row", alignItems: "center", gap: 10 }}>
+                {tag.tagger.profile_picture ? (
+                    <CachedImage
+                        source={{ uri: tag.tagger.profile_picture }}
+                        style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2 }}
+                        variant="thumbnail"
+                        cachePolicy="memory-disk"
+                    />
+                ) : (
+                    <View style={{ width: AVATAR_SIZE, height: AVATAR_SIZE, borderRadius: AVATAR_SIZE / 2, backgroundColor: ThemedColor.primary + "33" }} />
+                )}
+                <View style={{ flex: 1 }}>
+                    <ThemedText type="default">
+                        <ThemedText type="defaultSemiBold">{tag.tagger.display_name}</ThemedText> tagged you in a task
+                    </ThemedText>
+                    <ThemedText type="caption">
+                        {tag.content} · {tag.value} pts
+                    </ThemedText>
+                </View>
+            </View>
+            <View style={{ flexDirection: "row", gap: 24 }}>
+                <TouchableOpacity onPress={() => respond.mutate("watching")} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>Watch</ThemedText>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={handleCopy} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.caption }}>Copy</ThemedText>
+                </TouchableOpacity>
+                <TouchableOpacity onPress={() => respond.mutate("untagged")} hitSlop={8}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.caption, opacity: 0.6 }}>Untag me</ThemedText>
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+};

--- a/frontend/components/inputs/FriendPicker.tsx
+++ b/frontend/components/inputs/FriendPicker.tsx
@@ -21,7 +21,7 @@ const FriendPicker = ({ selectedIds, onToggle, lockedIds }: Props) => {
     const matches = useMemo(() => filter(query), [query, filter]);
 
     return (
-        <View style={{ flex: 1, gap: 12 }}>
+        <View style={{ flex: 1 }}>
             <ThemedInput value={query} setValue={setQuery} placeHolder="Search friends" />
             <FlatList
                 data={matches}

--- a/frontend/components/inputs/FriendPicker.tsx
+++ b/frontend/components/inputs/FriendPicker.tsx
@@ -1,0 +1,72 @@
+import React, { useMemo, useState } from "react";
+import { FlatList, TouchableOpacity, View } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import ThemedInput from "@/components/inputs/ThemedInput";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { useFriendsForMention, MentionCandidate } from "@/hooks/useFriendsForMention";
+import { Ionicons } from "@expo/vector-icons";
+import { formatHandle } from "@/utils/handle";
+
+type Props = {
+    selectedIds: Set<string>;
+    onToggle: (candidate: MentionCandidate) => void;
+    /** Friend IDs that can't be toggled (e.g. tags already responded to). */
+    lockedIds?: Set<string>;
+};
+
+const FriendPicker = ({ selectedIds, onToggle, lockedIds }: Props) => {
+    const ThemedColor = useThemeColor();
+    const [query, setQuery] = useState("");
+    const { filter } = useFriendsForMention();
+    const matches = useMemo(() => filter(query), [query, filter]);
+
+    return (
+        <View style={{ flex: 1, gap: 12 }}>
+            <ThemedInput value={query} setValue={setQuery} placeHolder="Search friends" />
+            <FlatList
+                data={matches}
+                keyExtractor={(item) => item.id}
+                renderItem={({ item }) => (
+                    <FriendRow
+                        item={item}
+                        checked={selectedIds.has(item.id)}
+                        locked={lockedIds?.has(item.id) ?? false}
+                        onToggle={onToggle}
+                        primaryColor={ThemedColor.primary}
+                        captionColor={ThemedColor.caption}
+                    />
+                )}
+            />
+        </View>
+    );
+};
+
+type FriendRowProps = {
+    item: MentionCandidate;
+    checked: boolean;
+    locked: boolean;
+    onToggle: (c: MentionCandidate) => void;
+    primaryColor: string;
+    captionColor: string;
+};
+
+function FriendRow({ item, checked, locked, onToggle, primaryColor, captionColor }: FriendRowProps) {
+    return (
+        <TouchableOpacity
+            disabled={locked}
+            onPress={() => onToggle(item)}
+            style={{ flexDirection: "row", alignItems: "center", paddingVertical: 10, gap: 12, opacity: locked ? 0.5 : 1 }}>
+            <View style={{ flex: 1 }}>
+                <ThemedText type="defaultSemiBold">{item.display_name}</ThemedText>
+                <ThemedText type="caption">{formatHandle(item.handle)}</ThemedText>
+            </View>
+            <Ionicons
+                name={checked ? "checkmark-circle" : "ellipse-outline"}
+                size={22}
+                color={checked ? primaryColor : captionColor}
+            />
+        </TouchableOpacity>
+    );
+}
+
+export default FriendPicker;

--- a/frontend/components/modals/CreateModal.tsx
+++ b/frontend/components/modals/CreateModal.tsx
@@ -46,7 +46,7 @@ const CreateModal = (props: Props) => {
     const ThemedColor = useThemeColor();
 
     // Get task creation context values to include in memoization dependencies
-    const { taskName, startDate, startTime, deadline, reminders, recurring } = useTaskCreation();
+    const { taskName, startDate, startTime, deadline, reminders, recurring, setCopySourceTaskId } = useTaskCreation();
 
     // Reference to the bottom sheet modal
     const bottomSheetModalRef = useRef<BottomSheetModal>(null);
@@ -111,6 +111,8 @@ const CreateModal = (props: Props) => {
     useEffect(() => {
         if (!props.visible) {
             bottomSheetModalRef.current?.dismiss();
+            // Cancelled copy must not mark the tag "copied" on a later create
+            setCopySourceTaskId(null);
             const timer = setTimeout(() => {
                 setScreen(Screen.STANDARD);
             }, 300);

--- a/frontend/components/modals/TagFriendsModal.tsx
+++ b/frontend/components/modals/TagFriendsModal.tsx
@@ -1,0 +1,77 @@
+import React, { useMemo, useState, useEffect } from "react";
+import { Modal, View, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ThemedView } from "@/components/ThemedView";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import FriendPicker from "@/components/inputs/FriendPicker";
+import { updateTaskTagsAPI } from "@/api/task";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
+import type { Task } from "@/api/types";
+
+type Props = {
+    visible: boolean;
+    onClose: () => void;
+    task: Task;
+    onTagsUpdated: (taggedUsers: Task["taggedUsers"]) => void;
+};
+
+const TagFriendsModal = ({ visible, onClose, task, onTagsUpdated }: Props) => {
+    const insets = useSafeAreaInsets();
+    const ThemedColor = useThemeColor();
+
+    // Responded entries are locked: removal-after-response is out of scope
+    const lockedIds = useMemo(
+        () => new Set((task.taggedUsers ?? []).filter((t) => t.status !== "pending").map((t) => t.id)),
+        [task.taggedUsers]
+    );
+
+    const [selected, setSelected] = useState<Set<string>>(
+        () => new Set((task.taggedUsers ?? []).filter((t) => t.status !== "untagged").map((t) => t.id))
+    );
+
+    // Reset selection whenever the modal is opened so cancel-then-reopen shows fresh state
+    useEffect(() => {
+        if (visible) {
+            setSelected(new Set((task.taggedUsers ?? []).filter((t) => t.status !== "untagged").map((t) => t.id)));
+        }
+    }, [visible]);
+
+    const toggle = (c: MentionCandidate) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(c.id)) next.delete(c.id);
+            else next.add(c.id);
+            return next;
+        });
+    };
+
+    const save = async () => {
+        try {
+            const result = await updateTaskTagsAPI(task.categoryID!, task.id, Array.from(selected));
+            onTagsUpdated(result.taggedUsers);
+        } catch (error) {
+            console.error("Failed to update tags:", error);
+        }
+        onClose();
+    };
+
+    return (
+        <Modal visible={visible} animationType="slide" onRequestClose={onClose}>
+            <ThemedView style={{ flex: 1, paddingTop: insets.top, paddingHorizontal: 16, gap: 12 }}>
+                <View style={{ flexDirection: "row", alignItems: "center", paddingVertical: 12 }}>
+                    <TouchableOpacity onPress={onClose} hitSlop={8}>
+                        <ThemedText style={{ color: ThemedColor.caption }}>Cancel</ThemedText>
+                    </TouchableOpacity>
+                    <ThemedText type="subtitle" style={{ flex: 1, textAlign: "center" }}>Tag friends</ThemedText>
+                    <TouchableOpacity onPress={save} hitSlop={8}>
+                        <ThemedText style={{ color: ThemedColor.primary }}>Done</ThemedText>
+                    </TouchableOpacity>
+                </View>
+                <FriendPicker selectedIds={selected} onToggle={toggle} lockedIds={lockedIds} />
+            </ThemedView>
+        </Modal>
+    );
+};
+
+export default TagFriendsModal;

--- a/frontend/components/modals/create/Collaborators.tsx
+++ b/frontend/components/modals/create/Collaborators.tsx
@@ -1,9 +1,12 @@
-import { View } from "react-native";
 import React from "react";
+import { View, TouchableOpacity } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import Feather from "@expo/vector-icons/Feather";
-import { TouchableOpacity } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
+import { useTaskCreation } from "@/contexts/taskCreationContext";
+import FriendPicker from "@/components/inputs/FriendPicker";
+import TaggedUsersChips from "@/components/inputs/TaggedUsersChips";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
 
 type Props = {
     goToStandard: () => void;
@@ -11,18 +14,35 @@ type Props = {
 
 const Collaborators = ({ goToStandard }: Props) => {
     const ThemedColor = useThemeColor();
+    const { taggedUsers, setTaggedUsers } = useTaskCreation();
+
+    const toggle = (c: MentionCandidate) => {
+        if (taggedUsers.some((u) => u.id === c.id)) {
+            setTaggedUsers(taggedUsers.filter((u) => u.id !== c.id));
+        } else {
+            setTaggedUsers([...taggedUsers, { id: c.id, handle: c.handle, display_name: c.display_name }]);
+        }
+    };
 
     return (
-        <View style={{ gap: 24, display: "flex", flexDirection: "column" }}>
-            <View style={{ display: "flex", flexDirection: "row", gap: 16 }}>
+        <View style={{ gap: 16, flex: 1 }}>
+            <View style={{ flexDirection: "row", gap: 16, alignItems: "center" }}>
                 <TouchableOpacity onPress={goToStandard}>
                     <Feather name="arrow-left" size={24} color={ThemedColor.text} />
                 </TouchableOpacity>
-                <ThemedText type="defaultSemiBold" style={{ textAlign: "center" }}>
-                    Add Collaborators
-                </ThemedText>
+                <ThemedText type="defaultSemiBold">Tag friends</ThemedText>
             </View>
-            {/* Add collaborator search and selection here */}
+            <TaggedUsersChips
+                users={taggedUsers}
+                onRemove={(id) => setTaggedUsers(taggedUsers.filter((u) => u.id !== id))}
+            />
+            {/* Fixed height prevents nested VirtualizedList warning inside BottomSheetScrollView */}
+            <View style={{ height: 400 }}>
+                <FriendPicker
+                    selectedIds={new Set(taggedUsers.map((u) => u.id))}
+                    onToggle={toggle}
+                />
+            </View>
         </View>
     );
 };

--- a/frontend/components/modals/create/Standard.tsx
+++ b/frontend/components/modals/create/Standard.tsx
@@ -76,6 +76,11 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
         setIsPublic,
         isBlueprint: isBlueprintState,
         setIsBlueprint,
+        taggedUsers,
+        notes,
+        checklist,
+        copySourceTaskId,
+        setCopySourceTaskId,
     } = useTaskCreation();
     const ThemedColor = useThemeColor();
     const { capture } = useAnalytics();
@@ -155,8 +160,8 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
                 recurring: recurring,
                 public: isPublic,
                 active: false,
-                checklist: [],
-                notes: "",
+                checklist: checklist,
+                notes: notes,
                 startDate: (startDate && startTime ? combineDateAndTime(startDate, startTime) : startDate)?.toISOString(),
                 startTime: startTime?.toISOString(),
                 deadline: deadline?.toISOString(),
@@ -195,8 +200,8 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
             recurring: recurring,
             public: isPublic,
             active: false,
-            checklist: [],
-            notes: "",
+            checklist: checklist,
+            notes: notes,
             startDate: (startDate && startTime ? combineDateAndTime(startDate, startTime) : startDate)?.toISOString(),
             startTime: startTime?.toISOString(),
             deadline: deadline?.toISOString(),
@@ -225,8 +230,8 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
             recurring: recurring,
             public: isPublic,
             active: false,
-            checklist: [],
-            notes: "",
+            checklist: checklist,
+            notes: notes,
             startDate: (startDate && startTime ? combineDateAndTime(startDate, startTime) : startDate)?.toISOString(),
             startTime: startTime?.toISOString(),
             deadline: deadline?.toISOString(),
@@ -235,6 +240,7 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
                 triggerTime: reminder.triggerTime.toISOString(),
             })),
             integration: integration || undefined,
+            taggedUserIds: taggedUsers.length > 0 ? taggedUsers.map((u) => u.id) : undefined,
         };
         if (recurring || flexDetails) {
             postBody.recurFrequency = recurFrequency;
@@ -253,6 +259,12 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
             // This ensures we don't have ID mismatches
             removeFromCategory(selectedCategory.id, tempId);
             addToCategory(selectedCategory.id, response);
+            if (copySourceTaskId) {
+                const { respondToTaskTagAPI } = await import("@/api/task");
+                respondToTaskTagAPI(copySourceTaskId, "copied").catch(() => {});
+                setCopySourceTaskId(null);
+                queryClient.invalidateQueries({ queryKey: ["taskTags", "pending"] });
+            }
             showRingUpdate((response as any)?.ringDelta);
             queryClient.invalidateQueries({ queryKey: ["rings", "today"] });
             capture(AnalyticsEvents.TASK_CREATED, {
@@ -512,7 +524,7 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
                 />
             </View>
             <PrimaryOptionRow goTo={goTo} />
-            <AdvancedOptionList goTo={goTo} showUnconfigured={false} />
+            <AdvancedOptionList goTo={goTo} showUnconfigured={false} edit={edit} />
             <TouchableOpacity
                 onPress={() => {
                     setShowAdvanced(!showAdvanced);
@@ -533,7 +545,7 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
                 )}
             </TouchableOpacity>
             <ConditionalView condition={showAdvanced}>
-                <AdvancedOptionList goTo={goTo} showUnconfigured={true} />
+                <AdvancedOptionList goTo={goTo} showUnconfigured={true} edit={edit} />
             </ConditionalView>
 
             <CustomAlert
@@ -764,9 +776,11 @@ const DeadlineQuickAccess = ({ goTo }: { goTo: (screen: Screen) => void }) => {
 const AdvancedOptionList = ({
     goTo,
     showUnconfigured,
+    edit,
 }: {
     goTo: (screen: Screen) => void;
     showUnconfigured: boolean;
+    edit?: boolean;
 }) => {
     const {
         startDate,
@@ -778,6 +792,7 @@ const AdvancedOptionList = ({
         flexDetails,
         isBlueprint: isBlueprintMode,
         integration,
+        taggedUsers,
     } = useTaskCreation();
     const ThemedColor = useThemeColor();
 
@@ -856,14 +871,20 @@ const AdvancedOptionList = ({
                 showUnconfigured={showUnconfigured}
                 configured={integration !== ""}
             />
-            {/* <AdvancedOption
-                icon="people"
-                label="Add Collaborators"
-                screen={Screen.COLLABORATORS}
-                goTo={goTo}
-                showUnconfigured={showUnconfigured}
-                configured={false}
-            /> */}
+            {!edit && (
+                <AdvancedOption
+                    icon="people"
+                    label={
+                        taggedUsers.length > 0
+                            ? `Tagged: ${taggedUsers.map((u) => u.handle).join(", ")}`
+                            : "Tag friends"
+                    }
+                    screen={Screen.COLLABORATORS}
+                    goTo={goTo}
+                    showUnconfigured={showUnconfigured}
+                    configured={taggedUsers.length > 0}
+                />
+            )}
         </View>
     );
 };

--- a/frontend/components/modals/create/Standard.tsx
+++ b/frontend/components/modals/create/Standard.tsx
@@ -17,7 +17,7 @@ import { CaretUp, CaretDown, Eye, EyeSlash, Flag, Barbell, WarningCircle, Plugs 
 import Popover from "react-native-popover-view";
 import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import type { components } from "@/api/generated/types";
-import { updateTaskAPI, updateTemplateAPI } from "@/api/task";
+import { updateTaskAPI, updateTemplateAPI, respondToTaskTagAPI } from "@/api/task";
 import { ObjectId } from "bson";
 import type { RecurDetails } from "@/api/types";
 import { combineDateAndTime } from "@/utils/timeUtils";
@@ -260,7 +260,6 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
             removeFromCategory(selectedCategory.id, tempId);
             addToCategory(selectedCategory.id, response);
             if (copySourceTaskId) {
-                const { respondToTaskTagAPI } = await import("@/api/task");
                 respondToTaskTagAPI(copySourceTaskId, "copied").catch(() => {});
                 setCopySourceTaskId(null);
                 queryClient.invalidateQueries({ queryKey: ["taskTags", "pending"] });

--- a/frontend/components/notifications/NotificationsView.tsx
+++ b/frontend/components/notifications/NotificationsView.tsx
@@ -10,6 +10,7 @@ import UserInfoFriendAcceptedNotification from "@/components/UserInfo/UserInfoFr
 import UserInfoPostTagNotification from "@/components/UserInfo/UserInfoPostTagNotification";
 import UserInfoRingsClosedNotification from "@/components/UserInfo/UserInfoRingsClosedNotification";
 import UserInfoTaskTaggedNotification from "@/components/UserInfo/UserInfoTaskTaggedNotification";
+import UserInfoTaskCopiedNotification from "@/components/UserInfo/UserInfoTaskCopiedNotification";
 import { Icons } from "@/constants/Icons";
 import { router } from "expo-router";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -270,12 +271,13 @@ const NotificationItem = ({
                     image={notification.thumbnail}
                 />
             ) : notification.type === "task_copied" ? (
-                <UserInfoFriendAcceptedNotification
+                <UserInfoTaskCopiedNotification
                     name={notification.name}
                     userId={notification.userId}
                     content={notification.content}
                     icon={notification.icon}
                     time={notification.time}
+                    referenceId={notification.referenceId}
                 />
             ) : null}
         </TouchableOpacity>

--- a/frontend/components/notifications/NotificationsView.tsx
+++ b/frontend/components/notifications/NotificationsView.tsx
@@ -9,6 +9,7 @@ import UserInfoEncouragementNotification from "@/components/UserInfo/UserInfoEnc
 import UserInfoFriendAcceptedNotification from "@/components/UserInfo/UserInfoFriendAcceptedNotification";
 import UserInfoPostTagNotification from "@/components/UserInfo/UserInfoPostTagNotification";
 import UserInfoRingsClosedNotification from "@/components/UserInfo/UserInfoRingsClosedNotification";
+import UserInfoTaskTaggedNotification from "@/components/UserInfo/UserInfoTaskTaggedNotification";
 import { Icons } from "@/constants/Icons";
 import { router } from "expo-router";
 import { useNotifications } from "@/hooks/useNotifications";
@@ -261,13 +262,12 @@ const NotificationItem = ({
                     referenceId={notification.referenceId}
                 />
             ) : notification.type === "task_tagged" ? (
-                <UserInfoPostTagNotification
+                <UserInfoTaskTaggedNotification
                     name={notification.name}
                     userId={notification.userId}
                     icon={notification.icon}
                     time={notification.time}
                     image={notification.thumbnail}
-                    referenceId={notification.referenceId}
                 />
             ) : notification.type === "task_copied" ? (
                 <UserInfoFriendAcceptedNotification

--- a/frontend/components/notifications/NotificationsView.tsx
+++ b/frontend/components/notifications/NotificationsView.tsx
@@ -260,6 +260,23 @@ const NotificationItem = ({
                     image={notification.thumbnail}
                     referenceId={notification.referenceId}
                 />
+            ) : notification.type === "task_tagged" ? (
+                <UserInfoPostTagNotification
+                    name={notification.name}
+                    userId={notification.userId}
+                    icon={notification.icon}
+                    time={notification.time}
+                    image={notification.thumbnail}
+                    referenceId={notification.referenceId}
+                />
+            ) : notification.type === "task_copied" ? (
+                <UserInfoFriendAcceptedNotification
+                    name={notification.name}
+                    userId={notification.userId}
+                    content={notification.content}
+                    icon={notification.icon}
+                    time={notification.time}
+                />
             ) : null}
         </TouchableOpacity>
     );
@@ -362,6 +379,13 @@ const NotificationsView = ({ isActive, onBack }: NotificationsViewProps) => {
                     router.push(`/(logged-in)/posting/${notification.referenceId}`);
                 }
                 break;
+            case "task_tagged":
+                // Response banner lives on home
+                router.push("/(logged-in)/(tabs)/(task)");
+                break;
+            case "task_copied":
+                router.push(`/(logged-in)/(tabs)/(task)/task/${notification.referenceId}`);
+                break;
         }
     };
 
@@ -441,7 +465,9 @@ const NotificationsView = ({ isActive, onBack }: NotificationsViewProps) => {
                     | "congratulation"
                     | "friend_request"
                     | "friend_request_accepted"
-                    | "post_tag",
+                    | "post_tag"
+                    | "task_tagged"
+                    | "task_copied",
                 name: notification.user.display_name,
                 handle: notification.user.handle ?? "",
                 userId: notification.user.id,

--- a/frontend/contexts/taskCreationContext.tsx
+++ b/frontend/contexts/taskCreationContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
 import { useReminder, Reminder } from "@/hooks/useReminder";
-import { FlexDetails } from "@/api/types";
+import { FlexDetails, ChecklistItem } from "@/api/types";
+import type { TaggedUser } from "@/components/inputs/TaggedUsersChips";
 
 type TaskCreationContextType = {
     taskName: string;
@@ -50,6 +51,16 @@ type TaskCreationContextType = {
     setStartTime: (startTime: Date | null) => void;
     setStartDate: (startDate: Date | null) => void;
     addSmartStartReminders: (startDate: Date, startTime: Date | null) => void;
+    taggedUsers: TaggedUser[];
+    setTaggedUsers: (users: TaggedUser[]) => void;
+    /** Notes/checklist prefill — used by the tag Copy flow; create otherwise sends empty. */
+    notes: string;
+    setNotes: (notes: string) => void;
+    checklist: ChecklistItem[];
+    setChecklist: (items: ChecklistItem[]) => void;
+    /** When set, a successful create marks this original task's tag as "copied". */
+    copySourceTaskId: string | null;
+    setCopySourceTaskId: (id: string | null) => void;
 };
 
 const TaskCreationContext = createContext<TaskCreationContextType | undefined>(undefined);
@@ -75,6 +86,10 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
     const [isBlueprint, setIsBlueprint] = useState(false);
     const [integration, setIntegration] = useState("");
     const [flexDetails, setFlexDetails] = useState<FlexDetails | null>(null);
+    const [taggedUsers, setTaggedUsers] = useState<TaggedUser[]>([]);
+    const [notes, setNotes] = useState("");
+    const [checklist, setChecklist] = useState<ChecklistItem[]>([]);
+    const [copySourceTaskId, setCopySourceTaskId] = useState<string | null>(null);
 
     const { getDeadlineReminder, getStartDateReminder, getStartTimeReminder } = useReminder();
 
@@ -196,6 +211,10 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
         setIsPublic(true);
         setIntegration("");
         setFlexDetails(null);
+        setTaggedUsers([]);
+        setNotes("");
+        setChecklist([]);
+        setCopySourceTaskId(null);
         // Don't reset isBlueprint here as it should persist
         setShowAdvanced(false);
     };
@@ -240,6 +259,9 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
         setBlueprintStateInternal(taskData.isBlueprint || false);
         setIntegration(taskData.integration || "");
         setFlexDetails(taskData.recurDetails?.flex || null);
+        setNotes(taskData.notes || "");
+        setChecklist(taskData.checklist || []);
+        setTaggedUsers([]);
     }, []);
 
     const contextValue = useMemo(() => ({
@@ -278,11 +300,20 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
         setStartDate,
         setStartTime,
         addSmartStartReminders,
+        taggedUsers,
+        setTaggedUsers,
+        notes,
+        setNotes,
+        checklist,
+        setChecklist,
+        copySourceTaskId,
+        setCopySourceTaskId,
     }), [
         taskName, showAdvanced, suggestion, priority, value,
         recurring, recurFrequency, recurDetails, deadline,
         startTime, startDate, reminders, isPublic, isBlueprint,
         integration, flexDetails, loadTaskData,
+        taggedUsers, notes, checklist, copySourceTaskId,
     ]);
 
     return (

--- a/frontend/contexts/taskCreationContext.tsx
+++ b/frontend/contexts/taskCreationContext.tsx
@@ -73,7 +73,7 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
     const [value, setValue] = useState(1);
     const [recurring, setRecurring] = useState(false);
     const [recurFrequency, setRecurFrequency] = useState("");
-    const [recurDetails, setRecurDetails] = useState({
+    const [recurDetails, setRecurDetails] = useState<TaskCreationContextType["recurDetails"]>({
         every: 1,
         daysOfWeek: [0, 0, 0, 0, 0, 0, 0],
         behavior: "ROLLING",
@@ -231,6 +231,8 @@ export const TaskCreationProvider = ({ children }: { children: React.ReactNode }
             setRecurDetails({
                 every: taskData.recurDetails.every || 1,
                 daysOfWeek: taskData.recurDetails.daysOfWeek || [0, 0, 0, 0, 0, 0, 0],
+                daysOfMonth: taskData.recurDetails.daysOfMonth,
+                months: taskData.recurDetails.months,
                 behavior: (taskData.recurDetails?.behavior as "BUILDUP" | "ROLLING") || "ROLLING",
             });
         } else {

--- a/frontend/hooks/usePendingTaskTags.ts
+++ b/frontend/hooks/usePendingTaskTags.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { getPendingTaggedTasksAPI } from "@/api/task";
+
+export const PENDING_TAGS_KEY = ["taskTags", "pending"] as const;
+
+export const usePendingTaskTags = () => {
+    return useQuery({
+        queryKey: PENDING_TAGS_KEY,
+        queryFn: getPendingTaggedTasksAPI,
+        staleTime: 60_000,
+    });
+};

--- a/frontend/utils/notifications.ts
+++ b/frontend/utils/notifications.ts
@@ -7,7 +7,9 @@ export type ProcessedNotification = {
         | "friend_request"
         | "friend_request_accepted"
         | "rings_closed"
-        | "post_tag";
+        | "post_tag"
+        | "task_tagged"
+        | "task_copied";
     name: string;
     handle: string;
     userId: string;
@@ -42,6 +44,8 @@ export const SUPPORTED_TYPES = new Set([
     "friend_request_accepted",
     "rings_closed",
     "post_tag",
+    "task_tagged",
+    "task_copied",
 ]);
 
 export const filterByActivityType = (


### PR DESCRIPTION
## Summary
- **Tag friends in tasks**: tag from the create-task sheet or the task detail screen (UserPlus icon). Tagged friends get a push + a persistent home-screen banner with **Watch / Copy / Untag me** actions.
- **Accountability loop**: watchers (pending + watching) get a push every time the task is completed; copying pre-fills the create sheet (content, points, deadline, notes, checklist, recurrence) and notifies the original owner ("copied your task 💪"); untag is silent and permanent.
- **Recurrence-aware**: tag state lives on the task and mirrors to the recurring template, so responses survive across generated instances (incl. flex tasks).
- **Reuses existing surfaces**: encouragements glow + avatar stack on task cards now include watchers; friend picker extracted from the posting tag flow (`FriendPicker`); notification cards + deep links for `TASK_TAGGED` / `TASK_COPIED` / `task_completed_watcher`.

Spec: `docs/superpowers/specs/2026-06-10-task-tagging-design.md` · Plan: `docs/superpowers/plans/2026-06-10-task-tagging.md`

## Backend
- `taggedUsers[]` (denormalized, typed `TagStatus` enum) on `TaskDocument` + `TemplateTaskDocument`
- `PATCH /v1/user/tasks/{category}/{id}/tags` — reconcile tag set (responded entries never removed)
- `GET /v1/user/tagged-tasks` — pending tags for the signed-in user (feeds the banner; indexed via `tasks.taggedUsers.id`)
- `POST /v1/user/tagged-tasks/{id}/respond` — watch/copied/untagged, scoped by array filters to the responder's own entry, idempotent
- 25 integration tests, race-clean under CI flags (`-short -race`); fixed a latent data race in `MockPushNotificationSender` (now mutex-guarded)

## Deploy notes
- ⚠️ Run `cmd/db/apply_indexes` at/before deploy — the pending-tags query collection-scans until the new `categories` index exists.

## Follow-ups (non-blocking, from final review)
- Server-side friend-gating on tag (picker is friend-only client-side; API accepts any user id)
- `BulkCompleteTask` doesn't ping watchers (v1 scope: single completion only)
- Edit-to-recurring conversion doesn't carry existing tags onto the new template
- Pre-modal workspace picker for the Copy flow (v1 copies into the current workspace)

## Test Plan
- [x] Backend: `go test -short -race ./...` green; tag suite 25/25
- [x] Frontend: `bun x tsc --noEmit` at baseline (no new errors)
- [ ] Two-account smoke: tag → banner → Watch → complete → push
- [ ] Copy flow: prefill (incl. recurrence) → save → owner push; cancel → no "copied" mark
- [ ] Untag → silence; recurring task → next instance keeps tag state

🤖 Generated with [Claude Code](https://claude.com/claude-code)