### PR TITLE
feat(feed): score and prioritize tasks shown in the feed

### DIFF
--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"sort"
 	"time"
 
@@ -281,25 +282,19 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		offset = 0
 	}
 
-	// Fetch more items than requested to account for interleaving
-	// We want to interleave 1 task per 5 posts, so we need roughly 83% posts and 17% tasks
-	postsNeeded := int(float64(limit) * 0.83)
-	if postsNeeded < 1 {
-		postsNeeded = 1
-	}
-	tasksNeeded := limit - postsNeeded
-
-	// Get friends posts
-	posts, postsTotal, err := h.service.GetFriendsPosts(userID, postsNeeded, offset)
+	// Posts fill the page; sampled tasks displace a few at reserved slots.
+	posts, postsTotal, err := h.service.GetFriendsPosts(userID, limit, offset)
 	if err != nil {
 		slog.Error("failed to get feed posts", "userId", userIDStr, "error", err)
 		return nil, huma.Error500InternalServerError("Unable to get feed. Please try again.", err)
 	}
 
-	// Get friends' public tasks (with user data from aggregation pipeline)
-	tasks, tasksTotal, err := h.service.GetFriendsPublicTasks(userID, tasksNeeded)
+	// Fetch the task candidate pool; scoring + sampling happens below.
+	// Errors degrade to a posts-only feed.
+	taskDocs, tasksTotal, err := h.service.GetFriendsPublicTasks(userID, defaultTaskPoolSize)
 	if err != nil {
-		tasks = []bson.M{} // Empty tasks if there's an error
+		taskDocs = nil
+		tasksTotal = 0
 	}
 
 	// Get friends' ring closure events
@@ -315,82 +310,20 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		apiPosts = append(apiPosts, *post.ToAPI(userID))
 	}
 
-	// Convert tasks to FeedTaskData
-	var feedTasks []FeedTaskData
-	for _, task := range tasks {
-		// Extract user data from the task document
-		var taskUser *types.UserExtendedReference
-		if userDoc, ok := task["user"].(bson.M); ok {
-			if id, ok := userDoc["_id"].(primitive.ObjectID); ok {
-				if handle, ok := userDoc["handle"].(string); ok {
-					if displayName, ok := userDoc["display_name"].(string); ok {
-						if profilePicture, ok := userDoc["profile_picture"].(string); ok {
-							taskUser = &types.UserExtendedReference{
-								ID:             id.Hex(),
-								Handle:         handle,
-								DisplayName:    displayName,
-								ProfilePicture: profilePicture,
-							}
-						}
-					}
-				}
-			}
+	// Score the candidate pool and sample the page's task slots
+	candidates := make([]taskCandidate, 0, len(taskDocs))
+	for _, doc := range taskDocs {
+		if c, ok := parseTaskCandidate(doc); ok {
+			candidates = append(candidates, *c)
 		}
-
-		// Extract task fields with type assertions
-		taskID, ok := task["_id"].(primitive.ObjectID)
-		if !ok {
-			continue
-		}
-		content, ok := task["content"].(string)
-		if !ok {
-			continue
-		}
-		priority, ok := task["priority"].(int32)
-		if !ok {
-			continue
-		}
-		value, ok := task["value"].(float64)
-		if !ok {
-			continue
-		}
-		public, ok := task["public"].(bool)
-		if !ok {
-			continue
-		}
-		timestamp, ok := task["timestamp"].(primitive.DateTime)
-		if !ok {
-			continue
-		}
-		categoryID, ok := task["categoryId"].(primitive.ObjectID)
-		if !ok {
-			continue
-		}
-		categoryName, ok := task["categoryName"].(string)
-		if !ok {
-			continue
-		}
-		workspaceName, ok := task["workspaceName"].(string)
-		if !ok {
-			continue
-		}
-
-		feedTask := FeedTaskData{
-			ID:            taskID.Hex(),
-			Content:       content,
-			Priority:      int(priority),
-			Value:         value,
-			Public:        public,
-			Timestamp:     timestamp.Time().Format(time.RFC3339),
-			CategoryID:    categoryID.Hex(),
-			CategoryName:  categoryName,
-			WorkspaceName: workspaceName,
-			User:          taskUser,
-		}
-		feedTasks = append(feedTasks, feedTask)
 	}
+	now := time.Now()
+	rng := rand.New(rand.NewSource(now.UnixNano()))
+	tasksNeeded := limit / taskSlotInterval
+	sampledTasks := sampleTasks(candidates, tasksNeeded, defaultTaskScoring, now, rng)
 
-	// Build timestamped items for chronological merge
+	// Build timestamped items for chronological merge (posts + ring closures;
+	// tasks are placed by slot, not by timestamp)
 	type timestampedItem struct {
 		feedItem FeedItem
 		time     time.Time
@@ -403,15 +336,6 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		allItems = append(allItems, timestampedItem{
 			feedItem: FeedItem{Type: "post", Post: &post},
 			time:     post.Metadata.CreatedAt,
-		})
-	}
-
-	for i := range feedTasks {
-		task := feedTasks[i]
-		t, _ := time.Parse(time.RFC3339, task.Timestamp)
-		allItems = append(allItems, timestampedItem{
-			feedItem: FeedItem{Type: "task", Task: &task},
-			time:     t,
 		})
 	}
 
@@ -429,11 +353,12 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 		return allItems[i].time.After(allItems[j].time)
 	})
 
-	// Take up to limit items
-	var feedItems []FeedItem
-	for i := 0; i < len(allItems) && i < limit; i++ {
-		feedItems = append(feedItems, allItems[i].feedItem)
+	chronological := make([]FeedItem, len(allItems))
+	for i, item := range allItems {
+		chronological[i] = item.feedItem
 	}
+
+	feedItems := interleaveFeedItems(chronological, sampledTasks, limit)
 
 	// Calculate total items and pagination
 	totalItems := postsTotal + tasksTotal + ringsTotal

--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -297,31 +297,9 @@ func (h *Handler) GetFeedHuma(ctx context.Context, input *GetFeedInput) (*GetFee
 	}
 
 	// Get friends' public tasks (with user data from aggregation pipeline)
-	tasks, tasksTotal, err := h.service.GetFriendsPublicTasks(userID, tasksNeeded, offset)
+	tasks, tasksTotal, err := h.service.GetFriendsPublicTasks(userID, tasksNeeded)
 	if err != nil {
 		tasks = []bson.M{} // Empty tasks if there's an error
-	}
-
-	// Adaptive fetching: if we got fewer posts than expected, fetch more tasks to fill the feed
-	if len(posts) < postsNeeded && len(tasks) < limit {
-		additionalTasksNeeded := limit - len(posts) - len(tasks)
-		if additionalTasksNeeded > 0 {
-			moreTasks, _, err := h.service.GetFriendsPublicTasks(userID, additionalTasksNeeded, len(tasks))
-			if err == nil {
-				tasks = append(tasks, moreTasks...)
-			}
-		}
-	}
-
-	// Adaptive fetching: if we got fewer tasks than expected, fetch more posts to fill the feed
-	if len(tasks) < tasksNeeded && len(posts) < limit {
-		additionalPostsNeeded := limit - len(posts) - len(tasks)
-		if additionalPostsNeeded > 0 {
-			morePosts, _, err := h.service.GetFriendsPosts(userID, additionalPostsNeeded, len(posts))
-			if err == nil {
-				posts = append(posts, morePosts...)
-			}
-		}
 	}
 
 	// Get friends' ring closure events

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -671,20 +671,12 @@ func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit int) ([
 		// Stage 1: Match the specific user
 		{{Key: "$match", Value: bson.M{"_id": userID}}},
 
-		// Stage 2: Lookup friends from users collection based on friends array
-		{{Key: "$lookup", Value: bson.M{
-			"from":         "users",
-			"localField":   "friends",
-			"foreignField": "_id",
-			"as":           "friendsData",
-		}}},
-
-		// Stage 3: Extract friend IDs
+		// Stage 2: Extract friend IDs (already on the user doc)
 		{{Key: "$project", Value: bson.M{
 			"friendIds": "$friends",
 		}}},
 
-		// Stage 4: Lookup categories owned by friends
+		// Stage 3: Lookup categories owned by friends
 		{{Key: "$lookup", Value: bson.M{
 			"from": "categories",
 			"let":  bson.M{"friendIds": "$friendIds"},
@@ -726,18 +718,18 @@ func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit int) ([
 			"as": "friendsTasks",
 		}}},
 
-		// Stage 5: Unwind the tasks array
+		// Stage 4: Unwind the tasks array
 		{{Key: "$unwind", Value: "$friendsTasks"}},
 
-		// Stage 6: Replace root with the task document
+		// Stage 5: Replace root with the task document
 		{{Key: "$replaceRoot", Value: bson.M{
 			"newRoot": "$friendsTasks",
 		}}},
 
-		// Stage 7: Newest first so the pool cap keeps recent tasks
+		// Stage 6: Newest first so the pool cap keeps recent tasks
 		{{Key: "$sort", Value: bson.M{"timestamp": -1}}},
 
-		// Stage 8: Count the full stream; cap the pool and attach user data
+		// Stage 7: Count the full stream; cap the pool and attach user data
 		// only for the capped pool (bounds the per-task user lookups).
 		{{Key: "$facet", Value: bson.M{
 			"metadata": []bson.M{

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -653,16 +653,20 @@ func (s *Service) GetUserGroups(userID primitive.ObjectID) ([]types.GroupDocumen
 	return results, nil
 }
 
-// GetFriendsPublicTasks fetches public tasks from the user's friends using aggregation pipeline
-func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit, offset int) ([]bson.M, int, error) {
+// defaultTaskPoolSize caps how many candidate tasks the feed scorer considers.
+const defaultTaskPoolSize = 200
+
+// GetFriendsPublicTasks fetches a pool of friends' public, active, incomplete
+// tasks (newest first) for the feed scorer. The handler scores and samples
+// from this pool, so no offset is taken — pagination of sampled tasks is
+// inherently approximate.
+func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit int) ([]bson.M, int, error) {
 	ctx := context.Background()
 
-	// Set default limit if not provided
 	if limit <= 0 {
-		limit = 20
+		limit = defaultTaskPoolSize
 	}
 
-	// Build aggregation pipeline to get friends' public tasks
 	pipeline := mongo.Pipeline{
 		// Stage 1: Match the specific user
 		{{Key: "$match", Value: bson.M{"_id": userID}}},
@@ -693,23 +697,30 @@ func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit, offset
 				}}},
 				// Unwind tasks array to work with individual tasks
 				{{Key: "$unwind", Value: "$tasks"}},
-				// Match only public tasks (field is "public" not "isPublic")
+				// Only public, active, not-yet-completed tasks are worth
+				// encouraging. $ne false tolerates older docs missing "active".
 				{{Key: "$match", Value: bson.M{
-					"tasks.public": true,
+					"tasks.public":        true,
+					"tasks.active":        bson.M{"$ne": false},
+					"tasks.timeCompleted": bson.M{"$exists": false},
 				}}},
-				// Project the fields we need
+				// Project the fields we need (incl. scoring fields)
 				{{Key: "$project", Value: bson.M{
-					"_id":           "$tasks._id",
-					"content":       "$tasks.content",
-					"priority":      "$tasks.priority",
-					"value":         "$tasks.value",
-					"public":        "$tasks.public",
-					"timestamp":     "$tasks.timestamp",
-					"lastEdited":    "$tasks.lastEdited",
-					"categoryId":    "$_id",
-					"categoryName":  "$name",
-					"workspaceName": "$workspaceName",
-					"userId":        "$user",
+					"_id":            "$tasks._id",
+					"content":        "$tasks.content",
+					"priority":       "$tasks.priority",
+					"value":          "$tasks.value",
+					"public":         "$tasks.public",
+					"timestamp":      "$tasks.timestamp",
+					"lastEdited":     "$tasks.lastEdited",
+					"deadline":       "$tasks.deadline",
+					"startTime":      "$tasks.startTime",
+					"startDate":      "$tasks.startDate",
+					"workingOnSince": "$tasks.workingOnSince",
+					"categoryId":     "$_id",
+					"categoryName":   "$name",
+					"workspaceName":  "$workspaceName",
+					"userId":         "$user",
 				}}},
 			},
 			"as": "friendsTasks",
@@ -723,45 +734,29 @@ func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit, offset
 			"newRoot": "$friendsTasks",
 		}}},
 
-		// Stage 7: Lookup user information for the task owner
-		{{Key: "$lookup", Value: bson.M{
-			"from":         "users",
-			"localField":   "userId",
-			"foreignField": "_id",
-			"as":           "userData",
-		}}},
+		// Stage 7: Newest first so the pool cap keeps recent tasks
+		{{Key: "$sort", Value: bson.M{"timestamp": -1}}},
 
-		// Stage 8: Add user object to the task document
-		{{Key: "$addFields", Value: bson.M{
-			"user": bson.M{
-				"$arrayElemAt": []interface{}{"$userData", 0},
-			},
-		}}},
-
-		// Stage 9: Remove temporary userData field
-		{{Key: "$project", Value: bson.M{
-			"userData": 0,
-		}}},
-
-		// Stage 10: Add random field for sampling
-		{{Key: "$addFields", Value: bson.M{
-			"randomSort": bson.M{"$rand": bson.M{}},
-		}}},
-
-		// Stage 11: Sort by random field first, then timestamp for consistency
-		{{Key: "$sort", Value: bson.M{
-			"randomSort": 1,
-			"timestamp":  -1,
-		}}},
-
-		// Stage 12: Apply pagination
+		// Stage 8: Count the full stream; cap the pool and attach user data
+		// only for the capped pool (bounds the per-task user lookups).
 		{{Key: "$facet", Value: bson.M{
 			"metadata": []bson.M{
 				{"$count": "total"},
 			},
 			"data": []bson.M{
-				{"$skip": offset},
 				{"$limit": limit},
+				{"$lookup": bson.M{
+					"from":         "users",
+					"localField":   "userId",
+					"foreignField": "_id",
+					"as":           "userData",
+				}},
+				{"$addFields": bson.M{
+					"user": bson.M{
+						"$arrayElemAt": []interface{}{"$userData", 0},
+					},
+				}},
+				{"$project": bson.M{"userData": 0}},
 			},
 		}}},
 	}
@@ -801,12 +796,11 @@ func (s *Service) GetFriendsPublicTasks(userID primitive.ObjectID, limit, offset
 		}
 	}
 
-	slog.Info("Friends public tasks fetched with random sampling",
+	slog.Info("Friends public task pool fetched",
 		"userId", userID.Hex(),
 		"count", len(tasks),
 		"total", total,
 		"limit", limit,
-		"offset", offset,
 	)
 
 	return tasks, total, nil

--- a/backend/internal/handlers/post/service_test.go
+++ b/backend/internal/handlers/post/service_test.go
@@ -1233,15 +1233,14 @@ func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_NoFriends() {
 	})
 	s.NoError(err)
 
-	// Get friends public tasks
-	tasks, total, err := s.service.GetFriendsPublicTasks(user.ID, 10, 0)
+	tasks, total, err := s.service.GetFriendsPublicTasks(user.ID, 10)
 
 	s.NoError(err)
 	s.Equal(0, total)
 	s.Empty(tasks)
 }
 
-func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_WithFriends() {
+func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_FiltersAndProjections() {
 	user1 := s.GetUser(0)
 	user2 := s.GetUser(1)
 
@@ -1251,19 +1250,58 @@ func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_WithFriends() {
 	})
 	s.NoError(err)
 
-	// Create a category for user2 with public tasks
+	now := time.Now()
+	deadline := primitive.NewDateTimeFromTime(now.Add(24 * time.Hour))
+	startTime := primitive.NewDateTimeFromTime(now.Add(2 * time.Hour))
+
 	category := bson.M{
-		"_id":  primitive.NewObjectID(),
-		"name": "Fitness",
-		"user": user2.ID,
+		"_id":           primitive.NewObjectID(),
+		"name":          "Fitness",
+		"workspaceName": "Personal",
+		"user":          user2.ID,
 		"tasks": []bson.M{
 			{
+				// Eligible: public, active, not completed — must appear
 				"_id":       primitive.NewObjectID(),
-				"content":   "Morning workout",
+				"content":   "eligible task",
 				"priority":  1,
 				"value":     10.0,
 				"public":    true,
-				"timestamp": primitive.NewDateTimeFromTime(time.Now()),
+				"active":    true,
+				"timestamp": primitive.NewDateTimeFromTime(now),
+				"deadline":  deadline,
+				"startTime": startTime,
+			},
+			{
+				// Completed — must be excluded
+				"_id":           primitive.NewObjectID(),
+				"content":       "completed task",
+				"priority":      1,
+				"value":         10.0,
+				"public":        true,
+				"active":        false,
+				"timeCompleted": primitive.NewDateTimeFromTime(now),
+				"timestamp":     primitive.NewDateTimeFromTime(now),
+			},
+			{
+				// Inactive — must be excluded
+				"_id":       primitive.NewObjectID(),
+				"content":   "inactive task",
+				"priority":  1,
+				"value":     10.0,
+				"public":    true,
+				"active":    false,
+				"timestamp": primitive.NewDateTimeFromTime(now),
+			},
+			{
+				// Private — must be excluded
+				"_id":       primitive.NewObjectID(),
+				"content":   "private task",
+				"priority":  1,
+				"value":     10.0,
+				"public":    false,
+				"active":    true,
+				"timestamp": primitive.NewDateTimeFromTime(now),
 			},
 		},
 	}
@@ -1271,23 +1309,79 @@ func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_WithFriends() {
 	_, err = s.Collections["categories"].InsertOne(s.Ctx, category)
 	s.NoError(err)
 
-	// Get friends public tasks
-	tasks, total, err := s.service.GetFriendsPublicTasks(user1.ID, 10, 0)
-
+	tasks, total, err := s.service.GetFriendsPublicTasks(user1.ID, 50)
 	s.NoError(err)
-	s.GreaterOrEqual(total, 0)
-	s.NotNil(tasks)
+	s.GreaterOrEqual(total, 1)
+
+	contents := make(map[string]bson.M)
+	for _, task := range tasks {
+		if content, ok := task["content"].(string); ok {
+			contents[content] = task
+		}
+	}
+
+	s.Contains(contents, "eligible task")
+	s.NotContains(contents, "completed task")
+	s.NotContains(contents, "inactive task")
+	s.NotContains(contents, "private task")
+
+	// Scoring fields must be projected through the pipeline
+	eligible := contents["eligible task"]
+	s.Equal(deadline, eligible["deadline"])
+	s.Equal(startTime, eligible["startTime"])
+
+	// User data must still be attached (lookup moved inside $facet)
+	s.NotNil(eligible["user"])
+}
+
+func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_MissingActiveTreatedAsActive() {
+	user1 := s.GetUser(0)
+	user2 := s.GetUser(1)
+
+	_, err := s.Collections["users"].UpdateOne(s.Ctx, bson.M{"_id": user1.ID}, bson.M{
+		"$set": bson.M{"friends": []primitive.ObjectID{user2.ID}},
+	})
+	s.NoError(err)
+
+	// Older docs may lack the active field entirely — they must still appear.
+	category := bson.M{
+		"_id":  primitive.NewObjectID(),
+		"name": "Legacy",
+		"user": user2.ID,
+		"tasks": []bson.M{
+			{
+				"_id":       primitive.NewObjectID(),
+				"content":   "legacy task without active field",
+				"priority":  1,
+				"value":     5.0,
+				"public":    true,
+				"timestamp": primitive.NewDateTimeFromTime(time.Now()),
+			},
+		},
+	}
+	_, err = s.Collections["categories"].InsertOne(s.Ctx, category)
+	s.NoError(err)
+
+	tasks, _, err := s.service.GetFriendsPublicTasks(user1.ID, 50)
+	s.NoError(err)
+
+	found := false
+	for _, task := range tasks {
+		if content, ok := task["content"].(string); ok && content == "legacy task without active field" {
+			found = true
+		}
+	}
+	s.True(found, "task missing the active field should be treated as active")
 }
 
 func (s *PostServiceTestSuite) TestGetFriendsPublicTasks_DefaultLimit() {
 	user := s.GetUser(0)
 
-	// Get with limit 0 (should use default of 20)
-	tasks, total, err := s.service.GetFriendsPublicTasks(user.ID, 0, 0)
+	// Limit 0 should fall back to the default pool size
+	tasks, total, err := s.service.GetFriendsPublicTasks(user.ID, 0)
 
 	s.NoError(err)
 	s.GreaterOrEqual(total, 0)
-	// tasks can be empty slice or nil, both are valid
 	if tasks != nil {
 		s.GreaterOrEqual(len(tasks), 0)
 	}

--- a/backend/internal/handlers/post/task_candidates.go
+++ b/backend/internal/handlers/post/task_candidates.go
@@ -29,8 +29,13 @@ func parseTaskCandidate(task bson.M) (*taskCandidate, bool) {
 	if !ok {
 		return nil, false
 	}
-	priority, ok := task["priority"].(int32)
-	if !ok {
+	var priority int
+	switch p := task["priority"].(type) {
+	case int32:
+		priority = int(p)
+	case int64:
+		priority = int(p)
+	default:
 		return nil, false
 	}
 	value, ok := task["value"].(float64)
@@ -81,7 +86,7 @@ func parseTaskCandidate(task bson.M) (*taskCandidate, bool) {
 		feedTask: FeedTaskData{
 			ID:            taskID.Hex(),
 			Content:       content,
-			Priority:      int(priority),
+			Priority:      priority,
 			Value:         value,
 			Public:        public,
 			Timestamp:     createdAt.Format(time.RFC3339),

--- a/backend/internal/handlers/post/task_candidates.go
+++ b/backend/internal/handlers/post/task_candidates.go
@@ -1,0 +1,99 @@
+package Post
+
+import (
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// optionalTime extracts a nullable datetime field from a pipeline document.
+func optionalTime(doc bson.M, key string) *time.Time {
+	if dt, ok := doc[key].(primitive.DateTime); ok {
+		t := dt.Time()
+		return &t
+	}
+	return nil
+}
+
+// parseTaskCandidate converts a GetFriendsPublicTasks pipeline document into
+// a scoring candidate. Returns false if any required field is malformed
+// (the task is skipped, matching previous handler behavior).
+func parseTaskCandidate(task bson.M) (*taskCandidate, bool) {
+	taskID, ok := task["_id"].(primitive.ObjectID)
+	if !ok {
+		return nil, false
+	}
+	content, ok := task["content"].(string)
+	if !ok {
+		return nil, false
+	}
+	priority, ok := task["priority"].(int32)
+	if !ok {
+		return nil, false
+	}
+	value, ok := task["value"].(float64)
+	if !ok {
+		return nil, false
+	}
+	public, ok := task["public"].(bool)
+	if !ok {
+		return nil, false
+	}
+	timestamp, ok := task["timestamp"].(primitive.DateTime)
+	if !ok {
+		return nil, false
+	}
+	categoryID, ok := task["categoryId"].(primitive.ObjectID)
+	if !ok {
+		return nil, false
+	}
+	categoryName, ok := task["categoryName"].(string)
+	if !ok {
+		return nil, false
+	}
+	workspaceName, ok := task["workspaceName"].(string)
+	if !ok {
+		return nil, false
+	}
+
+	var taskUser *types.UserExtendedReference
+	if userDoc, ok := task["user"].(bson.M); ok {
+		if id, ok := userDoc["_id"].(primitive.ObjectID); ok {
+			if handle, ok := userDoc["handle"].(string); ok {
+				if displayName, ok := userDoc["display_name"].(string); ok {
+					if profilePicture, ok := userDoc["profile_picture"].(string); ok {
+						taskUser = &types.UserExtendedReference{
+							ID:             id.Hex(),
+							Handle:         handle,
+							DisplayName:    displayName,
+							ProfilePicture: profilePicture,
+						}
+					}
+				}
+			}
+		}
+	}
+
+	createdAt := timestamp.Time()
+	return &taskCandidate{
+		feedTask: FeedTaskData{
+			ID:            taskID.Hex(),
+			Content:       content,
+			Priority:      int(priority),
+			Value:         value,
+			Public:        public,
+			Timestamp:     createdAt.Format(time.RFC3339),
+			CategoryID:    categoryID.Hex(),
+			CategoryName:  categoryName,
+			WorkspaceName: workspaceName,
+			User:          taskUser,
+		},
+		createdAt:      createdAt,
+		deadline:       optionalTime(task, "deadline"),
+		startTime:      optionalTime(task, "startTime"),
+		startDate:      optionalTime(task, "startDate"),
+		workingOnSince: optionalTime(task, "workingOnSince"),
+	}, true
+}

--- a/backend/internal/handlers/post/task_candidates_test.go
+++ b/backend/internal/handlers/post/task_candidates_test.go
@@ -66,6 +66,18 @@ func TestParseTaskCandidate_OptionalFieldsAbsent(t *testing.T) {
 	}
 }
 
+func TestParseTaskCandidate_PriorityInt64(t *testing.T) {
+	doc := validTaskDoc()
+	doc["priority"] = int64(3)
+	c, ok := parseTaskCandidate(doc)
+	if !ok {
+		t.Fatal("expected parse to accept int64 priority")
+	}
+	if c.feedTask.Priority != 3 {
+		t.Fatalf("priority wrong: %d", c.feedTask.Priority)
+	}
+}
+
 func TestParseTaskCandidate_MissingRequiredField(t *testing.T) {
 	doc := validTaskDoc()
 	delete(doc, "content")

--- a/backend/internal/handlers/post/task_candidates_test.go
+++ b/backend/internal/handlers/post/task_candidates_test.go
@@ -1,0 +1,75 @@
+package Post
+
+import (
+	"testing"
+	"time"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+func validTaskDoc() bson.M {
+	return bson.M{
+		"_id":           primitive.NewObjectID(),
+		"content":       "Morning workout",
+		"priority":      int32(2),
+		"value":         7.5,
+		"public":        true,
+		"timestamp":     primitive.NewDateTimeFromTime(testNow.Add(-1 * time.Hour)),
+		"categoryId":    primitive.NewObjectID(),
+		"categoryName":  "Fitness",
+		"workspaceName": "Personal",
+		"user": bson.M{
+			"_id":             primitive.NewObjectID(),
+			"handle":          "@sam",
+			"display_name":    "Sam",
+			"profile_picture": "https://cdn/p.jpg",
+		},
+	}
+}
+
+func TestParseTaskCandidate_FullDoc(t *testing.T) {
+	doc := validTaskDoc()
+	doc["deadline"] = primitive.NewDateTimeFromTime(testNow.Add(24 * time.Hour))
+	doc["startTime"] = primitive.NewDateTimeFromTime(testNow.Add(2 * time.Hour))
+	doc["startDate"] = primitive.NewDateTimeFromTime(testNow)
+	doc["workingOnSince"] = primitive.NewDateTimeFromTime(testNow.Add(-5 * time.Minute))
+
+	c, ok := parseTaskCandidate(doc)
+	if !ok {
+		t.Fatal("expected parse to succeed")
+	}
+	if c.feedTask.Content != "Morning workout" || c.feedTask.Priority != 2 || c.feedTask.Value != 7.5 {
+		t.Fatalf("wire fields wrong: %+v", c.feedTask)
+	}
+	if c.feedTask.User == nil || c.feedTask.User.Handle != "@sam" {
+		t.Fatalf("user not parsed: %+v", c.feedTask.User)
+	}
+	if c.deadline == nil || c.startTime == nil || c.startDate == nil || c.workingOnSince == nil {
+		t.Fatal("scoring time fields not parsed")
+	}
+	if !c.deadline.Equal(testNow.Add(24 * time.Hour)) {
+		t.Fatalf("deadline wrong: %v", c.deadline)
+	}
+}
+
+func TestParseTaskCandidate_OptionalFieldsAbsent(t *testing.T) {
+	c, ok := parseTaskCandidate(validTaskDoc())
+	if !ok {
+		t.Fatal("expected parse to succeed without optional fields")
+	}
+	if c.deadline != nil || c.startTime != nil || c.startDate != nil || c.workingOnSince != nil {
+		t.Fatal("absent optional fields must parse as nil")
+	}
+	if c.feedTask.User == nil {
+		t.Fatal("user should be parsed")
+	}
+}
+
+func TestParseTaskCandidate_MissingRequiredField(t *testing.T) {
+	doc := validTaskDoc()
+	delete(doc, "content")
+	if _, ok := parseTaskCandidate(doc); ok {
+		t.Fatal("expected parse to fail when content missing")
+	}
+}

--- a/backend/internal/handlers/post/task_interleave.go
+++ b/backend/internal/handlers/post/task_interleave.go
@@ -1,0 +1,27 @@
+package Post
+
+// taskSlotInterval reserves every Nth feed slot for a task
+// (0-indexed positions 5, 11, 17 on a 20-item page ≈ 17% tasks).
+const taskSlotInterval = 6
+
+// interleaveFeedItems merges chronological items (posts + ring closures)
+// with sampled tasks: tasks take the reserved slots in draw order. If posts
+// run out, remaining tasks fill the tail; if tasks run out, posts fill through.
+func interleaveFeedItems(chronological []FeedItem, tasks []FeedTaskData, limit int) []FeedItem {
+	items := make([]FeedItem, 0, limit)
+	ci, ti := 0, 0
+	for len(items) < limit && (ci < len(chronological) || ti < len(tasks)) {
+		taskSlot := len(items)%taskSlotInterval == taskSlotInterval-1
+		if (taskSlot || ci >= len(chronological)) && ti < len(tasks) {
+			task := tasks[ti]
+			ti++
+			items = append(items, FeedItem{Type: "task", Task: &task})
+			continue
+		}
+		if ci < len(chronological) {
+			items = append(items, chronological[ci])
+			ci++
+		}
+	}
+	return items
+}

--- a/backend/internal/handlers/post/task_interleave_test.go
+++ b/backend/internal/handlers/post/task_interleave_test.go
@@ -1,0 +1,83 @@
+package Post
+
+import (
+	"testing"
+)
+
+func makePosts(n int) []FeedItem {
+	items := make([]FeedItem, n)
+	for i := range items {
+		items[i] = FeedItem{Type: "post"}
+	}
+	return items
+}
+
+func makeFeedTasks(n int) []FeedTaskData {
+	tasks := make([]FeedTaskData, n)
+	for i := range tasks {
+		tasks[i] = FeedTaskData{ID: "task-" + string(rune('a'+i))}
+	}
+	return tasks
+}
+
+func TestInterleave_TasksAtReservedSlots(t *testing.T) {
+	items := interleaveFeedItems(makePosts(20), makeFeedTasks(3), 20)
+	if len(items) != 20 {
+		t.Fatalf("expected 20 items, got %d", len(items))
+	}
+	for i, item := range items {
+		isTaskSlot := i%taskSlotInterval == taskSlotInterval-1 // positions 5, 11, 17
+		if isTaskSlot && item.Type != "task" {
+			t.Fatalf("position %d should be a task, got %s", i, item.Type)
+		}
+		if !isTaskSlot && item.Type != "post" {
+			t.Fatalf("position %d should be a post, got %s", i, item.Type)
+		}
+	}
+	// Sampled order preserved: best draw in the first slot.
+	if items[5].Task.ID != "task-a" || items[11].Task.ID != "task-b" || items[17].Task.ID != "task-c" {
+		t.Fatal("tasks should fill slots in sampled order")
+	}
+}
+
+func TestInterleave_NoTasks_AllPosts(t *testing.T) {
+	items := interleaveFeedItems(makePosts(10), nil, 20)
+	if len(items) != 10 {
+		t.Fatalf("expected 10 items, got %d", len(items))
+	}
+	for i, item := range items {
+		if item.Type != "post" {
+			t.Fatalf("position %d should be a post, got %s", i, item.Type)
+		}
+	}
+}
+
+func TestInterleave_PostsExhausted_TasksFillTail(t *testing.T) {
+	items := interleaveFeedItems(makePosts(2), makeFeedTasks(4), 20)
+	if len(items) != 6 {
+		t.Fatalf("expected 6 items (2 posts + 4 tasks), got %d", len(items))
+	}
+	// First two slots are posts (slot 5 never reached before posts run out),
+	// remaining are tasks.
+	if items[0].Type != "post" || items[1].Type != "post" {
+		t.Fatal("first two items should be posts")
+	}
+	for i := 2; i < 6; i++ {
+		if items[i].Type != "task" {
+			t.Fatalf("position %d should be a task, got %s", i, items[i].Type)
+		}
+	}
+}
+
+func TestInterleave_RespectsLimit(t *testing.T) {
+	items := interleaveFeedItems(makePosts(50), makeFeedTasks(10), 12)
+	if len(items) != 12 {
+		t.Fatalf("expected 12 items, got %d", len(items))
+	}
+}
+
+func TestInterleave_Empty(t *testing.T) {
+	if items := interleaveFeedItems(nil, nil, 20); len(items) != 0 {
+		t.Fatal("empty inputs should produce empty feed")
+	}
+}

--- a/backend/internal/handlers/post/task_sampling.go
+++ b/backend/internal/handlers/post/task_sampling.go
@@ -1,0 +1,63 @@
+package Post
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+	"time"
+)
+
+// sampleTasks picks n tasks by weighted sampling without replacement,
+// probability ∝ (score + ε)^exponent — high scorers dominate but any task
+// stays possible, so refreshes rotate. Returns picks in draw order.
+func sampleTasks(candidates []taskCandidate, n int, cfg taskScoringConfig, now time.Time, rng *rand.Rand) []FeedTaskData {
+	if n <= 0 || len(candidates) == 0 {
+		return nil
+	}
+
+	type scored struct {
+		idx    int
+		score  float64
+		weight float64
+	}
+	pool := make([]scored, len(candidates))
+	for i := range candidates {
+		s := scoreTask(&candidates[i], cfg, now)
+		pool[i] = scored{
+			idx:    i,
+			score:  s,
+			weight: math.Pow(s+cfg.SamplingEpsilon, cfg.SamplingExponent),
+		}
+	}
+
+	// Fewer candidates than asked: return everything, best first.
+	if n >= len(candidates) {
+		sort.SliceStable(pool, func(a, b int) bool { return pool[a].score > pool[b].score })
+		out := make([]FeedTaskData, len(pool))
+		for i, p := range pool {
+			out[i] = candidates[p.idx].feedTask
+		}
+		return out
+	}
+
+	out := make([]FeedTaskData, 0, n)
+	for len(out) < n {
+		total := 0.0
+		for _, p := range pool {
+			total += p.weight
+		}
+		r := rng.Float64() * total
+		pick := len(pool) - 1
+		acc := 0.0
+		for i, p := range pool {
+			acc += p.weight
+			if r < acc {
+				pick = i
+				break
+			}
+		}
+		out = append(out, candidates[pool[pick].idx].feedTask)
+		pool = append(pool[:pick], pool[pick+1:]...)
+	}
+	return out
+}

--- a/backend/internal/handlers/post/task_sampling_test.go
+++ b/backend/internal/handlers/post/task_sampling_test.go
@@ -1,0 +1,84 @@
+package Post
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+// makeCandidates builds candidates with distinct IDs; hot ones get an
+// imminent start + high priority so they score far above the rest.
+func makeCandidates(hot, cold int) []taskCandidate {
+	out := make([]taskCandidate, 0, hot+cold)
+	for i := 0; i < hot; i++ {
+		c := baselineCandidate()
+		c.feedTask.ID = "hot-" + string(rune('a'+i))
+		c.feedTask.Priority = 3
+		c.startTime = timePtr(testNow.Add(30 * time.Minute))
+		out = append(out, c)
+	}
+	for i := 0; i < cold; i++ {
+		c := baselineCandidate()
+		c.feedTask.ID = "cold-" + string(rune('a'+i))
+		c.createdAt = testNow.Add(-30 * 24 * time.Hour) // old → near-zero score
+		out = append(out, c)
+	}
+	return out
+}
+
+func TestSampleTasks_NoDuplicates(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+	candidates := makeCandidates(3, 7)
+	picked := sampleTasks(candidates, 5, defaultTaskScoring, testNow, rng)
+	if len(picked) != 5 {
+		t.Fatalf("expected 5 picks, got %d", len(picked))
+	}
+	seen := map[string]bool{}
+	for _, p := range picked {
+		if seen[p.ID] {
+			t.Fatalf("duplicate task sampled: %s", p.ID)
+		}
+		seen[p.ID] = true
+	}
+}
+
+func TestSampleTasks_FavorsHighScorers(t *testing.T) {
+	// Over many seeds, the first pick should overwhelmingly be a hot task.
+	hotFirst := 0
+	const runs = 500
+	for seed := 0; seed < runs; seed++ {
+		rng := rand.New(rand.NewSource(int64(seed)))
+		candidates := makeCandidates(2, 8)
+		picked := sampleTasks(candidates, 1, defaultTaskScoring, testNow, rng)
+		if len(picked) == 1 && picked[0].ID[:3] == "hot" {
+			hotFirst++
+		}
+	}
+	// 2 hot tasks score ~5.5 vs ~0.001 for cold; weighted (score+0.15)²
+	// sampling should pick hot first in the vast majority of runs.
+	if hotFirst < runs*8/10 {
+		t.Fatalf("hot tasks picked first only %d/%d runs", hotFirst, runs)
+	}
+}
+
+func TestSampleTasks_NMoreThanCandidates_ReturnsAllBestFirst(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	candidates := makeCandidates(1, 2)
+	picked := sampleTasks(candidates, 10, defaultTaskScoring, testNow, rng)
+	if len(picked) != 3 {
+		t.Fatalf("expected all 3 candidates, got %d", len(picked))
+	}
+	if picked[0].ID[:3] != "hot" {
+		t.Fatalf("expected highest scorer first, got %s", picked[0].ID)
+	}
+}
+
+func TestSampleTasks_EmptyAndZero(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	if got := sampleTasks(nil, 3, defaultTaskScoring, testNow, rng); len(got) != 0 {
+		t.Fatal("nil candidates should return empty")
+	}
+	if got := sampleTasks(makeCandidates(1, 1), 0, defaultTaskScoring, testNow, rng); len(got) != 0 {
+		t.Fatal("n=0 should return empty")
+	}
+}

--- a/backend/internal/handlers/post/task_scoring.go
+++ b/backend/internal/handlers/post/task_scoring.go
@@ -1,0 +1,129 @@
+package Post
+
+import (
+	"math"
+	"time"
+)
+
+// taskScoringConfig holds every tunable knob for feed task selection.
+// Tune weights/windows here — nowhere else.
+type taskScoringConfig struct {
+	WorkingNowWeight    float64 // boost when a friend is actively working on the task
+	StartWeight         float64 // weight of start-time proximity
+	StartRampHours      float64 // ramp-up window before start
+	StartDecayHours     float64 // decay window after start
+	DeadlineWeight      float64 // weight of deadline urgency
+	DeadlineRampHours   float64 // ramp-up window before deadline
+	OverdueScore        float64 // flat component score while slightly overdue
+	OverdueGraceHours   float64 // how long the overdue grace lasts
+	PriorityWeight      float64 // weight of user-set priority (1=Low..3=High)
+	RecencyWeight       float64 // weight of creation recency
+	RecencyHalfLifeDays float64 // half-life of the recency decay
+	ValueWeight         float64 // weight of user-set value (0..10)
+	SamplingEpsilon     float64 // floor so zero-score tasks stay sampleable
+	SamplingExponent    float64 // sharpens sampling toward high scorers
+}
+
+var defaultTaskScoring = taskScoringConfig{
+	WorkingNowWeight:    2.5,
+	StartWeight:         3.0,
+	StartRampHours:      24,
+	StartDecayHours:     6,
+	DeadlineWeight:      3.0,
+	DeadlineRampHours:   48,
+	OverdueScore:        0.3,
+	OverdueGraceHours:   24,
+	PriorityWeight:      1.5,
+	RecencyWeight:       1.0,
+	RecencyHalfLifeDays: 3,
+	ValueWeight:         0.5,
+	SamplingEpsilon:     0.15,
+	SamplingExponent:    2,
+}
+
+// taskCandidate is a friend's task parsed from the aggregation pipeline,
+// carrying the time fields needed for scoring alongside the wire format.
+type taskCandidate struct {
+	feedTask       FeedTaskData
+	createdAt      time.Time
+	deadline       *time.Time
+	startTime      *time.Time
+	startDate      *time.Time
+	workingOnSince *time.Time
+}
+
+// effectiveStart prefers the precise startTime over the date-only startDate.
+func (c *taskCandidate) effectiveStart() *time.Time {
+	if c.startTime != nil {
+		return c.startTime
+	}
+	return c.startDate
+}
+
+// scoreTask answers "how encourageable is this task right now?" as a
+// weighted sum of normalized (0..1) components.
+func scoreTask(c *taskCandidate, cfg taskScoringConfig, now time.Time) float64 {
+	score := 0.0
+	if c.workingOnSince != nil {
+		score += cfg.WorkingNowWeight
+	}
+	score += cfg.StartWeight * startProximity(c.effectiveStart(), cfg, now)
+	score += cfg.DeadlineWeight * deadlineUrgency(c.deadline, cfg, now)
+	score += cfg.PriorityWeight * clamp01(float64(c.feedTask.Priority-1)/2)
+	score += cfg.RecencyWeight * recencyScore(c.createdAt, cfg, now)
+	score += cfg.ValueWeight * clamp01(c.feedTask.Value/10)
+	return score
+}
+
+// startProximity peaks at the start moment: linear ramp 0→1 over the
+// StartRampHours before start, linear decay 1→0 over StartDecayHours after.
+func startProximity(start *time.Time, cfg taskScoringConfig, now time.Time) float64 {
+	if start == nil {
+		return 0
+	}
+	hoursUntil := start.Sub(now).Hours()
+	switch {
+	case hoursUntil >= 0 && hoursUntil <= cfg.StartRampHours:
+		return 1 - hoursUntil/cfg.StartRampHours
+	case hoursUntil < 0 && -hoursUntil <= cfg.StartDecayHours:
+		return 1 + hoursUntil/cfg.StartDecayHours
+	default:
+		return 0
+	}
+}
+
+// deadlineUrgency ramps 0→1 over DeadlineRampHours before the deadline,
+// holds a small flat grace while recently overdue, then drops to zero.
+func deadlineUrgency(deadline *time.Time, cfg taskScoringConfig, now time.Time) float64 {
+	if deadline == nil {
+		return 0
+	}
+	hoursUntil := deadline.Sub(now).Hours()
+	switch {
+	case hoursUntil >= 0 && hoursUntil <= cfg.DeadlineRampHours:
+		return 1 - hoursUntil/cfg.DeadlineRampHours
+	case hoursUntil < 0 && -hoursUntil <= cfg.OverdueGraceHours:
+		return cfg.OverdueScore
+	default:
+		return 0
+	}
+}
+
+// recencyScore decays exponentially with task age (creation time).
+func recencyScore(createdAt time.Time, cfg taskScoringConfig, now time.Time) float64 {
+	ageDays := now.Sub(createdAt).Hours() / 24
+	if ageDays < 0 {
+		ageDays = 0
+	}
+	return math.Pow(0.5, ageDays/cfg.RecencyHalfLifeDays)
+}
+
+func clamp01(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 1 {
+		return 1
+	}
+	return v
+}

--- a/backend/internal/handlers/post/task_scoring_test.go
+++ b/backend/internal/handlers/post/task_scoring_test.go
@@ -1,0 +1,132 @@
+package Post
+
+import (
+	"testing"
+	"time"
+)
+
+var testNow = time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)
+
+func timePtr(t time.Time) *time.Time { return &t }
+
+// baselineCandidate has no time fields and minimum priority/value — score ~0
+// except recency (created now → recency component = 1.0 × weight).
+func baselineCandidate() taskCandidate {
+	return taskCandidate{
+		feedTask:  FeedTaskData{Priority: 1, Value: 0},
+		createdAt: testNow,
+	}
+}
+
+func TestScoreTask_ImminentStartBeatsFarFuture(t *testing.T) {
+	soon := baselineCandidate()
+	soon.startTime = timePtr(testNow.Add(30 * time.Minute))
+
+	far := baselineCandidate()
+	far.startTime = timePtr(testNow.Add(72 * time.Hour))
+
+	if scoreTask(&soon, defaultTaskScoring, testNow) <= scoreTask(&far, defaultTaskScoring, testNow) {
+		t.Fatal("task starting in 30m should outscore task starting in 72h")
+	}
+}
+
+func TestScoreTask_RecentlyStartedStillScores(t *testing.T) {
+	started := baselineCandidate()
+	started.startTime = timePtr(testNow.Add(-2 * time.Hour))
+
+	base := baselineCandidate()
+
+	if scoreTask(&started, defaultTaskScoring, testNow) <= scoreTask(&base, defaultTaskScoring, testNow) {
+		t.Fatal("task started 2h ago (within decay window) should outscore no-start task")
+	}
+}
+
+func TestScoreTask_StartTimePrecedesStartDate(t *testing.T) {
+	// startTime imminent, startDate far away — startTime must win.
+	c := baselineCandidate()
+	c.startTime = timePtr(testNow.Add(1 * time.Hour))
+	c.startDate = timePtr(testNow.Add(100 * time.Hour))
+
+	dateOnly := baselineCandidate()
+	dateOnly.startDate = timePtr(testNow.Add(100 * time.Hour))
+
+	if scoreTask(&c, defaultTaskScoring, testNow) <= scoreTask(&dateOnly, defaultTaskScoring, testNow) {
+		t.Fatal("startTime should take precedence over startDate")
+	}
+}
+
+func TestScoreTask_DeadlineTomorrowBeatsNoDeadline(t *testing.T) {
+	due := baselineCandidate()
+	due.deadline = timePtr(testNow.Add(24 * time.Hour))
+
+	base := baselineCandidate()
+
+	if scoreTask(&due, defaultTaskScoring, testNow) <= scoreTask(&base, defaultTaskScoring, testNow) {
+		t.Fatal("task due in 24h should outscore task with no deadline")
+	}
+}
+
+func TestScoreTask_OverdueGraceThenZero(t *testing.T) {
+	slightlyLate := baselineCandidate()
+	slightlyLate.deadline = timePtr(testNow.Add(-12 * time.Hour))
+
+	veryLate := baselineCandidate()
+	veryLate.deadline = timePtr(testNow.Add(-72 * time.Hour))
+
+	base := baselineCandidate()
+
+	if scoreTask(&slightlyLate, defaultTaskScoring, testNow) <= scoreTask(&base, defaultTaskScoring, testNow) {
+		t.Fatal("12h-overdue task should still get the grace boost")
+	}
+	if scoreTask(&veryLate, defaultTaskScoring, testNow) != scoreTask(&base, defaultTaskScoring, testNow) {
+		t.Fatal("72h-overdue task should score same as no-deadline task")
+	}
+}
+
+func TestScoreTask_WorkingNowDominatesPriority(t *testing.T) {
+	working := baselineCandidate()
+	working.workingOnSince = timePtr(testNow.Add(-10 * time.Minute))
+
+	highPri := baselineCandidate()
+	highPri.feedTask.Priority = 3
+
+	if scoreTask(&working, defaultTaskScoring, testNow) <= scoreTask(&highPri, defaultTaskScoring, testNow) {
+		t.Fatal("working-now (weight 2.5) should outscore high priority alone (weight 1.5)")
+	}
+}
+
+func TestScoreTask_PriorityOrdering(t *testing.T) {
+	low, med, high := baselineCandidate(), baselineCandidate(), baselineCandidate()
+	low.feedTask.Priority = 1
+	med.feedTask.Priority = 2
+	high.feedTask.Priority = 3
+
+	sLow := scoreTask(&low, defaultTaskScoring, testNow)
+	sMed := scoreTask(&med, defaultTaskScoring, testNow)
+	sHigh := scoreTask(&high, defaultTaskScoring, testNow)
+	if !(sHigh > sMed && sMed > sLow) {
+		t.Fatalf("priority ordering broken: high=%v med=%v low=%v", sHigh, sMed, sLow)
+	}
+}
+
+func TestScoreTask_RecencyDecays(t *testing.T) {
+	fresh := baselineCandidate()
+
+	old := baselineCandidate()
+	old.createdAt = testNow.Add(-30 * 24 * time.Hour)
+
+	if scoreTask(&fresh, defaultTaskScoring, testNow) <= scoreTask(&old, defaultTaskScoring, testNow) {
+		t.Fatal("freshly created task should outscore 30-day-old task")
+	}
+}
+
+func TestScoreTask_ValueContributes(t *testing.T) {
+	valuable := baselineCandidate()
+	valuable.feedTask.Value = 10
+
+	base := baselineCandidate()
+
+	if scoreTask(&valuable, defaultTaskScoring, testNow) <= scoreTask(&base, defaultTaskScoring, testNow) {
+		t.Fatal("value-10 task should outscore value-0 task")
+	}
+}


### PR DESCRIPTION
## Summary

Replaces random (`$rand`) selection of friends' tasks in the feed with scored, weighted-sampled selection, and places tasks at reserved feed slots instead of burying them in the chronological merge.

- **Eligibility (new):** only public, active, not-completed tasks enter the pool; pipeline now projects `deadline`/`startTime`/`startDate`/`workingOnSince`; pool capped at 200 newest with the per-task user lookup bounded inside `$facet`; dropped a dead `friendsData` `$lookup` that fetched and discarded every friend's full profile on each feed load
- **Scoring (`task_scoring.go`):** weighted sum of normalized signals — start proximity 3.0 (24h ramp / 6h decay), deadline urgency 3.0 (48h ramp, 24h overdue grace at 0.3), working-on-it-now 2.5, priority 1.5, creation recency 1.0 (3-day half-life), value 0.5. All knobs in one `taskScoringConfig` struct for easy tuning
- **Variety (`task_sampling.go`):** weighted sampling without replacement, probability ∝ (score + 0.15)² — high scorers dominate, refreshes still rotate
- **Placement (`task_interleave.go`):** posts + ring closures stay chronological; sampled tasks take every 6th slot (positions 5/11/17 of 20 ≈ same ~17% task share as before). Replaces the old adaptive re-fetch logic
- **Handler (`post.go`):** `GetFeedHuma` rewired; inline bson parsing replaced by `parseTaskCandidate` (now accepts int32/int64 priority)

No API surface changes — endpoint, request, and response shapes are unchanged; frontend untouched. Known pre-existing quirk unchanged: sampled tasks can repeat across offset pages (true of `$rand` before).

## Testing

- 21 new unit tests (scoring orderings, sampling distribution/no-duplicates, slot placement, parser) — all pure, deterministic
- Suite tests rewritten for the new pipeline contract (filters, projections, legacy missing-`active` docs) against test Mongo
- Full backend suite green (23 packages); `go test -short -race` green on the touched package
- Each task went through spec-compliance + code-quality review

🤖 Generated with [Claude Code](https://claude.com/claude-code)