### PR TITLE
feat(kudos): video kudos for encouragements and congratulations

### DIFF
--- a/backend/internal/handlers/congratulation/congratulation.go
+++ b/backend/internal/handlers/congratulation/congratulation.go
@@ -54,6 +54,10 @@ func (h *Handler) CreateCongratulationHuma(ctx context.Context, input *CreateCon
 		congratulationType = "message"
 	}
 
+	if err := types.ValidateVideoKudos(congratulationType, input.Body.ThumbnailURL, input.Body.DurationMs); err != nil {
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
 	// Parse postId if provided
 	var postID *primitive.ObjectID
 	if input.Body.PostID != "" {
@@ -74,6 +78,8 @@ func (h *Handler) CreateCongratulationHuma(ctx context.Context, input *CreateCon
 		TaskName:     input.Body.TaskName,
 		Read:         false,
 		Type:         congratulationType,
+		ThumbnailURL: input.Body.ThumbnailURL,
+		DurationMs:   input.Body.DurationMs,
 		PostID:       postID,
 		Private:      input.Body.Private,
 	}

--- a/backend/internal/handlers/congratulation/service.go
+++ b/backend/internal/handlers/congratulation/service.go
@@ -126,6 +126,8 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 		TaskName:     r.TaskName,
 		Read:         false, // Default to unread
 		Type:         r.Type,
+		ThumbnailURL: r.ThumbnailURL,
+		DurationMs:   r.DurationMs,
 		PostID:       r.PostID,
 	}
 
@@ -152,7 +154,11 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 	slog.LogAttrs(ctx, slog.LevelInfo, "Congratulation inserted", slog.String("id", id.Hex()))
 
 	// Send push notification to receiver
-	err = s.sendCongratulationNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.PostID)
+	videoThumb := ""
+	if r.Type == "video" && r.ThumbnailURL != nil {
+		videoThumb = *r.ThumbnailURL
+	}
+	err = s.sendCongratulationNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.PostID, videoThumb)
 	if err != nil {
 		// Log error but don't fail the operation since congratulation was already created
 		slog.Error("Failed to send congratulation notification", "error", err, "receiver_id", r.Receiver)
@@ -175,6 +181,11 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 		}
 	}
 
+	// A video kudos carries its own thumbnail; prefer it over the post image.
+	if r.Type == "video" && r.ThumbnailURL != nil {
+		thumbnail = *r.ThumbnailURL
+	}
+
 	// Append a denormalized kudos onto the post so cards can render the
 	// congratulator cluster (and the in-thread kudos) without a join.
 	// Best-effort: a missing post or failed update is logged, not fatal.
@@ -186,10 +197,12 @@ func (s *Service) CreateCongratulation(r *CongratulationDocumentInternal) (*Cong
 				Name: r.Sender.Name,
 				Icon: r.Sender.Picture,
 			},
-			Message:   r.Message,
-			Timestamp: congratulation.Timestamp,
-			Type:      r.Type,
-			Private:   r.Private,
+			Message:      r.Message,
+			Timestamp:    congratulation.Timestamp,
+			Type:         r.Type,
+			ThumbnailURL: r.ThumbnailURL,
+			DurationMs:   r.DurationMs,
+			Private:      r.Private,
 		}
 		if _, err := s.Posts.UpdateOne(ctx, bson.M{"_id": r.PostID}, bson.M{"$push": bson.M{"kudos": kudos}}); err != nil {
 			slog.Error("Failed to append kudos to post", "error", err, "post_id", r.PostID.Hex())
@@ -477,7 +490,7 @@ func (s *Service) GetSenderInfo(senderID primitive.ObjectID) (*CongratulationSen
 
 // sendCongratulationNotification sends a push notification when a congratulation is created.
 // postID may be nil — congratulations created outside the post flow (e.g. beak onboarding) won't carry one.
-func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, senderName, taskName, congratulationText, congratulationType string, postID *primitive.ObjectID) error {
+func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, senderName, taskName, congratulationText, congratulationType string, postID *primitive.ObjectID, videoThumbnailURL string) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
@@ -509,8 +522,17 @@ func (s *Service) sendCongratulationNotification(receiverID primitive.ObjectID, 
 	var message string
 	var notification xutils.Notification
 
-	// Check if it's an image congratulation
-	if congratulationType == "image" {
+	// Check congratulation type
+	if congratulationType == "video" {
+		message = fmt.Sprintf("%s sent you a video cheer for \"%s\"!", senderName, taskName)
+		notification = xutils.Notification{
+			Token:    receiver.PushToken,
+			Title:    "You're killing it!",
+			Message:  message,
+			ImageURL: videoThumbnailURL, // push can't play video; show its thumbnail
+			Data:     data,
+		}
+	} else if congratulationType == "image" {
 		message = fmt.Sprintf("%s is celebrating your work on \"%s\"!", senderName, taskName)
 		notification = xutils.Notification{
 			Token:    receiver.PushToken,
@@ -568,7 +590,7 @@ func (s *Service) SendBeakCongratulation(receiverID primitive.ObjectID, message,
 	}
 
 	// Send push notification
-	err = s.sendCongratulationNotification(receiverID, beakName, taskName, message, "message", nil)
+	err = s.sendCongratulationNotification(receiverID, beakName, taskName, message, "message", nil, "")
 	if err != nil {
 		slog.Error("Failed to send beak congratulation notification", "error", err, "receiver_id", receiverID)
 	}

--- a/backend/internal/handlers/congratulation/service_test.go
+++ b/backend/internal/handlers/congratulation/service_test.go
@@ -400,6 +400,84 @@ func (s *CongratulationServiceTestSuite) TestCreateCongratulation_VideoType() {
 	s.Equal(thumb, *result.ThumbnailURL)
 	s.NotNil(result.DurationMs)
 	s.Equal(duration, *result.DurationMs)
+
+	// Read back the stored document so a bson-tag regression can't slip through.
+	congratulationID, err := primitive.ObjectIDFromHex(result.ID)
+	s.NoError(err)
+	var stored CongratulationDocumentInternal
+	err = s.Collections["congratulations"].FindOne(s.Ctx, bson.M{"_id": congratulationID}).Decode(&stored)
+	s.NoError(err)
+	s.Equal("video", stored.Type)
+	s.Require().NotNil(stored.ThumbnailURL)
+	s.Equal(thumb, *stored.ThumbnailURL)
+	s.Require().NotNil(stored.DurationMs)
+	s.Equal(duration, *stored.DurationMs)
+}
+
+func (s *CongratulationServiceTestSuite) TestCreateCongratulation_VideoType_WithPostID_DenormalizesKudos() {
+	user1 := s.GetUser(0)
+	user2 := s.GetUser(1)
+	postID := primitive.NewObjectID()
+
+	// Create a post with images
+	post := types.PostDocument{
+		ID:      postID,
+		Caption: "Test post",
+		User: types.UserExtendedReferenceInternal{
+			ID:             user2.ID,
+			DisplayName:    user2.DisplayName,
+			Handle:         user2.Handle,
+			ProfilePicture: user2.ProfilePicture,
+		},
+		Images: []string{"https://example.com/image1.jpg", "https://example.com/image2.jpg"},
+		Metadata: types.PostMetadata{
+			CreatedAt: time.Now(),
+			IsDeleted: false,
+		},
+	}
+	s.InsertOne("posts", post)
+
+	// Create video congratulation with post reference
+	thumb := "https://example.com/congrats-thumb.jpg"
+	duration := 20_000
+	newCongratulation := &CongratulationDocumentInternal{
+		Sender: CongratulationSenderInternal{
+			ID:      user1.ID,
+			Name:    user1.DisplayName,
+			Picture: user1.ProfilePicture,
+		},
+		Receiver:     user2.ID,
+		Message:      "https://example.com/congrats.mp4",
+		CategoryName: "Social",
+		TaskName:     "Share photo",
+		Type:         "video",
+		ThumbnailURL: &thumb,
+		DurationMs:   &duration,
+		PostID:       &postID,
+	}
+
+	result, err := s.service.CreateCongratulation(newCongratulation)
+
+	// Assertions
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("https://example.com/congrats.mp4", result.Message)
+
+	// The video congratulation should have been appended as a kudos on the
+	// post, carrying its thumbnail and duration through the denormalization.
+	var updatedPost types.PostDocument
+	err = s.Collections["posts"].FindOne(s.Ctx, bson.M{"_id": postID}).Decode(&updatedPost)
+	s.NoError(err)
+	s.Require().Len(updatedPost.Kudos, 1)
+	s.Equal("https://example.com/congrats.mp4", updatedPost.Kudos[0].Message)
+	s.Equal(user1.ID, updatedPost.Kudos[0].Sender.ID)
+	s.Equal(user1.DisplayName, updatedPost.Kudos[0].Sender.Name)
+	s.Equal(user1.ProfilePicture, updatedPost.Kudos[0].Sender.Icon)
+	s.Equal("video", updatedPost.Kudos[0].Type)
+	s.Require().NotNil(updatedPost.Kudos[0].ThumbnailURL)
+	s.Equal(thumb, *updatedPost.Kudos[0].ThumbnailURL)
+	s.Require().NotNil(updatedPost.Kudos[0].DurationMs)
+	s.Equal(duration, *updatedPost.Kudos[0].DurationMs)
 }
 
 // ========================================

--- a/backend/internal/handlers/congratulation/service_test.go
+++ b/backend/internal/handlers/congratulation/service_test.go
@@ -369,6 +369,39 @@ func (s *CongratulationServiceTestSuite) TestCreateCongratulation_ImageType() {
 	s.Equal("https://example.com/congrats-image.jpg", result.Message)
 }
 
+func (s *CongratulationServiceTestSuite) TestCreateCongratulation_VideoType() {
+	user1 := s.GetUser(0)
+	user2 := s.GetUser(1)
+
+	thumb := "https://example.com/congrats-thumb.jpg"
+	duration := 20_000
+	newCongratulation := &CongratulationDocumentInternal{
+		Sender: CongratulationSenderInternal{
+			ID:      user1.ID,
+			Name:    user1.DisplayName,
+			Picture: user1.ProfilePicture,
+		},
+		Receiver:     user2.ID,
+		Message:      "https://example.com/congrats.mp4",
+		CategoryName: "Personal",
+		TaskName:     "Achievement",
+		Type:         "video",
+		ThumbnailURL: &thumb,
+		DurationMs:   &duration,
+	}
+
+	result, err := s.service.CreateCongratulation(newCongratulation)
+
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("video", result.Type)
+	s.Equal("https://example.com/congrats.mp4", result.Message)
+	s.NotNil(result.ThumbnailURL)
+	s.Equal(thumb, *result.ThumbnailURL)
+	s.NotNil(result.DurationMs)
+	s.Equal(duration, *result.DurationMs)
+}
+
 // ========================================
 // UpdatePartialCongratulation Tests
 // ========================================

--- a/backend/internal/handlers/congratulation/types.go
+++ b/backend/internal/handlers/congratulation/types.go
@@ -187,7 +187,7 @@ type CongratulationDocument struct {
 	CategoryName string               `bson:"categoryName" json:"categoryName" example:"Work" doc:"Category name"`
 	TaskName     string               `bson:"taskName" json:"taskName" example:"Complete project proposal" doc:"Task name"`
 	Read         bool                 `bson:"read" json:"read" example:"false" doc:"Whether the congratulation has been read"`
-	Type         string               `bson:"type" json:"type" example:"message" doc:"Type of congratulation (message or image)"`
+	Type         string               `bson:"type" json:"type" example:"message" doc:"Type of congratulation (message, image, or video)"`
 	ThumbnailURL *string              `bson:"thumbnailUrl,omitempty" json:"thumbnailUrl,omitempty" example:"https://example.com/thumb.jpg" doc:"Video thumbnail URL (video type only)"`
 	DurationMs   *int                 `bson:"durationMs,omitempty" json:"durationMs,omitempty" example:"15000" doc:"Video duration in milliseconds (video type only)"`
 	Reaction     *string              `bson:"reaction,omitempty" json:"reaction,omitempty" example:"🙌" doc:"Receiver's emoji reaction"`

--- a/backend/internal/handlers/congratulation/types.go
+++ b/backend/internal/handlers/congratulation/types.go
@@ -167,13 +167,15 @@ func (s *CongratulationSenderInternal) ToAPI() *CongratulationSender {
 }
 
 type CreateCongratulationParams struct {
-	Receiver     string `json:"receiver" example:"507f1f77bcf86cd799439012" doc:"Receiver user ID" validate:"required"`
-	Message      string `json:"message" example:"Congratulations on completing your task!" doc:"Congratulation message" validate:"required"`
-	CategoryName string `json:"categoryName" example:"Work" doc:"Category name" validate:"required"`
-	TaskName     string `json:"taskName" example:"Complete project proposal" doc:"Task name" validate:"required"`
-	Type         string `json:"type" example:"message" doc:"Type of congratulation (message or image)" validate:"omitempty,oneof=message image"`
-	PostID       string `json:"postId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Optional post ID associated with the congratulation"`
-	Private      bool   `json:"private,omitempty" doc:"If true, the sender is anonymized to everyone except the receiver"`
+	Receiver     string  `json:"receiver" example:"507f1f77bcf86cd799439012" doc:"Receiver user ID" validate:"required"`
+	Message      string  `json:"message" example:"Congratulations on completing your task!" doc:"Congratulation message" validate:"required"`
+	CategoryName string  `json:"categoryName" example:"Work" doc:"Category name" validate:"required"`
+	TaskName     string  `json:"taskName" example:"Complete project proposal" doc:"Task name" validate:"required"`
+	Type         string  `json:"type" example:"message" doc:"Type of congratulation (message, image, or video)" validate:"omitempty,oneof=message image video"`
+	ThumbnailURL *string `json:"thumbnailUrl,omitempty" example:"https://example.com/thumb.jpg" doc:"Video thumbnail URL (required for video type)" validate:"omitempty,url"`
+	DurationMs   *int    `json:"durationMs,omitempty" example:"15000" doc:"Video duration in milliseconds, max 30000 (required for video type)"`
+	PostID       string  `json:"postId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Optional post ID associated with the congratulation"`
+	Private      bool    `json:"private,omitempty" doc:"If true, the sender is anonymized to everyone except the receiver"`
 }
 
 type CongratulationDocument struct {
@@ -186,6 +188,8 @@ type CongratulationDocument struct {
 	TaskName     string               `bson:"taskName" json:"taskName" example:"Complete project proposal" doc:"Task name"`
 	Read         bool                 `bson:"read" json:"read" example:"false" doc:"Whether the congratulation has been read"`
 	Type         string               `bson:"type" json:"type" example:"message" doc:"Type of congratulation (message or image)"`
+	ThumbnailURL *string              `bson:"thumbnailUrl,omitempty" json:"thumbnailUrl,omitempty" example:"https://example.com/thumb.jpg" doc:"Video thumbnail URL (video type only)"`
+	DurationMs   *int                 `bson:"durationMs,omitempty" json:"durationMs,omitempty" example:"15000" doc:"Video duration in milliseconds (video type only)"`
 	Reaction     *string              `bson:"reaction,omitempty" json:"reaction,omitempty" example:"🙌" doc:"Receiver's emoji reaction"`
 	ReactedAt    *time.Time           `bson:"reactedAt,omitempty" json:"reactedAt,omitempty" doc:"When the receiver reacted"`
 	// Populated only by sent queries (kudos documents store just the receiver's ID).
@@ -203,6 +207,8 @@ type CongratulationDocumentInternal struct {
 	TaskName     string                       `bson:"taskName"`
 	Read         bool                         `bson:"read"`
 	Type         string                       `bson:"type"`
+	ThumbnailURL *string                      `bson:"thumbnailUrl,omitempty"`
+	DurationMs   *int                         `bson:"durationMs,omitempty"`
 	PostID       *primitive.ObjectID          `bson:"postId,omitempty"`
 	Private      bool                         `bson:"private,omitempty"`
 	Reaction     *string                      `bson:"reaction,omitempty"`
@@ -229,6 +235,8 @@ func (c *CongratulationDocumentInternal) ToAPI() *CongratulationDocument {
 		TaskName:     c.TaskName,
 		Read:         c.Read,
 		Type:         c.Type,
+		ThumbnailURL: c.ThumbnailURL,
+		DurationMs:   c.DurationMs,
 		Reaction:     c.Reaction,
 		ReactedAt:    c.ReactedAt,
 	}

--- a/backend/internal/handlers/encouragement/encouragement.go
+++ b/backend/internal/handlers/encouragement/encouragement.go
@@ -83,6 +83,10 @@ func (h *Handler) CreateEncouragementHuma(ctx context.Context, input *CreateEnco
 		encouragementType = "message"
 	}
 
+	if err := types.ValidateVideoKudos(encouragementType, input.Body.ThumbnailURL, input.Body.DurationMs); err != nil {
+		return nil, huma.Error422UnprocessableEntity(err.Error())
+	}
+
 	// Create internal document for database operations
 	internalDoc := EncouragementDocumentInternal{
 		Sender:       *senderInfo,
@@ -94,6 +98,8 @@ func (h *Handler) CreateEncouragementHuma(ctx context.Context, input *CreateEnco
 		TaskID:       taskID,
 		Read:         false,
 		Type:         encouragementType,
+		ThumbnailURL: input.Body.ThumbnailURL,
+		DurationMs:   input.Body.DurationMs,
 	}
 
 	encouragement, err := h.service.CreateEncouragement(&internalDoc)

--- a/backend/internal/handlers/encouragement/service.go
+++ b/backend/internal/handlers/encouragement/service.go
@@ -160,6 +160,8 @@ func (s *Service) CreateEncouragement(r *EncouragementDocumentInternal) (*Encour
 		TaskID:       r.TaskID,
 		Read:         false, // Default to unread
 		Type:         r.Type,
+		ThumbnailURL: r.ThumbnailURL,
+		DurationMs:   r.DurationMs,
 	}
 
 	client := s.Encouragements.Database().Client()
@@ -214,9 +216,11 @@ func (s *Service) CreateEncouragement(r *EncouragementDocumentInternal) (*Encour
 					Name:   r.Sender.Name,
 					Icon:   r.Sender.Picture,
 				},
-				Message:   encouragement.Message,
-				Timestamp: encouragement.Timestamp,
-				Type:      encouragement.Type,
+				Message:      encouragement.Message,
+				Timestamp:    encouragement.Timestamp,
+				Type:         encouragement.Type,
+				ThumbnailURL: encouragement.ThumbnailURL,
+				DurationMs:   encouragement.DurationMs,
 			}
 			res, err := s.Categories.UpdateOne(sessCtx,
 				bson.M{"tasks._id": encouragement.TaskID},
@@ -242,7 +246,11 @@ func (s *Service) CreateEncouragement(r *EncouragementDocumentInternal) (*Encour
 	slog.LogAttrs(ctx, slog.LevelInfo, "Encouragement inserted", slog.String("id", encouragement.ID.Hex()))
 
 	// Best-effort side effects after commit (unchanged behavior).
-	if err := s.sendEncouragementNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.Scope, r.TaskID); err != nil {
+	videoThumb := ""
+	if r.Type == "video" && r.ThumbnailURL != nil {
+		videoThumb = *r.ThumbnailURL
+	}
+	if err := s.sendEncouragementNotification(r.Receiver, r.Sender.Name, r.TaskName, r.Message, r.Type, r.Scope, r.TaskID, videoThumb); err != nil {
 		slog.Error("Failed to send encouragement notification", "error", err, "receiver_id", r.Receiver)
 	}
 
@@ -254,7 +262,7 @@ func (s *Service) CreateEncouragement(r *EncouragementDocumentInternal) (*Encour
 		notificationContent = fmt.Sprintf("%s on \"%s\": \"%s\"", r.Sender.Name, r.TaskName, r.Message)
 		referenceID = r.TaskID
 	}
-	if err := s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeEncouragement, referenceID); err != nil {
+	if err := s.NotificationService.CreateNotification(r.Sender.ID, r.Receiver, notificationContent, notifications.NotificationTypeEncouragement, referenceID, videoThumb); err != nil {
 		slog.Error("Failed to create encouragement notification in database", "error", err, "receiver_id", r.Receiver)
 	}
 
@@ -524,7 +532,7 @@ func (s *Service) GetSenderInfo(senderID primitive.ObjectID) (*EncouragementSend
 }
 
 // sendEncouragementNotification sends a push notification when an encouragement is created
-func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, senderName, taskName, encouragementText, encouragementType, scope string, taskID primitive.ObjectID) error {
+func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, senderName, taskName, encouragementText, encouragementType, scope string, taskID primitive.ObjectID, videoThumbnailURL string) error {
 	if s.Users == nil {
 		return fmt.Errorf("users collection not available")
 	}
@@ -554,7 +562,16 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 			"sender_name":  senderName,
 			"message_text": encouragementText,
 		}
-		if encouragementType == "image" {
+		if encouragementType == "video" {
+			message = fmt.Sprintf("%s sent you a video cheer!", senderName)
+			notification = xutils.Notification{
+				Token:    receiver.PushToken,
+				Title:    "You've got a fan!",
+				Message:  message,
+				ImageURL: videoThumbnailURL, // push can't play video; show its thumbnail
+				Data:     data,
+			}
+		} else if encouragementType == "image" {
 			message = fmt.Sprintf("%s is rooting for you!", senderName)
 			notification = xutils.Notification{
 				Token:    receiver.PushToken,
@@ -584,7 +601,16 @@ func (s *Service) sendEncouragementNotification(receiverID primitive.ObjectID, s
 		if !taskID.IsZero() {
 			data["task_id"] = taskID.Hex()
 		}
-		if encouragementType == "image" {
+		if encouragementType == "video" {
+			message = fmt.Sprintf("%s sent you a video cheer for \"%s\"!", senderName, taskName)
+			notification = xutils.Notification{
+				Token:    receiver.PushToken,
+				Title:    "Someone believes in you!",
+				Message:  message,
+				ImageURL: videoThumbnailURL, // push can't play video; show its thumbnail
+				Data:     data,
+			}
+		} else if encouragementType == "image" {
 			message = fmt.Sprintf("%s is cheering you on for \"%s\"!", senderName, taskName)
 			notification = xutils.Notification{
 				Token:    receiver.PushToken,

--- a/backend/internal/handlers/encouragement/service_test.go
+++ b/backend/internal/handlers/encouragement/service_test.go
@@ -276,6 +276,39 @@ func (s *EncouragementServiceTestSuite) TestCreateEncouragement_ImageType_Succes
 	s.Equal("https://example.com/encouragement-image.jpg", result.Message)
 }
 
+func (s *EncouragementServiceTestSuite) TestCreateEncouragement_VideoType_Success() {
+	user1 := s.GetUser(0)
+	user2 := s.GetUser(1)
+
+	s.setUserEncouragementBalance(user1.ID, 2)
+
+	senderInfo, err := s.service.GetSenderInfo(user1.ID)
+	s.NoError(err)
+
+	thumb := "https://example.com/cheer-thumb.jpg"
+	duration := 12_000
+	newEnc := &encouragement.EncouragementDocumentInternal{
+		Sender:       *senderInfo,
+		Receiver:     user2.ID,
+		Message:      "https://example.com/cheer.mp4",
+		Scope:        "profile",
+		Type:         "video",
+		ThumbnailURL: &thumb,
+		DurationMs:   &duration,
+	}
+
+	result, err := s.service.CreateEncouragement(newEnc)
+
+	s.NoError(err)
+	s.NotNil(result)
+	s.Equal("video", result.Type)
+	s.Equal("https://example.com/cheer.mp4", result.Message)
+	s.NotNil(result.ThumbnailURL)
+	s.Equal(thumb, *result.ThumbnailURL)
+	s.NotNil(result.DurationMs)
+	s.Equal(duration, *result.DurationMs)
+}
+
 func (s *EncouragementServiceTestSuite) TestCreateEncouragement_InsufficientBalance() {
 	user1 := s.GetUser(0)
 	user2 := s.GetUser(1)

--- a/backend/internal/handlers/encouragement/service_test.go
+++ b/backend/internal/handlers/encouragement/service_test.go
@@ -307,6 +307,61 @@ func (s *EncouragementServiceTestSuite) TestCreateEncouragement_VideoType_Succes
 	s.Equal(thumb, *result.ThumbnailURL)
 	s.NotNil(result.DurationMs)
 	s.Equal(duration, *result.DurationMs)
+
+	// Round-trip: the persisted document must carry the video fields too.
+	encID, _ := primitive.ObjectIDFromHex(result.ID)
+	var found encouragement.EncouragementDocumentInternal
+	err = s.Collections["encouragements"].FindOne(s.Ctx, bson.M{"_id": encID}).Decode(&found)
+	s.NoError(err)
+	s.Equal("video", found.Type)
+	s.Require().NotNil(found.ThumbnailURL)
+	s.Equal(thumb, *found.ThumbnailURL)
+	s.Require().NotNil(found.DurationMs)
+	s.Equal(duration, *found.DurationMs)
+}
+
+func (s *EncouragementServiceTestSuite) TestCreateEncouragement_VideoType_TaskScope_RecordsKudosOnTask() {
+	sender := s.GetUser(0)
+	receiver := s.GetUser(1)
+	taskID := primitive.NewObjectID()
+	s.seedCategoryWithTask(receiver.ID, taskID, "Morning run")
+	s.setUserEncouragementBalance(sender.ID, 5)
+
+	senderInfo, err := s.service.GetSenderInfo(sender.ID)
+	s.Require().NoError(err)
+
+	thumb := "https://example.com/cheer-thumb.jpg"
+	duration := 12_000
+	newEnc := &encouragement.EncouragementDocumentInternal{
+		Sender:       *senderInfo,
+		Receiver:     receiver.ID,
+		Message:      "https://example.com/cheer.mp4",
+		Scope:        "task",
+		CategoryName: "Health",
+		TaskName:     "Morning run",
+		TaskID:       taskID,
+		Type:         "video",
+		ThumbnailURL: &thumb,
+		DurationMs:   &duration,
+	}
+
+	result, err := s.service.CreateEncouragement(newEnc)
+	s.NoError(err)
+	s.NotNil(result)
+
+	task := s.findTask(receiver.ID, taskID)
+	s.Require().Len(task.Encouragements, 1)
+	k := task.Encouragements[0]
+	s.Equal("https://example.com/cheer.mp4", k.Message)
+	s.Equal("video", k.Type)
+	s.Equal(sender.ID, k.Sender.ID)
+	s.Equal(sender.DisplayName, k.Sender.Name)
+	s.Require().NotNil(k.ThumbnailURL)
+	s.Equal(thumb, *k.ThumbnailURL)
+	s.Require().NotNil(k.DurationMs)
+	s.Equal(duration, *k.DurationMs)
+	encID, _ := primitive.ObjectIDFromHex(result.ID)
+	s.Equal(encID, k.EncouragementID)
 }
 
 func (s *EncouragementServiceTestSuite) TestCreateEncouragement_InsufficientBalance() {

--- a/backend/internal/handlers/encouragement/types.go
+++ b/backend/internal/handlers/encouragement/types.go
@@ -145,13 +145,15 @@ func (s *EncouragementSenderInternal) ToAPI() *EncouragementSender {
 }
 
 type CreateEncouragementParams struct {
-	Receiver     string `json:"receiver" example:"507f1f77bcf86cd799439012" doc:"Receiver user ID" validate:"required"`
-	Message      string `json:"message" example:"Great job on completing your task!" doc:"Encouragement message" validate:"required"`
-	Scope        string `json:"scope" example:"task" doc:"Scope of encouragement (task or profile)" validate:"omitempty,oneof=task profile"`
-	CategoryName string `json:"categoryName,omitempty" example:"Work" doc:"Category name (required for task scope)"`
-	TaskName     string `json:"taskName,omitempty" example:"Complete project proposal" doc:"Task name (required for task scope)"`
-	TaskID       string `json:"taskId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Task ID (required for task scope)"`
-	Type         string `json:"type" example:"message" doc:"Type of encouragement (message or image)" validate:"omitempty,oneof=message image"`
+	Receiver     string  `json:"receiver" example:"507f1f77bcf86cd799439012" doc:"Receiver user ID" validate:"required"`
+	Message      string  `json:"message" example:"Great job on completing your task!" doc:"Encouragement message" validate:"required"`
+	Scope        string  `json:"scope" example:"task" doc:"Scope of encouragement (task or profile)" validate:"omitempty,oneof=task profile"`
+	CategoryName string  `json:"categoryName,omitempty" example:"Work" doc:"Category name (required for task scope)"`
+	TaskName     string  `json:"taskName,omitempty" example:"Complete project proposal" doc:"Task name (required for task scope)"`
+	TaskID       string  `json:"taskId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Task ID (required for task scope)"`
+	Type         string  `json:"type" example:"message" doc:"Type of encouragement (message, image, or video)" validate:"omitempty,oneof=message image video"`
+	ThumbnailURL *string `json:"thumbnailUrl,omitempty" example:"https://example.com/thumb.jpg" doc:"Video thumbnail URL (required for video type)" validate:"omitempty,url"`
+	DurationMs   *int    `json:"durationMs,omitempty" example:"15000" doc:"Video duration in milliseconds, max 30000 (required for video type)"`
 }
 
 type EncouragementDocument struct {
@@ -166,6 +168,8 @@ type EncouragementDocument struct {
 	TaskID       string              `bson:"taskId,omitempty" json:"taskId,omitempty" example:"507f1f77bcf86cd799439013" doc:"Task ID being encouraged"`
 	Read         bool                `bson:"read" json:"read" example:"false" doc:"Whether the encouragement has been read"`
 	Type         string              `bson:"type" json:"type" example:"message" doc:"Type of encouragement (message or image)"`
+	ThumbnailURL *string             `bson:"thumbnailUrl,omitempty" json:"thumbnailUrl,omitempty" example:"https://example.com/thumb.jpg" doc:"Video thumbnail URL (video type only)"`
+	DurationMs   *int                `bson:"durationMs,omitempty" json:"durationMs,omitempty" example:"15000" doc:"Video duration in milliseconds (video type only)"`
 	Reaction     *string             `bson:"reaction,omitempty" json:"reaction,omitempty" example:"❤️" doc:"Receiver's emoji reaction"`
 	ReactedAt    *time.Time          `bson:"reactedAt,omitempty" json:"reactedAt,omitempty" doc:"When the receiver reacted"`
 	// Populated only by sent queries (kudos documents store just the receiver's ID).
@@ -185,6 +189,8 @@ type EncouragementDocumentInternal struct {
 	TaskID       primitive.ObjectID          `bson:"taskId,omitempty"`
 	Read         bool                        `bson:"read"`
 	Type         string                      `bson:"type"`
+	ThumbnailURL *string                     `bson:"thumbnailUrl,omitempty"`
+	DurationMs   *int                        `bson:"durationMs,omitempty"`
 	Reaction     *string                     `bson:"reaction,omitempty"`
 	ReactedAt    *time.Time                  `bson:"reactedAt,omitempty"`
 }
@@ -200,16 +206,18 @@ type UpdateEncouragementDocument struct {
 // Helper functions to convert between internal and API types
 func (e *EncouragementDocumentInternal) ToAPI() *EncouragementDocument {
 	doc := &EncouragementDocument{
-		ID:        e.ID.Hex(),
-		Sender:    *e.Sender.ToAPI(),
-		Receiver:  e.Receiver.Hex(),
-		Message:   e.Message,
-		Timestamp: e.Timestamp,
-		Scope:     e.Scope,
-		Read:      e.Read,
-		Type:      e.Type,
-		Reaction:  e.Reaction,
-		ReactedAt: e.ReactedAt,
+		ID:           e.ID.Hex(),
+		Sender:       *e.Sender.ToAPI(),
+		Receiver:     e.Receiver.Hex(),
+		Message:      e.Message,
+		Timestamp:    e.Timestamp,
+		Scope:        e.Scope,
+		Read:         e.Read,
+		Type:         e.Type,
+		ThumbnailURL: e.ThumbnailURL,
+		DurationMs:   e.DurationMs,
+		Reaction:     e.Reaction,
+		ReactedAt:    e.ReactedAt,
 	}
 
 	// Include task fields for task-scoped encouragements

--- a/backend/internal/handlers/types/kudos_video_test.go
+++ b/backend/internal/handlers/types/kudos_video_test.go
@@ -1,0 +1,36 @@
+package types
+
+import "testing"
+
+func strPtr(s string) *string { return &s }
+func intPtr(i int) *int       { return &i }
+
+func TestValidateVideoKudos(t *testing.T) {
+	thumb := strPtr("https://example.com/thumb.jpg")
+
+	tests := []struct {
+		name       string
+		kudosType  string
+		thumbnail  *string
+		durationMs *int
+		wantErr    bool
+	}{
+		{"message type ignores video fields", "message", nil, nil, false},
+		{"image type ignores video fields", "image", nil, nil, false},
+		{"valid video", "video", thumb, intPtr(15_000), false},
+		{"video at exactly the cap", "video", thumb, intPtr(30_000), false},
+		{"video missing thumbnail", "video", nil, intPtr(15_000), true},
+		{"video empty thumbnail", "video", strPtr(""), intPtr(15_000), true},
+		{"video missing duration", "video", thumb, nil, true},
+		{"video zero duration", "video", thumb, intPtr(0), true},
+		{"video over the cap", "video", thumb, intPtr(30_001), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateVideoKudos(tt.kudosType, tt.thumbnail, tt.durationMs)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateVideoKudos() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/backend/internal/handlers/types/types.go
+++ b/backend/internal/handlers/types/types.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+	"fmt"
 	"time"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
@@ -106,7 +108,9 @@ type TaskKudos struct {
 	Sender          KudosSender        `bson:"sender" json:"sender"`
 	Message         string             `bson:"message" json:"message"`
 	Timestamp       time.Time          `bson:"timestamp" json:"timestamp"`
-	Type            string             `bson:"type" json:"type"` // "message" | "image"
+	Type            string             `bson:"type" json:"type"`                                     // "message" | "image" | "video" (image/video => message holds the URL)
+	ThumbnailURL    *string            `bson:"thumbnailUrl,omitempty" json:"thumbnailUrl,omitempty"` // video only
+	DurationMs      *int               `bson:"durationMs,omitempty" json:"durationMs,omitempty"`     // video only
 }
 
 /*
@@ -465,10 +469,34 @@ type PostKudos struct {
 	Sender           KudosSender        `bson:"sender" json:"sender"`
 	Message          string             `bson:"message" json:"message"`
 	Timestamp        time.Time          `bson:"timestamp" json:"timestamp"`
-	Type             string             `bson:"type" json:"type"` // "message" | "image" (image => message holds the URL)
+	Type             string             `bson:"type" json:"type"`                                     // "message" | "image" | "video" (image/video => message holds the URL)
+	ThumbnailURL     *string            `bson:"thumbnailUrl,omitempty" json:"thumbnailUrl,omitempty"` // video only
+	DurationMs       *int               `bson:"durationMs,omitempty" json:"durationMs,omitempty"`     // video only
 	// Private kudos are anonymized (sender + message stripped) for everyone
 	// except the post owner. See PostDocument.ToAPI.
 	Private bool `bson:"private,omitempty" json:"private,omitempty"`
+}
+
+// KudosVideoMaxDurationMs caps video kudos length (30s — half the post limit).
+// Must stay in sync with KUDOS_VIDEO_MAX_DURATION_MS in frontend/api/upload.ts.
+const KudosVideoMaxDurationMs = 30_000
+
+// ValidateVideoKudos checks the extra fields a "video"-type kudos must carry.
+// Non-video types pass unconditionally.
+func ValidateVideoKudos(kudosType string, thumbnailURL *string, durationMs *int) error {
+	if kudosType != "video" {
+		return nil
+	}
+	if thumbnailURL == nil || *thumbnailURL == "" {
+		return errors.New("thumbnailUrl is required for video kudos")
+	}
+	if durationMs == nil || *durationMs <= 0 {
+		return errors.New("durationMs is required for video kudos")
+	}
+	if *durationMs > KudosVideoMaxDurationMs {
+		return fmt.Errorf("video kudos must be %d seconds or shorter", KudosVideoMaxDurationMs/1000)
+	}
+	return nil
 }
 
 type CommentDocument struct {

--- a/frontend/__tests__/KudosItem.test.tsx
+++ b/frontend/__tests__/KudosItem.test.tsx
@@ -4,6 +4,14 @@ import KudosItem from "@/components/cards/KudosItem";
 
 jest.mock("@/components/CachedImage", () => "CachedImage");
 jest.mock("expo-router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("expo-video", () => ({
+    useVideoPlayer: () => ({}),
+    VideoView: "VideoView",
+}));
+// KudosVideoPlayerModal positions its close button with safe-area insets.
+jest.mock("react-native-safe-area-context", () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
 
 const base = {
     id: "k1",
@@ -33,5 +41,25 @@ describe("KudosItem", () => {
             <KudosItem kudos={{ ...base, scope: "profile" }} formatTime={() => "now"} />,
         );
         getByText("Profile Encouragement 🎉");
+    });
+
+    test("video kudos renders the thumbnail, not the raw URL", () => {
+        const { getByTestId, queryByText } = render(
+            <KudosItem
+                kudos={{
+                    ...base,
+                    scope: "task",
+                    categoryName: "Fitness",
+                    taskName: "Morning run",
+                    type: "video",
+                    message: "https://x/cheer.mp4",
+                    thumbnailUrl: "https://x/cheer-thumb.jpg",
+                    durationMs: 12000,
+                }}
+                formatTime={() => "now"}
+            />,
+        );
+        getByTestId("bubble-video");
+        expect(queryByText("https://x/cheer.mp4")).toBeNull();
     });
 });

--- a/frontend/__tests__/SpeechBubbleCard.test.tsx
+++ b/frontend/__tests__/SpeechBubbleCard.test.tsx
@@ -6,6 +6,15 @@ import SpeechBubbleCard from "@/components/cards/SpeechBubbleCard";
 // CachedImage wraps expo-image; stub it so tests don't touch native modules.
 jest.mock("@/components/CachedImage", () => "CachedImage");
 
+jest.mock("expo-video", () => ({
+    useVideoPlayer: () => ({}),
+    VideoView: "VideoView",
+}));
+// KudosVideoPlayerModal positions its close button with safe-area insets.
+jest.mock("react-native-safe-area-context", () => ({
+    useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
 const sender = { name: "Sarah", picture: "https://x/a.png", id: "u1" };
 
 describe("SpeechBubbleCard", () => {
@@ -57,6 +66,36 @@ describe("SpeechBubbleCard", () => {
         );
         getByTestId("bubble-image");
         expect(queryByText("should be hidden")).toBeNull();
+    });
+
+    test("renders the video thumbnail with duration (not message text) when video props are set", () => {
+        const { getByTestId, getByText, queryByText } = render(
+            <SpeechBubbleCard
+                sender={sender}
+                message="should be hidden"
+                videoUri="https://x/cheer.mp4"
+                videoThumbnailUri="https://x/cheer-thumb.jpg"
+                videoDurationMs={15000}
+                timeLabel="now"
+            />,
+        );
+        getByTestId("bubble-video");
+        getByText("0:15");
+        expect(queryByText("should be hidden")).toBeNull();
+    });
+
+    test("tapping the video thumbnail opens the fullscreen player", () => {
+        const { getByTestId, queryByTestId } = render(
+            <SpeechBubbleCard
+                sender={sender}
+                videoUri="https://x/cheer.mp4"
+                videoThumbnailUri="https://x/cheer-thumb.jpg"
+                timeLabel="now"
+            />,
+        );
+        expect(queryByTestId("kudos-video-close")).toBeNull();
+        fireEvent.press(getByTestId("bubble-video"));
+        getByTestId("kudos-video-close");
     });
 
     test("renders footerSlot beside the time", () => {

--- a/frontend/__tests__/media.test.ts
+++ b/frontend/__tests__/media.test.ts
@@ -1,4 +1,4 @@
-import { assetsToPickedMedia, resolvePlayableVideo, type PickedMedia } from "../api/media";
+import { assetsToPickedMedia, resolvePlayableVideo, formatVideoDuration, mediaTypeFromUri, type PickedMedia } from "../api/media";
 
 describe("assetsToPickedMedia", () => {
     it("tags each asset as image or video and preserves order", () => {
@@ -44,5 +44,27 @@ describe("resolvePlayableVideo", () => {
             resolvePlayableVideo("file://same.mov", "file://same.mov", getThumbnail)
         ).rejects.toThrow("Cannot Open");
         expect(getThumbnail).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("mediaTypeFromUri", () => {
+    test("classifies remote video URLs by extension", () => {
+        expect(mediaTypeFromUri("https://cdn.example.com/kudos/cheer.mp4")).toBe("video");
+        expect(mediaTypeFromUri("https://cdn.example.com/kudos/cheer.MOV")).toBe("video");
+    });
+
+    test("treats non-video and extension-less URLs as images", () => {
+        expect(mediaTypeFromUri("https://cdn.example.com/kudos/pic.jpg")).toBe("image");
+        expect(mediaTypeFromUri("https://media.tenor.com/abc/tenor.gif")).toBe("image");
+        expect(mediaTypeFromUri("https://cdn.example.com/no-extension")).toBe("image");
+    });
+});
+
+describe("formatVideoDuration", () => {
+    test("formats ms as m:ss", () => {
+        expect(formatVideoDuration(15_000)).toBe("0:15");
+        expect(formatVideoDuration(5_400)).toBe("0:05");
+        expect(formatVideoDuration(30_000)).toBe("0:30");
+        expect(formatVideoDuration(90_000)).toBe("1:30");
     });
 });

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -7943,6 +7943,12 @@ components:
                     description: Category name
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds (video type only)
+                    format: int64
+                    examples:
+                        - 15000
                 id:
                     type: string
                     description: Unique identifier for the congratulation
@@ -7983,6 +7989,11 @@ components:
                     description: Task name
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (video type only)
+                    examples:
+                        - https://example.com/thumb.jpg
                 timestamp:
                     type: string
                     description: Creation timestamp
@@ -7991,7 +8002,7 @@ components:
                         - "2023-01-01T00:00:00Z"
                 type:
                     type: string
-                    description: Type of congratulation (message or image)
+                    description: Type of congratulation (message, image, or video)
                     examples:
                         - message
             required:
@@ -8240,6 +8251,12 @@ components:
                     description: Category name
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds (video type only)
+                    format: int64
+                    examples:
+                        - 15000
                 id:
                     type: string
                     description: Unique identifier for the congratulation
@@ -8283,6 +8300,11 @@ components:
                     description: Task name
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (video type only)
+                    examples:
+                        - https://example.com/thumb.jpg
                 timestamp:
                     type: string
                     description: Creation timestamp
@@ -8291,7 +8313,7 @@ components:
                         - "2023-01-01T00:00:00Z"
                 type:
                     type: string
-                    description: Type of congratulation (message or image)
+                    description: Type of congratulation (message, image, or video)
                     examples:
                         - message
             required:
@@ -8320,6 +8342,12 @@ components:
                     description: Category name
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds, max 30000 (required for video type)
+                    format: int64
+                    examples:
+                        - 15000
                 message:
                     type: string
                     description: Congratulation message
@@ -8343,9 +8371,14 @@ components:
                     description: Task name
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (required for video type)
+                    examples:
+                        - https://example.com/thumb.jpg
                 type:
                     type: string
-                    description: Type of congratulation (message or image)
+                    description: Type of congratulation (message, image, or video)
                     examples:
                         - message
             required:
@@ -8388,6 +8421,12 @@ components:
                     description: Category name
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds (video type only)
+                    format: int64
+                    examples:
+                        - 15000
                 id:
                     type: string
                     description: Unique identifier for the encouragement
@@ -8441,6 +8480,11 @@ components:
                     description: Task name
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (video type only)
+                    examples:
+                        - https://example.com/thumb.jpg
                 timestamp:
                     type: string
                     description: Creation timestamp
@@ -8477,6 +8521,12 @@ components:
                     description: Category name (required for task scope)
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds, max 30000 (required for video type)
+                    format: int64
+                    examples:
+                        - 15000
                 message:
                     type: string
                     description: Encouragement message
@@ -8502,9 +8552,14 @@ components:
                     description: Task name (required for task scope)
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (required for video type)
+                    examples:
+                        - https://example.com/thumb.jpg
                 type:
                     type: string
-                    description: Type of encouragement (message or image)
+                    description: Type of encouragement (message, image, or video)
                     examples:
                         - message
             required:
@@ -9346,6 +9401,12 @@ components:
                     description: Category name
                     examples:
                         - Work
+                durationMs:
+                    type: integer
+                    description: Video duration in milliseconds (video type only)
+                    format: int64
+                    examples:
+                        - 15000
                 id:
                     type: string
                     description: Unique identifier for the encouragement
@@ -9396,6 +9457,11 @@ components:
                     description: Task name
                     examples:
                         - Complete project proposal
+                thumbnailUrl:
+                    type: string
+                    description: Video thumbnail URL (video type only)
+                    examples:
+                        - https://example.com/thumb.jpg
                 timestamp:
                     type: string
                     description: Creation timestamp
@@ -11181,12 +11247,17 @@ components:
             properties:
                 congratulationId:
                     type: string
+                durationMs:
+                    type: integer
+                    format: int64
                 message:
                     type: string
                 private:
                     type: boolean
                 sender:
                     $ref: '#/components/schemas/KudosSender'
+                thumbnailUrl:
+                    type: string
                 timestamp:
                     type: string
                     format: date-time
@@ -12707,12 +12778,17 @@ components:
             type: object
             additionalProperties: false
             properties:
+                durationMs:
+                    type: integer
+                    format: int64
                 encouragementId:
                     type: string
                 message:
                     type: string
                 sender:
                     $ref: '#/components/schemas/KudosSender'
+                thumbnailUrl:
+                    type: string
                 timestamp:
                     type: string
                     format: date-time

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -3989,6 +3989,12 @@ export interface components {
              */
             categoryName: string;
             /**
+             * Format: int64
+             * @description Video duration in milliseconds (video type only)
+             * @example 15000
+             */
+            durationMs?: number;
+            /**
              * @description Unique identifier for the congratulation
              * @example 507f1f77bcf86cd799439011
              */
@@ -4028,13 +4034,18 @@ export interface components {
              */
             taskName: string;
             /**
+             * @description Video thumbnail URL (video type only)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
+            /**
              * Format: date-time
              * @description Creation timestamp
              * @example 2023-01-01T00:00:00Z
              */
             timestamp: string;
             /**
-             * @description Type of congratulation (message or image)
+             * @description Type of congratulation (message, image, or video)
              * @example message
              */
             type: string;
@@ -4212,6 +4223,12 @@ export interface components {
              */
             categoryName: string;
             /**
+             * Format: int64
+             * @description Video duration in milliseconds (video type only)
+             * @example 15000
+             */
+            durationMs?: number;
+            /**
              * @description Unique identifier for the congratulation
              * @example 507f1f77bcf86cd799439011
              */
@@ -4253,13 +4270,18 @@ export interface components {
              */
             taskName: string;
             /**
+             * @description Video thumbnail URL (video type only)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
+            /**
              * Format: date-time
              * @description Creation timestamp
              * @example 2023-01-01T00:00:00Z
              */
             timestamp: string;
             /**
-             * @description Type of congratulation (message or image)
+             * @description Type of congratulation (message, image, or video)
              * @example message
              */
             type: string;
@@ -4276,6 +4298,12 @@ export interface components {
              * @example Work
              */
             categoryName: string;
+            /**
+             * Format: int64
+             * @description Video duration in milliseconds, max 30000 (required for video type)
+             * @example 15000
+             */
+            durationMs?: number;
             /**
              * @description Congratulation message
              * @example Congratulations on completing your task!
@@ -4299,7 +4327,12 @@ export interface components {
              */
             taskName: string;
             /**
-             * @description Type of congratulation (message or image)
+             * @description Video thumbnail URL (required for video type)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
+            /**
+             * @description Type of congratulation (message, image, or video)
              * @example message
              */
             type: string;
@@ -4329,6 +4362,12 @@ export interface components {
              * @example Work
              */
             categoryName?: string;
+            /**
+             * Format: int64
+             * @description Video duration in milliseconds (video type only)
+             * @example 15000
+             */
+            durationMs?: number;
             /**
              * @description Unique identifier for the encouragement
              * @example 507f1f77bcf86cd799439011
@@ -4381,6 +4420,11 @@ export interface components {
              */
             taskName?: string;
             /**
+             * @description Video thumbnail URL (video type only)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
+            /**
              * Format: date-time
              * @description Creation timestamp
              * @example 2023-01-01T00:00:00Z
@@ -4404,6 +4448,12 @@ export interface components {
              * @example Work
              */
             categoryName?: string;
+            /**
+             * Format: int64
+             * @description Video duration in milliseconds, max 30000 (required for video type)
+             * @example 15000
+             */
+            durationMs?: number;
             /**
              * @description Encouragement message
              * @example Great job on completing your task!
@@ -4430,7 +4480,12 @@ export interface components {
              */
             taskName?: string;
             /**
-             * @description Type of encouragement (message or image)
+             * @description Video thumbnail URL (required for video type)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
+            /**
+             * @description Type of encouragement (message, image, or video)
              * @example message
              */
             type: string;
@@ -4888,6 +4943,12 @@ export interface components {
              */
             categoryName?: string;
             /**
+             * Format: int64
+             * @description Video duration in milliseconds (video type only)
+             * @example 15000
+             */
+            durationMs?: number;
+            /**
              * @description Unique identifier for the encouragement
              * @example 507f1f77bcf86cd799439011
              */
@@ -4936,6 +4997,11 @@ export interface components {
              * @example Complete project proposal
              */
             taskName?: string;
+            /**
+             * @description Video thumbnail URL (video type only)
+             * @example https://example.com/thumb.jpg
+             */
+            thumbnailUrl?: string;
             /**
              * Format: date-time
              * @description Creation timestamp
@@ -5917,9 +5983,12 @@ export interface components {
         };
         PostKudos: {
             congratulationId: string;
+            /** Format: int64 */
+            durationMs?: number;
             message: string;
             private?: boolean;
             sender: components["schemas"]["KudosSender"];
+            thumbnailUrl?: string;
             /** Format: date-time */
             timestamp: string;
             type: string;
@@ -6715,9 +6784,12 @@ export interface components {
             workingOnSince?: string;
         };
         TaskKudos: {
+            /** Format: int64 */
+            durationMs?: number;
             encouragementId: string;
             message: string;
             sender: components["schemas"]["KudosSender"];
+            thumbnailUrl?: string;
             /** Format: date-time */
             timestamp: string;
             type: string;

--- a/frontend/api/media.ts
+++ b/frontend/api/media.ts
@@ -24,6 +24,14 @@ export function assetsToPickedMedia(
     }));
 }
 
+/** "m:ss" label for video duration pills (15000 -> "0:15"). */
+export function formatVideoDuration(durationMs: number): string {
+    const totalSec = Math.round(durationMs / 1000);
+    const m = Math.floor(totalSec / 60);
+    const s = totalSec % 60;
+    return `${m}:${String(s).padStart(2, "0")}`;
+}
+
 export type VideoThumb = { uri: string; width: number; height: number };
 
 /**

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -75,7 +75,9 @@ export interface TaskKudos {
     sender: KudosSender;
     message: string;
     timestamp: string;
-    type: string; // "message" | "image"
+    type: string; // "message" | "image" | "video"
+    thumbnailUrl?: string; // video kudos: poster frame URL
+    durationMs?: number;  // video kudos: clip length
 }
 
 export interface PostKudos {

--- a/frontend/api/types.ts
+++ b/frontend/api/types.ts
@@ -83,7 +83,9 @@ export interface PostKudos {
     sender: KudosSender;
     message: string;
     timestamp: string;
-    type?: string; // "message" | "image" (image => message holds the URL/GIF)
+    type?: string; // "message" | "image" | "video"
+    thumbnailUrl?: string; // video kudos: poster frame URL
+    durationMs?: number;  // video kudos: clip length
     // Private congrats are anonymized for non-owners: backend strips sender +
     // message, leaving private=true. Owner still receives the real sender.
     private?: boolean;

--- a/frontend/api/upload.ts
+++ b/frontend/api/upload.ts
@@ -389,6 +389,18 @@ export async function uploadBlueprintBanner(blueprintId: string, imageUri: strin
 export const VIDEO_MAX_BYTES = 100 * 1024 * 1024; // 100MB
 export const VIDEO_MAX_DURATION_MS = 60_000; // 60s
 
+// Kudos videos are quick cheers — half the post limits.
+// Must stay in sync with KudosVideoMaxDurationMs in backend/internal/handlers/types/types.go.
+export const KUDOS_VIDEO_MAX_BYTES = 50 * 1024 * 1024; // 50MB
+export const KUDOS_VIDEO_MAX_DURATION_MS = 30_000; // 30s
+
+export type UploadVideoOptions = {
+    /** Byte cap applied to the file actually uploaded. Defaults to the post limit. */
+    maxBytes?: number;
+    /** Known clip length, threaded onto the returned MediaItem. */
+    durationMs?: number;
+};
+
 /**
  * Compress a video on-device (~720p H.264), generate a thumbnail, and upload both.
  * Returns a MediaItem for inclusion in a post's media[].
@@ -396,7 +408,8 @@ export const VIDEO_MAX_DURATION_MS = 60_000; // 60s
 export async function uploadVideo(
     resourceType: string,
     resourceId: string,
-    videoUri: string
+    videoUri: string,
+    options: UploadVideoOptions = {}
 ): Promise<MediaItem> {
     // Lazy-load native modules so merely importing this file never crashes the
     // app in a build that hasn't been prebuilt with these native deps.
@@ -424,8 +437,9 @@ export async function uploadVideo(
     );
 
     // 3. Enforce size cap on the file we'll actually upload.
+    const maxBytes = options.maxBytes ?? VIDEO_MAX_BYTES;
     const blob = await fetch(uploadUri).then((r) => r.blob());
-    if (blob.size > VIDEO_MAX_BYTES) {
+    if (blob.size > maxBytes) {
         throw new Error("Video is too large after compression. Please pick a shorter clip.");
     }
 
@@ -449,5 +463,6 @@ export async function uploadVideo(
         width: thumb.width || thumbResult.width || 0,
         height: thumb.height || thumbResult.height || 0,
         bytes: blob.size,
+        durationMs: options.durationMs,
     };
 }

--- a/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(task)/task/[id].tsx
@@ -740,6 +740,8 @@ export default function Task() {
                                                 icon={k.sender.icon}
                                                 time={new Date(k.timestamp).getTime()}
                                                 referenceId={task?.id ?? ""}
+                                                thumbnail={k.thumbnailUrl ?? undefined}
+                                                durationMs={k.durationMs ?? undefined}
                                                 type="encouragement"
                                             />
                                         ))}

--- a/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { StyleSheet, TouchableOpacity } from "react-native";
-import { router } from "expo-router";
+import { router, type Href } from "expo-router";
 import { ThemedText } from "../ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import KudosItem from "@/components/cards/KudosItem";
@@ -51,7 +51,7 @@ const UserInfoEncouragementNotification = ({
     const isProfileScope = !referenceId && !taskName;
 
     const handlePress = () => {
-        router.push(`/account/${userId}` as never);
+        router.push(`/account/${userId}` as Href);
     };
 
     const kudos = {

--- a/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
+++ b/frontend/components/UserInfo/UserInfoEncouragementNotification.tsx
@@ -5,6 +5,7 @@ import { ThemedText } from "../ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import KudosItem from "@/components/cards/KudosItem";
 import { getNotificationTimeLabel } from "./notificationTime";
+import { mediaTypeFromUri } from "@/api/media";
 
 type Props = {
     name: string;
@@ -17,6 +18,10 @@ type Props = {
     // for profile-scope kudos (e.g. ring encouragements) where there's no
     // task to deep-link to.
     referenceId: string;
+    /** Kudos video thumbnail (notification.thumbnail / TaskKudos.thumbnailUrl). */
+    thumbnail?: string;
+    /** Video length when the source carries it (TaskKudos.durationMs). */
+    durationMs?: number;
     type?: "encouragement" | "congratulation";
 };
 
@@ -28,13 +33,18 @@ const UserInfoEncouragementNotification = ({
     icon,
     time,
     referenceId,
+    thumbnail,
+    durationMs,
     type = "encouragement",
 }: Props) => {
     const ThemedColor = useThemeColor();
     const isCongrats = type === "congratulation";
-    // Notification content carries no kudos type, so an image/GIF kudos arrives
-    // as its URL in `message`. Detect it so KudosItem renders the image, not the URL.
-    const isImage = !!message && /^https?:\/\//i.test(message.trim());
+    // Notification content carries no kudos type, so a media kudos arrives as
+    // its URL in `message`. Classify by extension so KudosItem renders the
+    // image/video, not the URL. Video needs a thumbnail to render as video.
+    const isMediaUrl = !!message && /^https?:\/\//i.test(message.trim());
+    const isVideo = isMediaUrl && !!thumbnail && mediaTypeFromUri(message!.trim()) === "video";
+    const isImage = isMediaUrl && !isVideo;
     // Profile-scope (ring) encouragements arrive with no taskName and no
     // referenceId — KudosItem renders a "Profile Encouragement" header
     // instead of an empty category/task row when we pass scope: "profile".
@@ -53,7 +63,9 @@ const UserInfoEncouragementNotification = ({
         taskName: isProfileScope ? "" : taskName,
         timestamp: new Date(time).toISOString(),
         read: true,
-        type: isImage ? "image" : "message",
+        type: isVideo ? "video" : isImage ? "image" : "message",
+        thumbnailUrl: isVideo ? thumbnail : undefined,
+        durationMs: isVideo ? durationMs : undefined,
     };
 
     return (

--- a/frontend/components/cards/KudosItem.tsx
+++ b/frontend/components/cards/KudosItem.tsx
@@ -31,6 +31,8 @@ interface KudosData {
     timestamp: string;
     read: boolean;
     type?: string;
+    thumbnailUrl?: string | null;
+    durationMs?: number | null;
     reaction?: string | null;
     reactedAt?: string;
 }
@@ -62,6 +64,7 @@ export default function KudosItem({
     const animatedStyle = useAnimatedStyle(() => ({ transform: [{ scale: scale.value }] }));
 
     const isImage = kudos.type === "image";
+    const isVideo = kudos.type === "video" && !!kudos.thumbnailUrl;
     const isProfileLevel = kudos.scope === "profile";
     const hasReaction = Boolean(kudos.reaction);
 
@@ -132,8 +135,11 @@ export default function KudosItem({
         <SpeechBubbleCard
             sender={kudos.sender}
             header={header}
-            message={isImage ? undefined : kudos.message}
+            message={isImage || isVideo ? undefined : kudos.message}
             imageUri={isImage ? kudos.message : undefined}
+            videoUri={isVideo ? kudos.message : undefined}
+            videoThumbnailUri={isVideo ? kudos.thumbnailUrl ?? undefined : undefined}
+            videoDurationMs={isVideo ? kudos.durationMs ?? undefined : undefined}
             timeLabel={formatTime(kudos.timestamp)}
             read={kudos.read}
             footerSlot={footerSlot ?? reactionButton}

--- a/frontend/components/cards/SpeechBubbleCard.tsx
+++ b/frontend/components/cards/SpeechBubbleCard.tsx
@@ -1,8 +1,11 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { View, StyleSheet, Dimensions, Image, TouchableOpacity, Animated } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import CachedImage from "@/components/CachedImage";
+import { Play } from "phosphor-react-native";
+import KudosVideoPlayerModal from "@/components/modals/KudosVideoPlayerModal";
+import { formatVideoDuration } from "@/api/media";
 
 export interface SpeechBubbleSender {
     name: string;
@@ -18,6 +21,12 @@ export interface SpeechBubbleCardProps {
     message?: string;
     /** Full-width inline image (image kudos). */
     imageUri?: string;
+    /** Video kudos: tappable thumbnail that opens fullscreen playback. */
+    videoUri?: string;
+    /** Poster shown for videoUri (full-width, like imageUri). */
+    videoThumbnailUri?: string;
+    /** Clip length for the duration pill. */
+    videoDurationMs?: number;
     /** Small rounded image in the bubble's top-right (e.g. comment post thumbnail). */
     thumbnailUri?: string;
     /** Pre-formatted time string — this component does not format time. */
@@ -39,6 +48,9 @@ export default function SpeechBubbleCard({
     header,
     message,
     imageUri,
+    videoUri,
+    videoThumbnailUri,
+    videoDurationMs,
     thumbnailUri,
     timeLabel,
     read = true,
@@ -50,6 +62,7 @@ export default function SpeechBubbleCard({
 }: SpeechBubbleCardProps) {
     const ThemedColor = useThemeColor();
     const styles = createStyles(ThemedColor);
+    const [playerOpen, setPlayerOpen] = useState(false);
 
     const bubbleTranslateX = useRef(new Animated.Value(-28)).current;
     const bubbleOpacity = useRef(new Animated.Value(0)).current;
@@ -123,7 +136,24 @@ export default function SpeechBubbleCard({
                     <View style={styles.bubbleBody}>
                         <View style={styles.contentRow}>
                             <View style={styles.contentMain}>
-                                {imageUri ? (
+                                {videoUri && videoThumbnailUri ? (
+                                    <TouchableOpacity
+                                        testID="bubble-video"
+                                        onPress={() => setPlayerOpen(true)}
+                                        activeOpacity={0.85}>
+                                        <Image source={{ uri: videoThumbnailUri }} style={styles.image} />
+                                        <View style={styles.playOverlay}>
+                                            <Play size={32} color="#fff" weight="fill" />
+                                        </View>
+                                        {videoDurationMs ? (
+                                            <View style={styles.durationPill}>
+                                                <ThemedText type="caption" style={styles.durationText}>
+                                                    {formatVideoDuration(videoDurationMs)}
+                                                </ThemedText>
+                                            </View>
+                                        ) : null}
+                                    </TouchableOpacity>
+                                ) : imageUri ? (
                                     <Image testID="bubble-image" source={{ uri: imageUri }} style={styles.image} />
                                 ) : message ? (
                                     <ThemedText type="lightBody" style={styles.messageText}>
@@ -150,6 +180,9 @@ export default function SpeechBubbleCard({
                     </View>
                 </View>
             </CardContainer>
+            {playerOpen && videoUri ? (
+                <KudosVideoPlayerModal uri={videoUri} onClose={() => setPlayerOpen(false)} />
+            ) : null}
         </Animated.View>
     );
 }
@@ -210,4 +243,19 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
             zIndex: 1,
         },
         footerRow: { flexDirection: "row", justifyContent: "space-between", alignItems: "center", marginTop: 10, gap: 8 },
+        playOverlay: {
+            ...StyleSheet.absoluteFillObject,
+            alignItems: "center",
+            justifyContent: "center",
+        },
+        durationPill: {
+            position: "absolute",
+            bottom: 16,
+            right: 8,
+            backgroundColor: "rgba(0,0,0,0.6)",
+            borderRadius: 10,
+            paddingHorizontal: 8,
+            paddingVertical: 2,
+        },
+        durationText: { color: "#fff", fontSize: 12 },
     });

--- a/frontend/components/modals/CongratulateModal.tsx
+++ b/frontend/components/modals/CongratulateModal.tsx
@@ -10,10 +10,13 @@ import Octicons from "@expo/vector-icons/Octicons";
 import { createCongratulationAPI } from "@/api/congratulation";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserKudos } from "@/hooks/useUserKudos";
-import { useMediaLibrary } from "@/hooks/useMediaLibrary";
-import { uploadImageSmart } from "@/api/upload";
-import { Images, Gif, Sparkle } from "phosphor-react-native";
+import { useMediaLibrary, IMAGE_AND_VIDEO_TYPES } from "@/hooks/useMediaLibrary";
+import { uploadImageSmart, uploadVideo, KUDOS_VIDEO_MAX_BYTES, KUDOS_VIDEO_MAX_DURATION_MS } from "@/api/upload";
+import { Images, Gif, Sparkle, VideoCamera } from "phosphor-react-native";
 import GifPicker from "./GifPicker";
+import KudosVideoRecorder from "./KudosVideoRecorder";
+import KudosVideoPreview from "./KudosVideoPreview";
+import { formatVideoDuration } from "@/api/media";
 import { LinearGradient } from "expo-linear-gradient";
 import { Portal } from "@gorhom/portal";
 import ConfettiCannon from "react-native-confetti-cannon";
@@ -22,6 +25,8 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRingUpdate } from "@/contexts/ringUpdateContext";
+
+type SelectedKudosMedia = { uri: string; type: "image" | "video"; durationMs?: number };
 
 interface CongratulateModalProps {
     visible: boolean;
@@ -47,7 +52,8 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
     const { updateUser } = useAuth();
     const { showRingUpdate } = useRingUpdate();
     const [congratulationMessage, setCongratulationMessage] = useState("");
-    const [selectedImage, setSelectedImage] = useState<string | null>(null);
+    const [selectedMedia, setSelectedMedia] = useState<SelectedKudosMedia | null>(null);
+    const [showRecorder, setShowRecorder] = useState(false);
     const [isUploading, setIsUploading] = useState(false);
     const [showGifPicker, setShowGifPicker] = useState(false);
     const [showConfetti, setShowConfetti] = useState(false);
@@ -112,7 +118,8 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
         } else {
             // Reset state when modal closes
             setCongratulationMessage("");
-            setSelectedImage(null);
+            setSelectedMedia(null);
+            setShowRecorder(false);
             setIsUploading(false);
             setShowGifPicker(false);
             setIsPrivate(false);
@@ -126,30 +133,52 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
     const { congratulationsLeft, currentKudosRewards } = useUserKudos();
     const { capture } = useAnalytics();
 
-    const handleImagePick = async () => {
+    const handleMediaPick = async () => {
         try {
             const result = await pickImage({
+                mediaTypes: IMAGE_AND_VIDEO_TYPES,
                 allowsEditing: true,
                 quality: 0.7,
+                videoMaxDuration: KUDOS_VIDEO_MAX_DURATION_MS / 1000,
             });
 
             if (result && !result.canceled && result.assets && result.assets[0]) {
-                const imageUri = result.assets[0].uri;
-                setSelectedImage(imageUri);
-                // Clear message when image is selected
+                const asset = result.assets[0];
+                if (asset.type === "video") {
+                    // iOS trims via allowsEditing; Android ignores videoMaxDuration
+                    // for library picks, so enforce the cap here. duration is ms.
+                    if (!asset.duration) {
+                        setAlertTitle("Error");
+                        setAlertMessage("Couldn't read the video's length. Please try a different video.");
+                        setAlertButtons([{ text: "OK", style: "default" }]);
+                        setAlertVisible(true);
+                        return;
+                    }
+                    if (asset.duration > KUDOS_VIDEO_MAX_DURATION_MS) {
+                        setAlertTitle("Video too long");
+                        setAlertMessage("Videos can be up to 30 seconds.");
+                        setAlertButtons([{ text: "OK", style: "default" }]);
+                        setAlertVisible(true);
+                        return;
+                    }
+                    setSelectedMedia({ uri: asset.uri, type: "video", durationMs: asset.duration });
+                } else {
+                    setSelectedMedia({ uri: asset.uri, type: "image" });
+                }
+                // Clear message when media is selected
                 setCongratulationMessage("");
             }
         } catch (error) {
-            console.error("Error picking image:", error);
+            console.error("Error picking media:", error);
             setAlertTitle("Error");
-            setAlertMessage("Failed to select image. Please try again.");
+            setAlertMessage("Failed to select media. Please try again.");
             setAlertButtons([{ text: "OK", style: "default" }]);
             setAlertVisible(true);
         }
     };
 
     const handleGifSelect = (gifUrl: string) => {
-        setSelectedImage(gifUrl);
+        setSelectedMedia({ uri: gifUrl, type: "image" });
         setCongratulationMessage("");
         setShowGifPicker(false);
     };
@@ -171,8 +200,8 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
             return;
         }
 
-        // Check if either message or image is provided
-        if (!congratulationMessage.trim() && !selectedImage) {
+        // Check if either message or media is provided
+        if (!congratulationMessage.trim() && !selectedMedia) {
             setAlertTitle("Error");
             setAlertMessage("Please enter a message or select an image");
             setAlertButtons([{ text: "OK", style: "default" }]);
@@ -185,31 +214,43 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
 
             let contentToSend = congratulationMessage.trim();
             let congratulationType = "message";
+            let thumbnailUrl: string | undefined;
+            let durationMs: number | undefined;
 
-            // If image is selected, upload it first (unless it's a GIF URL)
-            if (selectedImage) {
+            if (selectedMedia) {
                 try {
-                    // Check if it's a URL (GIF from Tenor) or a local file (uploaded image)
-                    if (selectedImage.startsWith('http://') || selectedImage.startsWith('https://')) {
-                        // It's a GIF URL, use it directly
-                        contentToSend = selectedImage;
+                    if (selectedMedia.type === "video") {
+                        const tempId = `congratulation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+                        const media = await uploadVideo("congratulation", tempId, selectedMedia.uri, {
+                            maxBytes: KUDOS_VIDEO_MAX_BYTES,
+                            durationMs: selectedMedia.durationMs,
+                        });
+                        contentToSend = media.url;
+                        thumbnailUrl = media.thumbnailUrl ?? undefined;
+                        durationMs = media.durationMs ?? selectedMedia.durationMs;
+                        congratulationType = "video";
+                    } else if (selectedMedia.uri.startsWith("http://") || selectedMedia.uri.startsWith("https://")) {
+                        // GIF URL from Tenor — use it directly
+                        contentToSend = selectedMedia.uri;
                         congratulationType = "image";
                     } else {
-                        // It's a local image, upload it
+                        // Local image — upload it
                         const tempId = `congratulation-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-
-                        const imageUrl = await uploadImageSmart("congratulation", tempId, selectedImage, {
+                        const imageUrl = await uploadImageSmart("congratulation", tempId, selectedMedia.uri, {
                             variant: "large",
                         });
-
-                        contentToSend = typeof imageUrl === 'string' ? imageUrl : imageUrl.public_url;
+                        contentToSend = typeof imageUrl === "string" ? imageUrl : imageUrl.public_url;
                         congratulationType = "image";
                     }
                 } catch (uploadError) {
-                    console.error("Error uploading image:", uploadError);
+                    console.error("Error uploading media:", uploadError);
                     setIsUploading(false);
                     setAlertTitle("Error");
-                    setAlertMessage("Failed to upload image. Please try again.");
+                    setAlertMessage(
+                        uploadError instanceof Error && uploadError.message.includes("too large")
+                            ? uploadError.message
+                            : "Failed to upload media. Please try again."
+                    );
                     setAlertButtons([{ text: "OK", style: "default" }]);
                     setAlertVisible(true);
                     return;
@@ -223,6 +264,8 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                 categoryName: congratulationConfig.categoryName,
                 taskName: task.content,
                 type: congratulationType,
+                ...(thumbnailUrl && { thumbnailUrl }),
+                ...(durationMs && { durationMs }),
                 private: isPrivate,
                 ...(congratulationConfig.postId && { postId: congratulationConfig.postId }), // Include postId if available
             };
@@ -234,7 +277,9 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
             if (!isMountedRef.current) return;
 
             capture(AnalyticsEvents.CONGRATULATION_SENT, {
-                has_image: !!selectedImage,
+                has_message: !!congratulationMessage?.trim(),
+                has_image: selectedMedia?.type === "image",
+                has_video: selectedMedia?.type === "video",
             });
 
             setIsUploading(false);
@@ -344,7 +389,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                 </View>
             )}
 
-            <DefaultModal visible={visible} setVisible={setVisible} snapPoints={selectedImage ? ["85%"] : ["55%"]}>
+            <DefaultModal visible={visible} setVisible={setVisible} snapPoints={selectedMedia ? ["85%"] : ["55%"]}>
                 <View style={styles.container}>
                 {/* Task Card */}
                 <View style={styles.taskCardContainer}>
@@ -373,8 +418,8 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                     A little goes a long way
                 </ThemedText>
 
-                {/* Text Input or Image Preview */}
-                {!selectedImage ? (
+                {/* Text Input or Media Preview */}
+                {!selectedMedia ? (
                     <View style={styles.inputContainer}>
                         <BottomSheetTextInput
                             placeholder={`Write a message...`}
@@ -388,7 +433,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                         <View style={styles.mediaIconsRow}>
                             <TouchableOpacity
                                 style={styles.iconButton}
-                                onPress={handleImagePick}
+                                onPress={handleMediaPick}
                                 disabled={isUploading}
                             >
                                 <Images size={20} color={ThemedColor.caption} weight="regular" />
@@ -400,20 +445,46 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                             >
                                 <Gif size={20} color={ThemedColor.caption} weight="regular" />
                             </TouchableOpacity>
+                            <TouchableOpacity
+                                style={styles.iconButton}
+                                onPress={() => setShowRecorder(true)}
+                                disabled={isUploading}
+                            >
+                                <VideoCamera size={20} color={ThemedColor.caption} weight="regular" />
+                            </TouchableOpacity>
                         </View>
+                    </View>
+                ) : selectedMedia.type === "video" ? (
+                    <View style={styles.imagePreviewContainer}>
+                        <View style={styles.videoPreview}>
+                            <KudosVideoPreview uri={selectedMedia.uri} />
+                        </View>
+                        {selectedMedia.durationMs ? (
+                            <View style={styles.durationPill}>
+                                <ThemedText type="caption" style={{ color: "#fff", fontSize: 12 }}>
+                                    {formatVideoDuration(selectedMedia.durationMs)}
+                                </ThemedText>
+                            </View>
+                        ) : null}
+                        <TouchableOpacity
+                            style={styles.removeImageButton}
+                            onPress={() => setSelectedMedia(null)}
+                        >
+                            <Octicons name="x" size={20} color={ThemedColor.text} />
+                        </TouchableOpacity>
                     </View>
                 ) : (
                     <TouchableOpacity
                         style={styles.imagePreviewContainer}
-                        onPress={handleImagePick}
+                        onPress={handleMediaPick}
                         activeOpacity={0.9}
                     >
-                        <Image source={{ uri: selectedImage }} style={styles.imagePreview} resizeMode="contain" />
+                        <Image source={{ uri: selectedMedia.uri }} style={styles.imagePreview} resizeMode="contain" />
                         <TouchableOpacity
                             style={styles.removeImageButton}
                             onPress={(e) => {
                                 e.stopPropagation();
-                                setSelectedImage(null);
+                                setSelectedMedia(null);
                             }}
                         >
                             <Octicons name="x" size={20} color={ThemedColor.text} />
@@ -443,7 +514,7 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                     <PrimaryButton
                         title={isUploading ? "Uploading..." : "Send Congratulation"}
                         onPress={handleSendCongratulation}
-                        disabled={(!congratulationMessage.trim() && !selectedImage) || congratulationsLeft === 0 || isUploading}
+                        disabled={(!congratulationMessage.trim() && !selectedMedia) || congratulationsLeft === 0 || isUploading}
                         style={styles.sendButton}
                     />
                     <ThemedText type="caption" style={styles.counterStyled}>
@@ -470,6 +541,16 @@ export default function CongratulateModal({ visible, setVisible, task, congratul
                     <GifPicker onGifSelect={handleGifSelect} />
                 </View>
             </Modal>
+
+            <KudosVideoRecorder
+                visible={showRecorder}
+                onClose={() => setShowRecorder(false)}
+                onRecorded={({ uri, durationMs: recordedMs }) => {
+                    setSelectedMedia({ uri, type: "video", durationMs: recordedMs });
+                    setCongratulationMessage("");
+                    setShowRecorder(false);
+                }}
+            />
 
             <CustomAlert
                 visible={alertVisible}
@@ -610,6 +691,22 @@ const styleSheet = (ThemedColor: ReturnType<typeof useThemeColor>) =>
             height: 32,
             alignItems: "center",
             justifyContent: "center",
+        },
+        videoPreview: {
+            width: "100%",
+            height: Dimensions.get("window").height * 0.3,
+            borderRadius: 12,
+            overflow: "hidden",
+            backgroundColor: "#000",
+        },
+        durationPill: {
+            position: "absolute",
+            bottom: 8,
+            left: 8,
+            backgroundColor: "rgba(0,0,0,0.6)",
+            borderRadius: 10,
+            paddingHorizontal: 8,
+            paddingVertical: 2,
         },
         gifPickerContainer: {
             flex: 1,

--- a/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
+++ b/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
@@ -1,8 +1,9 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { BottomSheetFlatList } from "@gorhom/bottom-sheet";
 import { router, type Href } from "expo-router";
-import { User } from "phosphor-react-native";
+import { Play, User } from "phosphor-react-native";
+import KudosVideoPlayerModal from "./KudosVideoPlayerModal";
 import { ThemedText } from "@/components/ThemedText";
 import DefaultModal from "./DefaultModal";
 import CachedImage from "@/components/CachedImage";
@@ -24,6 +25,7 @@ interface Props {
 export default function CongratulatorsBottomSheetModal({ visible, setVisible, kudos }: Props) {
     const ThemedColor = useThemeColor();
     const styles = createStyles(ThemedColor);
+    const [playingUri, setPlayingUri] = useState<string | null>(null);
 
     return (
         <DefaultModal visible={visible} setVisible={setVisible}>
@@ -63,7 +65,22 @@ export default function CongratulatorsBottomSheetModal({ visible, setVisible, ku
                                         {anon ? "Anonymous" : item.sender.name}
                                     </ThemedText>
                                     {!anon && item.message ? (
-                                        item.type === "image" ? (
+                                        item.type === "video" && item.thumbnailUrl ? (
+                                            <TouchableOpacity
+                                                onPress={() => setPlayingUri(item.message)}
+                                                activeOpacity={0.8}
+                                                style={styles.kudosVideoWrap}>
+                                                <CachedImage
+                                                    source={{ uri: item.thumbnailUrl }}
+                                                    contentFit="cover"
+                                                    cachePolicy="memory-disk"
+                                                    style={styles.kudosImage}
+                                                />
+                                                <View style={styles.playBadge}>
+                                                    <Play size={14} color="#fff" weight="fill" />
+                                                </View>
+                                            </TouchableOpacity>
+                                        ) : item.type === "image" ? (
                                             <CachedImage
                                                 source={{ uri: item.message }}
                                                 contentFit="cover"
@@ -82,6 +99,8 @@ export default function CongratulatorsBottomSheetModal({ visible, setVisible, ku
                     }}
                 />
             </View>
+            {/* RN Modal from inside a gorhom sheet — pending on-device verification. */}
+            {playingUri ? <KudosVideoPlayerModal uri={playingUri} onClose={() => setPlayingUri(null)} /> : null}
         </DefaultModal>
     );
 }
@@ -94,4 +113,14 @@ const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
         avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: ThemedColor.tertiary },
         anon: { alignItems: "center", justifyContent: "center" },
         kudosImage: { width: 120, height: 120, borderRadius: 10, marginTop: 4 },
+        kudosVideoWrap: { position: "relative", alignSelf: "flex-start" },
+        playBadge: {
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            alignItems: "center",
+            justifyContent: "center",
+        },
     });

--- a/frontend/components/modals/EncourageModal.tsx
+++ b/frontend/components/modals/EncourageModal.tsx
@@ -10,10 +10,13 @@ import Octicons from "@expo/vector-icons/Octicons";
 import { createEncouragementAPI } from "@/api/encouragement";
 import { useAuth } from "@/hooks/useAuth";
 import { useUserKudos } from "@/hooks/useUserKudos";
-import { useMediaLibrary } from "@/hooks/useMediaLibrary";
-import { uploadImageSmart } from "@/api/upload";
-import { Images, Gif, Sparkle } from "phosphor-react-native";
+import { useMediaLibrary, IMAGE_AND_VIDEO_TYPES } from "@/hooks/useMediaLibrary";
+import { uploadImageSmart, uploadVideo, KUDOS_VIDEO_MAX_BYTES, KUDOS_VIDEO_MAX_DURATION_MS } from "@/api/upload";
+import { Images, Gif, Sparkle, VideoCamera } from "phosphor-react-native";
 import GifPicker from "./GifPicker";
+import KudosVideoRecorder from "./KudosVideoRecorder";
+import KudosVideoPreview from "./KudosVideoPreview";
+import { formatVideoDuration } from "@/api/media";
 import { LinearGradient } from "expo-linear-gradient";
 import { Portal } from "@gorhom/portal";
 import ConfettiCannon from "react-native-confetti-cannon";
@@ -22,6 +25,8 @@ import { useAnalytics } from "@/hooks/useAnalytics";
 import { AnalyticsEvents } from "@/utils/analytics";
 import { useQueryClient } from "@tanstack/react-query";
 import { useRingUpdate } from "@/contexts/ringUpdateContext";
+
+type SelectedKudosMedia = { uri: string; type: "image" | "video"; durationMs?: number };
 
 interface EncourageModalProps {
     visible: boolean;
@@ -49,7 +54,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
     const queryClient = useQueryClient();
     const { showRingUpdate } = useRingUpdate();
     const [encouragementMessage, setEncouragementMessage] = useState("");
-    const [selectedImage, setSelectedImage] = useState<string | null>(null);
+    const [selectedMedia, setSelectedMedia] = useState<SelectedKudosMedia | null>(null);
+    const [showRecorder, setShowRecorder] = useState(false);
     const [isUploading, setIsUploading] = useState(false);
     const [showGifPicker, setShowGifPicker] = useState(false);
     const [showConfetti, setShowConfetti] = useState(false);
@@ -120,7 +126,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
         } else {
             // Reset state when modal closes
             setEncouragementMessage("");
-            setSelectedImage(null);
+            setSelectedMedia(null);
+            setShowRecorder(false);
             setIsUploading(false);
             setShowGifPicker(false);
             // Don't reset showConfetti immediately - let it finish animation
@@ -132,30 +139,52 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
 
     const { encouragementsLeft, currentKudosRewards } = useUserKudos();
 
-    const handleImagePick = async () => {
+    const handleMediaPick = async () => {
         try {
             const result = await pickImage({
+                mediaTypes: IMAGE_AND_VIDEO_TYPES,
                 allowsEditing: true,
                 quality: 0.7,
+                videoMaxDuration: KUDOS_VIDEO_MAX_DURATION_MS / 1000,
             });
 
             if (result && !result.canceled && result.assets && result.assets[0]) {
-                const imageUri = result.assets[0].uri;
-                setSelectedImage(imageUri);
-                // Clear message when image is selected
+                const asset = result.assets[0];
+                if (asset.type === "video") {
+                    // iOS trims via allowsEditing; Android ignores videoMaxDuration
+                    // for library picks, so enforce the cap here. duration is ms.
+                    if (!asset.duration) {
+                        setAlertTitle("Error");
+                        setAlertMessage("Couldn't read the video's length. Please try a different video.");
+                        setAlertButtons([{ text: "OK", style: "default" }]);
+                        setAlertVisible(true);
+                        return;
+                    }
+                    if (asset.duration > KUDOS_VIDEO_MAX_DURATION_MS) {
+                        setAlertTitle("Video too long");
+                        setAlertMessage("Videos can be up to 30 seconds.");
+                        setAlertButtons([{ text: "OK", style: "default" }]);
+                        setAlertVisible(true);
+                        return;
+                    }
+                    setSelectedMedia({ uri: asset.uri, type: "video", durationMs: asset.duration });
+                } else {
+                    setSelectedMedia({ uri: asset.uri, type: "image" });
+                }
+                // Clear message when media is selected
                 setEncouragementMessage("");
             }
         } catch (error) {
-            console.error("Error picking image:", error);
+            console.error("Error picking media:", error);
             setAlertTitle("Error");
-            setAlertMessage("Failed to select image. Please try again.");
+            setAlertMessage("Failed to select media. Please try again.");
             setAlertButtons([{ text: "OK", style: "default" }]);
             setAlertVisible(true);
         }
     };
 
     const handleGifSelect = (gifUrl: string) => {
-        setSelectedImage(gifUrl);
+        setSelectedMedia({ uri: gifUrl, type: "image" });
         setEncouragementMessage("");
         setShowGifPicker(false);
     };
@@ -188,8 +217,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
             return;
         }
 
-        // Check if either message or image is provided
-        if (!encouragementMessage.trim() && !selectedImage) {
+        // Check if either message or media is provided
+        if (!encouragementMessage.trim() && !selectedMedia) {
             setAlertTitle("Error");
             setAlertMessage("Please enter a message or select an image");
             setAlertButtons([{ text: "OK", style: "default" }]);
@@ -202,31 +231,43 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
 
             let contentToSend = encouragementMessage.trim();
             let encouragementType = "message";
+            let thumbnailUrl: string | undefined;
+            let durationMs: number | undefined;
 
-            // If image is selected, upload it first (unless it's a GIF URL)
-            if (selectedImage) {
+            if (selectedMedia) {
                 try {
-                    // Check if it's a URL (GIF from Tenor) or a local file (uploaded image)
-                    if (selectedImage.startsWith('http://') || selectedImage.startsWith('https://')) {
-                        // It's a GIF URL, use it directly
-                        contentToSend = selectedImage;
+                    if (selectedMedia.type === "video") {
+                        const tempId = `encouragement-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+                        const media = await uploadVideo("encouragement", tempId, selectedMedia.uri, {
+                            maxBytes: KUDOS_VIDEO_MAX_BYTES,
+                            durationMs: selectedMedia.durationMs,
+                        });
+                        contentToSend = media.url;
+                        thumbnailUrl = media.thumbnailUrl ?? undefined;
+                        durationMs = media.durationMs ?? selectedMedia.durationMs;
+                        encouragementType = "video";
+                    } else if (selectedMedia.uri.startsWith("http://") || selectedMedia.uri.startsWith("https://")) {
+                        // GIF URL from Tenor — use it directly
+                        contentToSend = selectedMedia.uri;
                         encouragementType = "image";
                     } else {
-                        // It's a local image, upload it
+                        // Local image — upload it
                         const tempId = `encouragement-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
-
-                        const imageUrl = await uploadImageSmart("encouragement", tempId, selectedImage, {
+                        const imageUrl = await uploadImageSmart("encouragement", tempId, selectedMedia.uri, {
                             variant: "large",
                         });
-
-                        contentToSend = typeof imageUrl === 'string' ? imageUrl : imageUrl.public_url;
+                        contentToSend = typeof imageUrl === "string" ? imageUrl : imageUrl.public_url;
                         encouragementType = "image";
                     }
                 } catch (uploadError) {
-                    console.error("Error uploading image:", uploadError);
+                    console.error("Error uploading media:", uploadError);
                     setIsUploading(false);
                     setAlertTitle("Error");
-                    setAlertMessage("Failed to upload image. Please try again.");
+                    setAlertMessage(
+                        uploadError instanceof Error && uploadError.message.includes("too large")
+                            ? uploadError.message
+                            : "Failed to upload media. Please try again."
+                    );
                     setAlertButtons([{ text: "OK", style: "default" }]);
                     setAlertVisible(true);
                     return;
@@ -240,6 +281,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     message: contentToSend,
                     scope: "profile" as const,
                     type: encouragementType,
+                    ...(thumbnailUrl && { thumbnailUrl }),
+                    ...(durationMs && { durationMs }),
                 }
                 : {
                     receiver: encouragementConfig.receiverId,
@@ -249,6 +292,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     taskName: task!.content,
                     taskId: task!.id,
                     type: encouragementType,
+                    ...(thumbnailUrl && { thumbnailUrl }),
+                    ...(durationMs && { durationMs }),
                 };
 
             // Make the API call
@@ -263,7 +308,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
 
             capture(AnalyticsEvents.ENCOURAGEMENT_SENT, {
                 has_message: !!encouragementMessage?.trim(),
-                has_image: !!selectedImage,
+                has_image: selectedMedia?.type === "image",
+                has_video: selectedMedia?.type === "video",
             });
 
             // Update user's encouragement count locally
@@ -370,7 +416,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                 </View>
             )}
 
-            <DefaultModal visible={visible} setVisible={setVisible} snapPoints={selectedImage ? ["85%"] : ["55%"]}>
+            <DefaultModal visible={visible} setVisible={setVisible} snapPoints={selectedMedia ? ["85%"] : ["55%"]}>
                 <View style={styles.container}>
                 {/* Task Card - Only show for task-level encouragements */}
                 {!isProfileLevel && (
@@ -401,8 +447,8 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     A little goes a long way
                 </ThemedText>
 
-                {/* Text Input or Image Preview */}
-                {!selectedImage ? (
+                {/* Text Input or Media Preview */}
+                {!selectedMedia ? (
                     <View style={styles.inputContainer}>
                         <BottomSheetTextInput
                             placeholder="Write a message..."
@@ -416,7 +462,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                         <View style={styles.mediaIconsRow}>
                             <TouchableOpacity
                                 style={styles.iconButton}
-                                onPress={handleImagePick}
+                                onPress={handleMediaPick}
                                 disabled={isUploading}
                             >
                                 <Images size={20} color={ThemedColor.caption} weight="regular" />
@@ -428,20 +474,46 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                             >
                                 <Gif size={20} color={ThemedColor.caption} weight="regular" />
                             </TouchableOpacity>
+                            <TouchableOpacity
+                                style={styles.iconButton}
+                                onPress={() => setShowRecorder(true)}
+                                disabled={isUploading}
+                            >
+                                <VideoCamera size={20} color={ThemedColor.caption} weight="regular" />
+                            </TouchableOpacity>
                         </View>
+                    </View>
+                ) : selectedMedia.type === "video" ? (
+                    <View style={styles.imagePreviewContainer}>
+                        <View style={styles.videoPreview}>
+                            <KudosVideoPreview uri={selectedMedia.uri} />
+                        </View>
+                        {selectedMedia.durationMs ? (
+                            <View style={styles.durationPill}>
+                                <ThemedText type="caption" style={{ color: "#fff", fontSize: 12 }}>
+                                    {formatVideoDuration(selectedMedia.durationMs)}
+                                </ThemedText>
+                            </View>
+                        ) : null}
+                        <TouchableOpacity
+                            style={styles.removeImageButton}
+                            onPress={() => setSelectedMedia(null)}
+                        >
+                            <Octicons name="x" size={20} color={ThemedColor.text} />
+                        </TouchableOpacity>
                     </View>
                 ) : (
                     <TouchableOpacity
                         style={styles.imagePreviewContainer}
-                        onPress={handleImagePick}
+                        onPress={handleMediaPick}
                         activeOpacity={0.9}
                     >
-                        <Image source={{ uri: selectedImage }} style={styles.imagePreview} resizeMode="contain" />
+                        <Image source={{ uri: selectedMedia.uri }} style={styles.imagePreview} resizeMode="contain" />
                         <TouchableOpacity
                             style={styles.removeImageButton}
                             onPress={(e) => {
                                 e.stopPropagation();
-                                setSelectedImage(null);
+                                setSelectedMedia(null);
                             }}
                         >
                             <Octicons name="x" size={20} color={ThemedColor.text} />
@@ -454,7 +526,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     <PrimaryButton
                         title={isUploading ? "Uploading..." : "Send Encouragement"}
                         onPress={handleSendEncouragement}
-                        disabled={(!encouragementMessage.trim() && !selectedImage) || encouragementsLeft === 0 || isUploading}
+                        disabled={(!encouragementMessage.trim() && !selectedMedia) || encouragementsLeft === 0 || isUploading}
                         style={styles.sendButton}
                     />
                     <ThemedText type="caption" style={styles.counterStyled}>
@@ -481,6 +553,16 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                     <GifPicker onGifSelect={handleGifSelect} />
                 </View>
             </Modal>
+
+            <KudosVideoRecorder
+                visible={showRecorder}
+                onClose={() => setShowRecorder(false)}
+                onRecorded={({ uri, durationMs: recordedMs }) => {
+                    setSelectedMedia({ uri, type: "video", durationMs: recordedMs });
+                    setEncouragementMessage("");
+                    setShowRecorder(false);
+                }}
+            />
 
             <CustomAlert
                 visible={alertVisible}
@@ -651,6 +733,22 @@ const styleSheet = (ThemedColor: ReturnType<typeof useThemeColor>) =>
             height: 32,
             alignItems: "center",
             justifyContent: "center",
+        },
+        videoPreview: {
+            width: "100%",
+            height: Dimensions.get("window").height * 0.3,
+            borderRadius: 12,
+            overflow: "hidden",
+            backgroundColor: "#000",
+        },
+        durationPill: {
+            position: "absolute",
+            bottom: 8,
+            left: 8,
+            backgroundColor: "rgba(0,0,0,0.6)",
+            borderRadius: 10,
+            paddingHorizontal: 8,
+            paddingVertical: 2,
         },
         gifPickerContainer: {
             flex: 1,

--- a/frontend/components/modals/EncourageModal.tsx
+++ b/frontend/components/modals/EncourageModal.tsx
@@ -8,6 +8,8 @@ import PrimaryButton from "@/components/inputs/PrimaryButton";
 import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import Octicons from "@expo/vector-icons/Octicons";
 import { createEncouragementAPI } from "@/api/encouragement";
+import type { components } from "@/api/generated/types";
+type CreateEncouragementParams = components["schemas"]["CreateEncouragementParams"];
 import { useAuth } from "@/hooks/useAuth";
 import { useUserKudos } from "@/hooks/useUserKudos";
 import { useMediaLibrary, IMAGE_AND_VIDEO_TYPES } from "@/hooks/useMediaLibrary";
@@ -275,7 +277,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
             }
 
             // Create the encouragement data based on scope
-            const encouragementData = isProfileLevel
+            const encouragementData: CreateEncouragementParams = isProfileLevel
                 ? {
                     receiver: encouragementConfig.receiverId,
                     message: contentToSend,
@@ -297,7 +299,7 @@ export default function EncourageModal({ visible, setVisible, task, encouragemen
                 };
 
             // Make the API call
-            const encouragementResult = await createEncouragementAPI(encouragementData as any);
+            const encouragementResult = await createEncouragementAPI(encouragementData);
 
             // Only update state if component is still mounted
             if (!isMountedRef.current) return;

--- a/frontend/components/modals/KudosVideoPlayerModal.tsx
+++ b/frontend/components/modals/KudosVideoPlayerModal.tsx
@@ -11,7 +11,8 @@ interface KudosVideoPlayerModalProps {
 
 /**
  * Fullscreen playback for a video kudos. Deliberate viewing (unlike feed
- * autoplay): sound on, native controls. Mount only while open.
+ * autoplay): sound on, native controls. Mount only while open, or the player
+ * is never released.
  */
 export default function KudosVideoPlayerModal({ uri, onClose }: KudosVideoPlayerModalProps) {
     const insets = useSafeAreaInsets();
@@ -21,7 +22,7 @@ export default function KudosVideoPlayerModal({ uri, onClose }: KudosVideoPlayer
     });
 
     return (
-        <Modal visible animationType="fade" onRequestClose={onClose}>
+        <Modal visible animationType="fade" onRequestClose={onClose} statusBarTranslucent>
             <View style={styles.container}>
                 <VideoView player={player} style={styles.video} contentFit="contain" nativeControls />
                 <TouchableOpacity

--- a/frontend/components/modals/KudosVideoPlayerModal.tsx
+++ b/frontend/components/modals/KudosVideoPlayerModal.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { Modal, StyleSheet, TouchableOpacity, View } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useVideoPlayer, VideoView } from "expo-video";
+import { X } from "phosphor-react-native";
+
+interface KudosVideoPlayerModalProps {
+    uri: string;
+    onClose: () => void;
+}
+
+/**
+ * Fullscreen playback for a video kudos. Deliberate viewing (unlike feed
+ * autoplay): sound on, native controls. Mount only while open.
+ */
+export default function KudosVideoPlayerModal({ uri, onClose }: KudosVideoPlayerModalProps) {
+    const insets = useSafeAreaInsets();
+    const player = useVideoPlayer(uri, (p) => {
+        p.loop = false;
+        p.play();
+    });
+
+    return (
+        <Modal visible animationType="fade" onRequestClose={onClose}>
+            <View style={styles.container}>
+                <VideoView player={player} style={styles.video} contentFit="contain" nativeControls />
+                <TouchableOpacity
+                    testID="kudos-video-close"
+                    style={[styles.close, { top: insets.top + 12 }]}
+                    onPress={onClose}
+                    accessibilityRole="button"
+                    accessibilityLabel="Close video">
+                    <X size={28} color="#fff" weight="bold" />
+                </TouchableOpacity>
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, backgroundColor: "#000" },
+    video: { flex: 1 },
+    close: {
+        position: "absolute",
+        right: 16,
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        backgroundColor: "rgba(0,0,0,0.5)",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+});

--- a/frontend/components/modals/KudosVideoPreview.tsx
+++ b/frontend/components/modals/KudosVideoPreview.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { useVideoPlayer, VideoView } from "expo-video";
+
+/** Muted looping preview of a selected video kudos inside the send modal. */
+export default function KudosVideoPreview({ uri }: { uri: string }) {
+    const player = useVideoPlayer(uri, (p) => {
+        p.loop = true;
+        p.muted = true;
+        p.play();
+    });
+
+    return <VideoView player={player} style={{ width: "100%", height: "100%" }} contentFit="cover" nativeControls={false} />;
+}

--- a/frontend/components/modals/KudosVideoRecorder.tsx
+++ b/frontend/components/modals/KudosVideoRecorder.tsx
@@ -1,0 +1,179 @@
+import React, { useRef, useState } from "react";
+import { Modal, StyleSheet, TouchableOpacity, View } from "react-native";
+import { CameraView, useCameraPermissions, useMicrophonePermissions, type CameraType } from "expo-camera";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { ArrowsClockwise, X } from "phosphor-react-native";
+import { ThemedText } from "@/components/ThemedText";
+import PrimaryButton from "@/components/inputs/PrimaryButton";
+import { KUDOS_VIDEO_MAX_DURATION_MS } from "@/api/upload";
+import { formatVideoDuration } from "@/api/media";
+
+interface KudosVideoRecorderProps {
+    visible: boolean;
+    onClose: () => void;
+    onRecorded: (video: { uri: string; durationMs: number }) => void;
+}
+
+/**
+ * Selfie-style video kudos recorder. Front camera by default, hard-stops at
+ * the kudos duration cap. The kudos modal's preview is the review step.
+ */
+export default function KudosVideoRecorder({ visible, onClose, onRecorded }: KudosVideoRecorderProps) {
+    const insets = useSafeAreaInsets();
+    const camera = useRef<CameraView>(null);
+    const recordStartRef = useRef(0);
+    const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const [facing, setFacing] = useState<CameraType>("front");
+    const [isRecording, setIsRecording] = useState(false);
+    const [elapsedMs, setElapsedMs] = useState(0);
+    const [cameraPermission, requestCameraPermission] = useCameraPermissions();
+    const [micPermission, requestMicPermission] = useMicrophonePermissions();
+
+    const hasPermissions = cameraPermission?.granted && micPermission?.granted;
+
+    const requestPermissions = async () => {
+        await requestCameraPermission();
+        await requestMicPermission();
+    };
+
+    const stopTimer = () => {
+        if (timerRef.current) {
+            clearInterval(timerRef.current);
+            timerRef.current = null;
+        }
+    };
+
+    const startRecording = async () => {
+        if (!camera.current || isRecording) return;
+        setIsRecording(true);
+        setElapsedMs(0);
+        recordStartRef.current = Date.now();
+        timerRef.current = setInterval(() => {
+            setElapsedMs(Date.now() - recordStartRef.current);
+        }, 250);
+        try {
+            // Resolves when recording stops — manually or at maxDuration (seconds).
+            const video = await camera.current.recordAsync({
+                maxDuration: KUDOS_VIDEO_MAX_DURATION_MS / 1000,
+            });
+            const durationMs = Math.min(Date.now() - recordStartRef.current, KUDOS_VIDEO_MAX_DURATION_MS);
+            if (video?.uri) {
+                onRecorded({ uri: video.uri, durationMs });
+            }
+        } catch (error) {
+            console.error("Error recording kudos video:", error);
+        } finally {
+            stopTimer();
+            setIsRecording(false);
+        }
+    };
+
+    const handleClose = () => {
+        if (isRecording) camera.current?.stopRecording();
+        stopTimer();
+        setIsRecording(false);
+        onClose();
+    };
+
+    return (
+        <Modal visible={visible} animationType="slide" onRequestClose={handleClose} statusBarTranslucent>
+            <View style={styles.container}>
+                {!hasPermissions ? (
+                    <View style={[styles.permissionGate, { paddingTop: insets.top }]}>
+                        <ThemedText type="default" style={styles.permissionText}>
+                            Allow camera and microphone access to record a video kudos.
+                        </ThemedText>
+                        <PrimaryButton title="Grant Access" onPress={requestPermissions} />
+                        <PrimaryButton ghost title="Cancel" onPress={handleClose} />
+                    </View>
+                ) : (
+                    <>
+                        <CameraView ref={camera} style={styles.camera} facing={facing} mode="video" />
+
+                        <View style={[styles.elapsedPill, { top: insets.top + 16 }]}>
+                            <ThemedText type="caption" style={styles.elapsedText}>
+                                {formatVideoDuration(elapsedMs)} / {formatVideoDuration(KUDOS_VIDEO_MAX_DURATION_MS)}
+                            </ThemedText>
+                        </View>
+
+                        <TouchableOpacity
+                            style={[styles.closeButton, { top: insets.top + 12 }]}
+                            onPress={handleClose}
+                            accessibilityRole="button"
+                            accessibilityLabel="Close recorder">
+                            <X size={28} color="#fff" weight="bold" />
+                        </TouchableOpacity>
+
+                        <View style={[styles.controls, { paddingBottom: insets.bottom + 24 }]}>
+                            <TouchableOpacity
+                                onPress={() => setFacing(facing === "front" ? "back" : "front")}
+                                disabled={isRecording}
+                                style={{ opacity: isRecording ? 0.4 : 1 }}
+                                accessibilityRole="button"
+                                accessibilityLabel="Flip camera">
+                                <ArrowsClockwise size={32} color="#fff" weight="regular" />
+                            </TouchableOpacity>
+
+                            <TouchableOpacity
+                                onPress={isRecording ? () => camera.current?.stopRecording() : startRecording}
+                                style={styles.recordRing}
+                                accessibilityRole="button"
+                                accessibilityLabel={isRecording ? "Stop recording" : "Start recording"}>
+                                <View style={isRecording ? styles.recordSquare : styles.recordCircle} />
+                            </TouchableOpacity>
+
+                            {/* spacer mirroring the flip button keeps the record button centered */}
+                            <View style={{ width: 32 }} />
+                        </View>
+                    </>
+                )}
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: { flex: 1, backgroundColor: "#000" },
+    camera: { flex: 1 },
+    permissionGate: { flex: 1, justifyContent: "center", alignItems: "center", gap: 16, padding: 24 },
+    permissionText: { color: "#fff", textAlign: "center" },
+    elapsedPill: {
+        position: "absolute",
+        alignSelf: "center",
+        backgroundColor: "rgba(0,0,0,0.6)",
+        borderRadius: 16,
+        paddingHorizontal: 12,
+        paddingVertical: 6,
+    },
+    elapsedText: { color: "#fff", fontSize: 14 },
+    closeButton: {
+        position: "absolute",
+        right: 16,
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        backgroundColor: "rgba(0,0,0,0.5)",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    controls: {
+        position: "absolute",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-evenly",
+    },
+    recordRing: {
+        width: 76,
+        height: 76,
+        borderRadius: 38,
+        borderWidth: 4,
+        borderColor: "#fff",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    recordCircle: { width: 60, height: 60, borderRadius: 30, backgroundColor: "#e0245e" },
+    recordSquare: { width: 32, height: 32, borderRadius: 6, backgroundColor: "#e0245e" },
+});

--- a/frontend/components/modals/KudosVideoRecorder.tsx
+++ b/frontend/components/modals/KudosVideoRecorder.tsx
@@ -1,5 +1,5 @@
-import React, { useRef, useState } from "react";
-import { Modal, StyleSheet, TouchableOpacity, View } from "react-native";
+import React, { useEffect, useRef, useState } from "react";
+import { Alert, Linking, Modal, Platform, StyleSheet, TouchableOpacity, View } from "react-native";
 import { CameraView, useCameraPermissions, useMicrophonePermissions, type CameraType } from "expo-camera";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ArrowsClockwise, X } from "phosphor-react-native";
@@ -11,6 +11,7 @@ import { formatVideoDuration } from "@/api/media";
 interface KudosVideoRecorderProps {
     visible: boolean;
     onClose: () => void;
+    /** Called with the captured clip; the parent is responsible for closing the recorder (set visible=false). */
     onRecorded: (video: { uri: string; durationMs: number }) => void;
 }
 
@@ -32,8 +33,24 @@ export default function KudosVideoRecorder({ visible, onClose, onRecorded }: Kud
     const hasPermissions = cameraPermission?.granted && micPermission?.granted;
 
     const requestPermissions = async () => {
-        await requestCameraPermission();
-        await requestMicPermission();
+        const cam = await requestCameraPermission();
+        const mic = await requestMicPermission();
+        // Permanently denied — the system dialog won't show again, so guide to Settings.
+        if ([cam, mic].some((p) => !p.granted && !p.canAskAgain)) {
+            Alert.alert("Camera Access", "To record a video kudos, allow camera and microphone access in Settings.", [
+                { text: "Cancel", style: "cancel" },
+                {
+                    text: "Open Settings",
+                    onPress: () => {
+                        if (Platform.OS === "ios") {
+                            Linking.openURL("app-settings:");
+                        } else {
+                            Linking.openSettings();
+                        }
+                    },
+                },
+            ]);
+        }
     };
 
     const stopTimer = () => {
@@ -42,6 +59,18 @@ export default function KudosVideoRecorder({ visible, onClose, onRecorded }: Kud
             timerRef.current = null;
         }
     };
+
+    // Cleanup if the parent unmounts us mid-recording.
+    useEffect(() => () => stopTimer(), []);
+
+    // Parent closed us via the visible prop: stop the camera + timer, reset the pill.
+    useEffect(() => {
+        if (visible) return;
+        camera.current?.stopRecording();
+        stopTimer();
+        setIsRecording(false);
+        setElapsedMs(0);
+    }, [visible]);
 
     const startRecording = async () => {
         if (!camera.current || isRecording) return;

--- a/frontend/components/notifications/NotificationsView.tsx
+++ b/frontend/components/notifications/NotificationsView.tsx
@@ -220,6 +220,7 @@ const NotificationItem = ({
                     icon={notification.icon}
                     time={notification.time}
                     referenceId={notification.referenceId}
+                    thumbnail={notification.thumbnail}
                     type="encouragement"
                 />
             ) : notification.type === "congratulation" ? (
@@ -231,6 +232,7 @@ const NotificationItem = ({
                     icon={notification.icon}
                     time={notification.time}
                     referenceId={notification.referenceId}
+                    thumbnail={notification.thumbnail}
                     type="congratulation"
                 />
             ) : notification.type === "friend_request_accepted" ? (


### PR DESCRIPTION
## Summary

- Adds `type: \"video\"` support to both kudos types (encouragements + congratulations), following the existing image pattern — video URL in `Message`, new optional `thumbnailUrl` + `durationMs` fields
- 30s / 50MB limits (half the post limits); on-device H.264 compression + thumbnail via existing upload pipeline
- Gallery pick or in-app selfie recording from both send modals (`EncourageModal`, `CongratulateModal`)
- Video kudos render as tappable thumbnails (play badge + duration pill) everywhere kudos display: notifications page, task detail encouragements, congratulators sheet on posts
- Push notifications use the thumbnail as the image payload (can't play video in a push)
- Private congratulation anonymization verified — `thumbnailUrl`/`durationMs` are stripped for non-owners by the existing allowlist in `PostDocument.ToAPI`
- Backend `go test -short -race ./...` green; 34/34 congratulation + 38/38 encouragement service tests pass including round-trip + denorm coverage for video kudos

## Architecture

- `ValidateVideoKudos` shared validator in `backend/internal/handlers/types` enforces: non-empty thumbnail, 0 < durationMs ≤ 30 000 ms; returns 422 via `huma.Error422UnprocessableEntity`
- `KUDOS_VIDEO_MAX_BYTES = 50MB`, `KUDOS_VIDEO_MAX_DURATION_MS = 30s` constants in `frontend/api/upload.ts`; `uploadVideo` accepts an options bag for per-caller limits
- `KudosVideoPlayerModal` — fullscreen RN Modal, sound on, native controls; `KudosVideoRecorder` — expo-camera selfie recorder with `visible`-prop lifecycle + permanent-denial → Settings redirect; `KudosVideoPreview` — muted looping in-modal preview
- `SpeechBubbleCard` / `KudosItem` updated to pass video props through to the player

## Manual test plan

- [ ] Send a video encouragement via gallery pick → notifications page shows thumbnail with play badge; tap → fullscreen player with sound; close works
- [ ] Send a video encouragement via in-app recorder (selfie, ≤30s) → same
- [ ] Try picking a gallery video >30s → "Videos can be up to 30 seconds" alert fires, nothing sent
- [ ] Send a video congratulation on a post → congratulators sheet shows thumbnail + play glyph; tap plays
- [ ] Send a private video congratulation → non-owner sees "Anonymous" row with no thumbnail (verify on two accounts)
- [ ] Push notification on a second device shows the thumbnail image and "video cheer" copy
- [ ] First-time camera permission permanently denied → "Open Settings" alert appears
- [ ] Existing image and GIF kudos flows unchanged on both modals

## Known pending (on-device verify)

- RN `Modal` inside the gorhom bottom sheet (`CongratulatorsBottomSheetModal`) — works on most platforms but noted for explicit device smoke test
- Frontend jest suites not run in CI (sandbox outage during development); backend suite is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)