### PR TITLE
feat(profile): profile-song PoC (tag a song, play its iTunes preview)

### DIFF
--- a/PROFILE_SONG_POC.md
+++ b/PROFILE_SONG_POC.md
@@ -1,0 +1,46 @@
+# Profile Song — Proof of Concept
+
+Instagram-style "song on your profile": search a track, attach it, and play its 30s
+preview from a pill on the profile. Frontend-only PoC — no backend, no new native module.
+
+## How it works
+
+- **Search**: hits the public **iTunes Search API** directly from the client (no auth, no key, no backend endpoint). 30s preview clips come back as `previewUrl`.
+- **Playback**: reuses the already-installed **`expo-video`** player to play the preview m4a (audio-only, hidden 1px view). No `expo-audio`, so **no dev-client rebuild** — runs on your existing dev client.
+- **Persistence**: `AsyncStorage` (`poc:profileSong`). The real version would store this on the user via the existing `PATCH /v1/profiles/{id}`.
+
+## Files
+
+| File | What |
+|---|---|
+| `frontend/api/itunes.ts` | iTunes search + response→`Song` mapping (pure, unit-tested) |
+| `frontend/__tests__/itunes.test.ts` | 3 passing logic tests |
+| `frontend/components/profile/song/SongPickerModal.tsx` | Debounced search sheet → tap to attach |
+| `frontend/components/profile/song/ProfileSongWidget.tsx` | The pill: play/pause preview, change song |
+| `frontend/components/profile/song/Equalizer.tsx` | Animated equalizer bars while playing |
+| `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx` | Renders `<ProfileSongWidget />` under the edit row |
+
+## Run it
+
+```bash
+cd frontend
+bun start          # then open in your existing dev client
+```
+
+Go to the **Profile** tab → "Add a song to your profile" → search → tap a result →
+tap the pill to play/pause. **Ringer must be on** (iOS silent switch mutes it; a real
+build would set the playback audio-session category).
+
+## Verify
+
+```bash
+cd frontend
+bunx jest itunes   # 3 pass
+bunx tsc --noEmit  # only the 14 pre-existing DatePager errors
+```
+
+## Not in scope (intentionally)
+
+- Backend persistence (one field on the user + the existing PATCH — ~0.5d).
+- Album artwork (dropped per scope).
+- Songs on *posts* + autoplay-as-you-scroll (the deferred feed-viewability work).

--- a/frontend/__tests__/itunes.test.ts
+++ b/frontend/__tests__/itunes.test.ts
@@ -1,0 +1,45 @@
+import { buildSearchUrl, mapItunesResults } from "@/api/itunes";
+
+describe("buildSearchUrl", () => {
+    it("encodes the term and pins music/song params", () => {
+        const url = buildSearchUrl("daft punk");
+        expect(url).toContain("term=daft+punk");
+        expect(url).toContain("media=music");
+        expect(url).toContain("entity=song");
+        expect(url).toContain("limit=15");
+    });
+});
+
+describe("mapItunesResults", () => {
+    it("maps fields and drops tracks without a preview url", () => {
+        const songs = mapItunesResults({
+            resultCount: 2,
+            results: [
+                {
+                    trackId: 1,
+                    trackName: "One More Time",
+                    artistName: "Daft Punk",
+                    previewUrl: "https://x/a.m4a",
+                    artworkUrl100: "https://x/art.jpg",
+                    trackViewUrl: "https://music/1",
+                },
+                { trackId: 2, trackName: "No Preview", artistName: "Nobody" },
+            ],
+        });
+        expect(songs).toEqual([
+            {
+                id: 1,
+                title: "One More Time",
+                artist: "Daft Punk",
+                previewUrl: "https://x/a.m4a",
+                artworkUrl: "https://x/art.jpg",
+                appleMusicUrl: "https://music/1",
+            },
+        ]);
+    });
+
+    it("returns [] for empty or missing results", () => {
+        expect(mapItunesResults({ resultCount: 0, results: [] })).toEqual([]);
+        expect(mapItunesResults(null as never)).toEqual([]);
+    });
+});

--- a/frontend/api/itunes.ts
+++ b/frontend/api/itunes.ts
@@ -1,0 +1,59 @@
+// iTunes Search API — public, no auth, no key. Returns songs + free 30s preview clips.
+// https://performance-partners.apple.com/search-api
+
+export interface Song {
+    id: number;
+    title: string;
+    artist: string;
+    previewUrl: string;
+    artworkUrl?: string;
+    appleMusicUrl?: string;
+}
+
+interface ItunesTrack {
+    trackId?: number;
+    trackName?: string;
+    artistName?: string;
+    previewUrl?: string;
+    artworkUrl100?: string;
+    trackViewUrl?: string;
+}
+
+interface ItunesResponse {
+    resultCount: number;
+    results: ItunesTrack[];
+}
+
+const ENDPOINT = "https://itunes.apple.com/search";
+
+export function buildSearchUrl(term: string, limit = 15): string {
+    const params = new URLSearchParams({
+        term: term.trim(),
+        media: "music",
+        entity: "song",
+        limit: String(limit),
+    });
+    return `${ENDPOINT}?${params.toString()}`;
+}
+
+export function mapItunesResults(raw: ItunesResponse): Song[] {
+    if (!raw?.results) return [];
+    return raw.results
+        .filter((t) => typeof t.trackId === "number" && !!t.previewUrl)
+        .map((t) => ({
+            id: t.trackId as number,
+            title: t.trackName ?? "Unknown",
+            artist: t.artistName ?? "Unknown artist",
+            previewUrl: t.previewUrl as string,
+            artworkUrl: t.artworkUrl100,
+            appleMusicUrl: t.trackViewUrl,
+        }));
+}
+
+export async function searchSongs(term: string, signal?: AbortSignal): Promise<Song[]> {
+    if (!term.trim()) return [];
+    const res = await fetch(buildSearchUrl(term), { signal });
+    if (!res.ok) throw new Error(`iTunes search failed: ${res.status}`);
+    const data = (await res.json()) as ItunesResponse;
+    return mapItunesResults(data);
+}

--- a/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx
@@ -22,6 +22,7 @@ import ProfileEdit from "@/components/profile/ProfileEdit";
 import CompleteProfileCard from "@/components/profile/CompleteProfileCard";
 import BlueprintSection from "@/components/profile/BlueprintSection";
 import ReferralCard from "@/components/profile/ReferralCard";
+import ProfileSongWidget from "@/components/profile/song/ProfileSongWidget";
 import { components } from "@/api/generated/types";
 import { useTasks } from "@/contexts/tasksContext";
 import { useQuery } from "@tanstack/react-query";
@@ -123,6 +124,8 @@ export default function Profile() {
                 <View style={{ width: "100%" }}>
                     <ProfileEdit friendsCount={user?.friends.length || 0} />
                 </View>
+
+                <ProfileSongWidget />
 
                 <CompleteProfileCard />
 

--- a/frontend/components/profile/song/Equalizer.tsx
+++ b/frontend/components/profile/song/Equalizer.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect } from "react";
+import { View, StyleSheet } from "react-native";
+import Animated, {
+    useSharedValue,
+    useAnimatedStyle,
+    withRepeat,
+    withTiming,
+    withDelay,
+    cancelAnimation,
+    Easing,
+} from "react-native-reanimated";
+
+// Staggered delays so bars bounce out of phase, like a real equalizer.
+const BAR_DELAYS = [0, 140, 70, 200];
+
+export default function Equalizer({ playing, color, size = 16 }: { playing: boolean; color: string; size?: number }) {
+    return (
+        <View style={[styles.row, { height: size }]}>
+            {BAR_DELAYS.map((delay, i) => (
+                <EqualizerBar key={i} playing={playing} color={color} delay={delay} maxHeight={size} />
+            ))}
+        </View>
+    );
+}
+
+function EqualizerBar({
+    playing,
+    color,
+    delay,
+    maxHeight,
+}: {
+    playing: boolean;
+    color: string;
+    delay: number;
+    maxHeight: number;
+}) {
+    const fraction = useSharedValue(0.3);
+
+    useEffect(() => {
+        if (playing) {
+            fraction.value = withDelay(
+                delay,
+                withRepeat(withTiming(1, { duration: 340, easing: Easing.inOut(Easing.ease) }), -1, true)
+            );
+        } else {
+            cancelAnimation(fraction);
+            fraction.value = withTiming(0.3, { duration: 150 });
+        }
+        return () => cancelAnimation(fraction);
+    }, [playing, delay, fraction]);
+
+    const style = useAnimatedStyle(() => ({ height: maxHeight * fraction.value }));
+
+    return <Animated.View style={[styles.bar, { backgroundColor: color }, style]} />;
+}
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        alignItems: "flex-end",
+        gap: 2,
+    },
+    bar: {
+        width: 3,
+        borderRadius: 2,
+    },
+});

--- a/frontend/components/profile/song/ProfileSongWidget.tsx
+++ b/frontend/components/profile/song/ProfileSongWidget.tsx
@@ -1,0 +1,143 @@
+import React, { useEffect, useState } from "react";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useVideoPlayer, VideoView } from "expo-video";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { MusicNotes, Play, Pause, PencilSimple } from "phosphor-react-native";
+import { type Song } from "@/api/itunes";
+import SongPickerModal from "./SongPickerModal";
+import Equalizer from "./Equalizer";
+
+// PoC persistence: local only. Real version stores this on the user via PATCH /v1/profiles/{id}.
+const STORAGE_KEY = "poc:profileSong";
+
+export default function ProfileSongWidget() {
+    const ThemedColor = useThemeColor();
+    const [song, setSong] = useState<Song | null>(null);
+    const [pickerOpen, setPickerOpen] = useState(false);
+
+    useEffect(() => {
+        AsyncStorage.getItem(STORAGE_KEY)
+            .then((raw) => raw && setSong(JSON.parse(raw)))
+            .catch(() => {});
+    }, []);
+
+    const select = (next: Song) => {
+        setSong(next);
+        AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(() => {});
+    };
+
+    return (
+        <View style={styles.wrapper}>
+            {song ? (
+                <SongPreviewPill key={song.id} song={song} onChange={() => setPickerOpen(true)} />
+            ) : (
+                <TouchableOpacity
+                    onPress={() => setPickerOpen(true)}
+                    activeOpacity={0.7}
+                    style={[styles.addPill, { borderColor: ThemedColor.primary }]}>
+                    <MusicNotes size={20} color={ThemedColor.primary} weight="fill" />
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                        Add a song to your profile
+                    </ThemedText>
+                </TouchableOpacity>
+            )}
+            <SongPickerModal visible={pickerOpen} onClose={() => setPickerOpen(false)} onSelect={select} />
+        </View>
+    );
+}
+
+function SongPreviewPill({ song, onChange }: { song: Song; onChange: () => void }) {
+    const ThemedColor = useThemeColor();
+    const [playing, setPlaying] = useState(false);
+    const player = useVideoPlayer(song.previewUrl, (p) => {
+        p.loop = true;
+    });
+
+    useEffect(() => () => player.pause(), [player]);
+
+    const toggle = () => {
+        setPlaying((prev) => {
+            const next = !prev;
+            next ? player.play() : player.pause();
+            return next;
+        });
+    };
+
+    return (
+        <View style={[styles.pill, { backgroundColor: ThemedColor.primary + "14" }]}>
+            <TouchableOpacity onPress={toggle} activeOpacity={0.8} style={styles.pillMain}>
+                <View style={[styles.playButton, { backgroundColor: ThemedColor.primary }]}>
+                    {playing ? (
+                        <Pause size={16} color="#fff" weight="fill" />
+                    ) : (
+                        <Play size={16} color="#fff" weight="fill" />
+                    )}
+                </View>
+                <Equalizer playing={playing} color={ThemedColor.primary} size={16} />
+                <View style={styles.pillText}>
+                    <ThemedText type="defaultSemiBold" numberOfLines={1}>
+                        {song.title}
+                    </ThemedText>
+                    <ThemedText type="smallerDefault" numberOfLines={1} style={{ color: ThemedColor.primary }}>
+                        {song.artist}
+                    </ThemedText>
+                </View>
+            </TouchableOpacity>
+            <TouchableOpacity onPress={onChange} hitSlop={10} style={styles.changeBtn}>
+                <PencilSimple size={18} color={ThemedColor.primary} />
+            </TouchableOpacity>
+            <VideoView player={player} style={styles.hiddenVideo} />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    wrapper: {
+        width: "100%",
+    },
+    addPill: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 10,
+        borderWidth: 1,
+        borderStyle: "dashed",
+        borderRadius: 14,
+        paddingVertical: 14,
+        paddingHorizontal: 16,
+    },
+    pill: {
+        flexDirection: "row",
+        alignItems: "center",
+        borderRadius: 14,
+        paddingVertical: 10,
+        paddingHorizontal: 12,
+        gap: 10,
+    },
+    pillMain: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 10,
+        flex: 1,
+    },
+    playButton: {
+        width: 34,
+        height: 34,
+        borderRadius: 17,
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    pillText: {
+        flex: 1,
+    },
+    changeBtn: {
+        padding: 4,
+    },
+    hiddenVideo: {
+        width: 1,
+        height: 1,
+        opacity: 0,
+        position: "absolute",
+    },
+});

--- a/frontend/components/profile/song/SongPickerModal.tsx
+++ b/frontend/components/profile/song/SongPickerModal.tsx
@@ -1,0 +1,148 @@
+import React, { useEffect, useState } from "react";
+import { Modal, View, TextInput, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { MagnifyingGlass, X } from "phosphor-react-native";
+import { searchSongs, type Song } from "@/api/itunes";
+
+export default function SongPickerModal({
+    visible,
+    onClose,
+    onSelect,
+}: {
+    visible: boolean;
+    onClose: () => void;
+    onSelect: (song: Song) => void;
+}) {
+    const ThemedColor = useThemeColor();
+    const [term, setTerm] = useState("");
+    const [results, setResults] = useState<Song[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    // Debounced search straight to the public iTunes API — no backend needed.
+    useEffect(() => {
+        if (!term.trim()) {
+            setResults([]);
+            return;
+        }
+        const controller = new AbortController();
+        const handle = setTimeout(async () => {
+            setLoading(true);
+            try {
+                setResults(await searchSongs(term, controller.signal));
+            } catch {
+                if (!controller.signal.aborted) setResults([]);
+            } finally {
+                setLoading(false);
+            }
+        }, 350);
+        return () => {
+            clearTimeout(handle);
+            controller.abort();
+        };
+    }, [term]);
+
+    const pick = (song: Song) => {
+        onSelect(song);
+        setTerm("");
+        setResults([]);
+        onClose();
+    };
+
+    return (
+        <Modal visible={visible} animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+            <View style={[styles.container, { backgroundColor: ThemedColor.background }]}>
+                <View style={styles.header}>
+                    <ThemedText type="fancyFrauncesSubheading">Add a song</ThemedText>
+                    <TouchableOpacity onPress={onClose} hitSlop={12}>
+                        <X size={24} color={ThemedColor.text} weight="bold" />
+                    </TouchableOpacity>
+                </View>
+
+                <View style={[styles.searchBar, { backgroundColor: ThemedColor.lightened }]}>
+                    <MagnifyingGlass size={18} color={ThemedColor.caption} />
+                    <TextInput
+                        value={term}
+                        onChangeText={setTerm}
+                        placeholder="Search songs or artists"
+                        placeholderTextColor={ThemedColor.caption}
+                        style={[styles.input, { color: ThemedColor.text }]}
+                        autoFocus
+                        returnKeyType="search"
+                        autoCorrect={false}
+                    />
+                </View>
+
+                {loading && <ActivityIndicator color={ThemedColor.primary} style={styles.spinner} />}
+
+                <FlatList
+                    data={results}
+                    keyExtractor={(item) => String(item.id)}
+                    keyboardShouldPersistTaps="handled"
+                    contentContainerStyle={styles.listContent}
+                    renderItem={({ item }) => (
+                        <TouchableOpacity
+                            style={[styles.row, { borderBottomColor: ThemedColor.tertiary }]}
+                            onPress={() => pick(item)}
+                            activeOpacity={0.7}>
+                            <ThemedText type="defaultSemiBold" numberOfLines={1}>
+                                {item.title}
+                            </ThemedText>
+                            <ThemedText type="caption" numberOfLines={1}>
+                                {item.artist}
+                            </ThemedText>
+                        </TouchableOpacity>
+                    )}
+                    ListEmptyComponent={
+                        !loading && term.trim() ? (
+                            <ThemedText type="caption" style={styles.empty}>
+                                No results
+                            </ThemedText>
+                        ) : null
+                    }
+                />
+            </View>
+        </Modal>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        paddingHorizontal: 20,
+        paddingTop: 20,
+    },
+    header: {
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "space-between",
+        marginBottom: 20,
+    },
+    searchBar: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 8,
+        borderRadius: 12,
+        paddingHorizontal: 12,
+        height: 48,
+    },
+    input: {
+        flex: 1,
+        fontFamily: "Outfit",
+        fontSize: 16,
+    },
+    spinner: {
+        marginTop: 16,
+    },
+    listContent: {
+        paddingBottom: 40,
+    },
+    row: {
+        paddingVertical: 14,
+        borderBottomWidth: 0.5,
+        gap: 2,
+    },
+    empty: {
+        marginTop: 24,
+    },
+});


### PR DESCRIPTION
## What

A **proof of concept** for an Instagram-style "song on your profile": search a track, attach it, and play its 30‑second preview from a pill on the Profile tab.

![flow] _Profile tab → "Add a song" → search → tap a result → pill plays the preview (▶ + animated equalizer + Title · Artist)._

## How it works (and why it's small)

1. **Search → public iTunes Search API, called directly from the client.** No auth, no key, **no backend endpoint**. Returns the free 30s `previewUrl`.
2. **Playback → reuses the already-installed `expo-video` player** to play the preview m4a (audio-only, hidden 1px view). No `expo-audio`, so **no dev-client rebuild** — runs on the existing dev client.
3. **Persistence → `AsyncStorage`** (`poc:profileSong`). Deliberately stubbed; production would store one field on the user via the existing `PATCH /v1/profiles/{id}`.

## Files

| File | What |
|---|---|
| `frontend/api/itunes.ts` | iTunes search + response→`Song` mapping (pure, unit-tested) |
| `frontend/__tests__/itunes.test.ts` | 3 logic tests |
| `frontend/components/profile/song/SongPickerModal.tsx` | Debounced search sheet → tap to attach |
| `frontend/components/profile/song/ProfileSongWidget.tsx` | The pill: play/pause preview, change song |
| `frontend/components/profile/song/Equalizer.tsx` | Animated equalizer bars while playing |
| `frontend/app/(logged-in)/(tabs)/(profile)/profile.tsx` | Renders `<ProfileSongWidget />` under the edit row |
| `PROFILE_SONG_POC.md` | Run/demo notes |

## How to run

```bash
cd frontend
bun start   # open in the existing dev client → Profile tab → "Add a song"
```

> **Ringer must be on** — the iOS silent switch mutes preview audio. A real build would set the playback audio-session category.

## Verification

- `bunx jest itunes` → **3/3 pass**
- `bunx tsc --noEmit` → 14 errors, all pre-existing `DatePager` baseline, **0 in new files**
- Not yet run on a simulator — audio playback should be confirmed on first run.

## Out of scope (intentionally)

- Backend persistence (one user field + the existing PATCH — ~0.5d).
- Album artwork (dropped per scoping).
- Songs on **posts** + autoplay-as-you-scroll (the deferred feed-viewability work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
