### PR TITLE
feat(analytics): widget-style Analytics dashboard (Phase 1)

### DIFF
--- a/backend/internal/handlers/analytics/analytics.go
+++ b/backend/internal/handlers/analytics/analytics.go
@@ -1,0 +1,37 @@
+package analytics
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/auth"
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
+// GetAnalytics returns the dashboard payload for the authenticated user.
+func (h *Handler) GetAnalytics(ctx context.Context, input *GetAnalyticsInput) (*GetAnalyticsOutput, error) {
+	uid, ok := auth.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, huma.Error401Unauthorized("Not authenticated")
+	}
+	userID, err := primitive.ObjectIDFromHex(uid)
+	if err != nil {
+		return nil, huma.Error400BadRequest("Invalid user ID", err)
+	}
+
+	rng := input.Range
+	switch rng {
+	case RangeWeek, RangeMonth, RangeSixMonth:
+	default:
+		rng = RangeWeek
+	}
+
+	resp, err := h.service.GetAnalytics(userID, rng, input.Workspace, input.Category)
+	if err != nil {
+		slog.Error("analytics: failed to build dashboard", "error", err, "user_id", uid, "range", rng)
+		return nil, huma.Error500InternalServerError("Unable to load analytics. Please try again.", err)
+	}
+
+	return &GetAnalyticsOutput{Body: resp}, nil
+}

--- a/backend/internal/handlers/analytics/compute.go
+++ b/backend/internal/handlers/analytics/compute.go
@@ -1,0 +1,923 @@
+package analytics
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+)
+
+// --- lite inputs -------------------------------------------------------------
+// These decouple the pure computation from MongoDB documents so it can be unit
+// tested with synthetic data. The service maps Mongo docs into these.
+
+type AnalyticsTaskLite struct {
+	CategoryID  string
+	CompletedAt time.Time
+	Deadline    *time.Time
+	KudosCount  int
+}
+
+type AnalyticsCategoryMeta struct {
+	ID        string
+	Name      string
+	Workspace string
+}
+
+type AnalyticsHabitLite struct {
+	TemplateID      string
+	CategoryID      string
+	Title           string
+	Frequency       string
+	Streak          int
+	CompletionDates []time.Time
+	NextDueAt       *time.Time
+}
+
+type computeInput struct {
+	Range           string
+	Now             time.Time
+	WorkspaceFilter string
+	CategoryFilter  string
+	Completed       []AnalyticsTaskLite // covers the heatmap window (>= 91 days) and both periods
+	Categories      []AnalyticsCategoryMeta
+	Habits          []AnalyticsHabitLite
+	SupportCurrent  int // kudos received in the current period
+	SupportPrev     int // kudos received in the previous period
+}
+
+// --- palette / thresholds ----------------------------------------------------
+
+var palette = []string{
+	"#854DFF", // Kindred purple
+	"#2DD4BF", // teal
+	"#F59E0B", // amber
+	"#EC4899", // pink
+	"#3B82F6", // blue
+	"#22C55E", // green
+	"#A855F7", // violet
+	"#F97316", // orange
+}
+
+const (
+	otherColor = "#6B7280"
+	otherID    = "other"
+	otherName  = "Other"
+
+	heatmapDays = 91 // trailing 13 weeks
+)
+
+func levelForCount(c int) int {
+	switch {
+	case c <= 0:
+		return 0
+	case c <= 2:
+		return 1
+	case c <= 4:
+		return 2
+	case c <= 6:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// --- date helpers ------------------------------------------------------------
+
+func startOfDay(t time.Time) time.Time {
+	y, m, d := t.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, t.Location())
+}
+
+func startOfWeekMonday(t time.Time) time.Time {
+	d := startOfDay(t)
+	offset := (int(d.Weekday()) + 6) % 7 // Sunday=0 -> 6, Monday=1 -> 0
+	return d.AddDate(0, 0, -offset)
+}
+
+func startOfMonth(t time.Time) time.Time {
+	y, m, _ := t.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, t.Location())
+}
+
+func daysInMonth(t time.Time) int {
+	return startOfMonth(t).AddDate(0, 1, -1).Day()
+}
+
+func shortWeekday(w time.Weekday) string {
+	return [...]string{"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"}[int(w)]
+}
+
+func windowBounds(rng string, now time.Time) (curStart, curEnd, prevStart, prevEnd time.Time, unit string) {
+	switch rng {
+	case RangeMonth:
+		curStart = startOfMonth(now)
+		curEnd = curStart.AddDate(0, 1, 0)
+		prevStart = curStart.AddDate(0, -1, 0)
+		prevEnd = curStart
+		unit = "week"
+	case RangeSixMonth:
+		curStart = startOfMonth(now).AddDate(0, -5, 0)
+		curEnd = startOfMonth(now).AddDate(0, 1, 0)
+		prevStart = curStart.AddDate(0, -6, 0)
+		prevEnd = curStart
+		unit = "month"
+	default: // week
+		curStart = startOfWeekMonday(now)
+		curEnd = curStart.AddDate(0, 0, 7)
+		prevStart = curStart.AddDate(0, 0, -7)
+		prevEnd = curStart
+		unit = "day"
+	}
+	return
+}
+
+func bucketCount(unit string, curStart time.Time) int {
+	switch unit {
+	case "day":
+		return 7
+	case "week":
+		return (daysInMonth(curStart)-1)/7 + 1
+	case "month":
+		return 6
+	}
+	return 7
+}
+
+func bucketIndex(unit string, curStart, t time.Time) int {
+	switch unit {
+	case "day":
+		return int(startOfDay(t).Sub(curStart).Hours() / 24)
+	case "week":
+		return (t.Day() - 1) / 7
+	case "month":
+		return (t.Year()-curStart.Year())*12 + int(t.Month()) - int(curStart.Month())
+	}
+	return 0
+}
+
+func bucketLabel(unit string, curStart time.Time, idx int) string {
+	switch unit {
+	case "day":
+		return shortWeekday(curStart.AddDate(0, 0, idx).Weekday())
+	case "week":
+		return fmt.Sprintf("W%d", idx+1)
+	case "month":
+		return curStart.AddDate(0, idx, 0).Month().String()[:3]
+	}
+	return ""
+}
+
+func bucketStart(unit string, curStart time.Time, idx int) time.Time {
+	switch unit {
+	case "day":
+		return curStart.AddDate(0, 0, idx)
+	case "week":
+		return curStart.AddDate(0, 0, idx*7)
+	case "month":
+		return curStart.AddDate(0, idx, 0)
+	}
+	return curStart
+}
+
+// --- small numeric helpers ---------------------------------------------------
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func pctChange(prev, cur int) float64 {
+	if prev == 0 {
+		if cur == 0 {
+			return 0
+		}
+		return 100
+	}
+	return math.Round(float64(cur-prev) / float64(prev) * 100)
+}
+
+func pctInt(part, whole int) int {
+	if whole == 0 {
+		return 0
+	}
+	return int(math.Round(float64(part) / float64(whole) * 100))
+}
+
+func direction(delta float64) string {
+	switch {
+	case delta > 0:
+		return "up"
+	case delta < 0:
+		return "down"
+	default:
+		return "flat"
+	}
+}
+
+func rangeSuffix(rng string) string {
+	switch rng {
+	case RangeMonth:
+		return "vs last month"
+	case RangeSixMonth:
+		return "vs prior 6 months"
+	default:
+		return "vs last week"
+	}
+}
+
+func signedPct(d float64) string {
+	if d >= 0 {
+		return fmt.Sprintf("+%d%%", int(d))
+	}
+	return fmt.Sprintf("%d%%", int(d))
+}
+
+func signedInt(d int) string {
+	if d >= 0 {
+		return fmt.Sprintf("+%d", d)
+	}
+	return fmt.Sprintf("%d", d)
+}
+
+// --- task helpers ------------------------------------------------------------
+
+func tasksInWindow(tasks []AnalyticsTaskLite, start, end time.Time) []AnalyticsTaskLite {
+	out := make([]AnalyticsTaskLite, 0, len(tasks))
+	for _, t := range tasks {
+		if !t.CompletedAt.Before(start) && t.CompletedAt.Before(end) {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+func countByCategory(tasks []AnalyticsTaskLite) map[string]int {
+	m := map[string]int{}
+	for _, t := range tasks {
+		m[t.CategoryID]++
+	}
+	return m
+}
+
+// orderCategories returns category IDs sorted by descending count (ties broken
+// by ID for determinism).
+func orderCategories(counts map[string]int) []string {
+	ids := make([]string, 0, len(counts))
+	for id := range counts {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		if counts[ids[i]] != counts[ids[j]] {
+			return counts[ids[i]] > counts[ids[j]]
+		}
+		return ids[i] < ids[j]
+	})
+	return ids
+}
+
+func onTimeStats(tasks []AnalyticsTaskLite) (withDeadline, onTime int) {
+	for _, t := range tasks {
+		if t.Deadline == nil {
+			continue
+		}
+		withDeadline++
+		if !t.CompletedAt.After(*t.Deadline) {
+			onTime++
+		}
+	}
+	return
+}
+
+func sumKudos(tasks []AnalyticsTaskLite) int {
+	total := 0
+	for _, t := range tasks {
+		total += t.KudosCount
+	}
+	return total
+}
+
+// --- main computation --------------------------------------------------------
+
+func computeAnalytics(in computeInput) AnalyticsResponse {
+	now := in.Now
+	curStart, curEnd, prevStart, prevEnd, unit := windowBounds(in.Range, now)
+
+	metaByID := map[string]AnalyticsCategoryMeta{}
+	for _, c := range in.Categories {
+		metaByID[c.ID] = c
+	}
+	nameOf := func(id string) string {
+		if m, ok := metaByID[id]; ok && m.Name != "" {
+			return m.Name
+		}
+		return "Uncategorized"
+	}
+	workspaceOf := func(id string) string {
+		if m, ok := metaByID[id]; ok {
+			return m.Workspace
+		}
+		return ""
+	}
+	inScope := func(catID string) bool {
+		if in.CategoryFilter != "" && catID != in.CategoryFilter {
+			return false
+		}
+		if in.WorkspaceFilter != "" && workspaceOf(catID) != in.WorkspaceFilter {
+			return false
+		}
+		return true
+	}
+
+	scoped := make([]AnalyticsTaskLite, 0, len(in.Completed))
+	for _, t := range in.Completed {
+		if inScope(t.CategoryID) {
+			scoped = append(scoped, t)
+		}
+	}
+
+	cur := tasksInWindow(scoped, curStart, curEnd)
+	prev := tasksInWindow(scoped, prevStart, prevEnd)
+
+	curByCat := countByCategory(cur)
+	orderedCats := orderCategories(curByCat)
+	colorByID := map[string]string{}
+	for i, id := range orderedCats {
+		colorByID[id] = palette[i%len(palette)]
+	}
+
+	top := orderedCats
+	if len(top) > 4 {
+		top = top[:4]
+	}
+	topSet := map[string]bool{}
+	for _, id := range top {
+		topSet[id] = true
+	}
+	hasOther := len(orderedCats) > len(top)
+
+	nb := bucketCount(unit, curStart)
+
+	resp := AnalyticsResponse{
+		Range:           in.Range,
+		WorkspaceFilter: in.WorkspaceFilter,
+		CategoryFilter:  in.CategoryFilter,
+		GeneratedAt:     now,
+	}
+	resp.Signals = computeSignals(in.Range, cur, prev, in.SupportCurrent, in.SupportPrev)
+	resp.Progress = computeProgress(unit, curStart, nb, cur, prev, top, topSet, hasOther, colorByID, nameOf)
+	resp.CategoryShare = computeShare(unit, curStart, nb, cur, orderedCats, top, topSet, colorByID, nameOf)
+	resp.Heatmap = computeHeatmap(scoped, now)
+	resp.Habits = computeHabits(in.Habits, inScope, curStart, curEnd)
+	resp.CategoryHealth = computeCategoryHealth(unit, curStart, nb, cur, orderedCats, colorByID, nameOf, workspaceOf)
+	resp.WorkspaceHealth = computeWorkspaceHealth(cur, workspaceOf)
+
+	return resp
+}
+
+func computeSignals(rng string, cur, prev []AnalyticsTaskLite, supportCur, supportPrev int) AnalyticsSignals {
+	suffix := rangeSuffix(rng)
+
+	doneCur, donePrev := len(cur), len(prev)
+	momDelta := pctChange(donePrev, doneCur)
+	momentum := AnalyticsSignal{
+		Label:      "Momentum",
+		Value:      fmt.Sprintf("%d done", doneCur),
+		RawValue:   float64(doneCur),
+		Delta:      momDelta,
+		DeltaLabel: fmt.Sprintf("%s %s", signedPct(momDelta), suffix),
+		Direction:  direction(momDelta),
+	}
+
+	wdCur, otCur := onTimeStats(cur)
+	wdPrev, otPrev := onTimeStats(prev)
+	onTimeCur := pctInt(otCur, wdCur)
+	onTimePrev := pctInt(otPrev, wdPrev)
+	timeDelta := float64(onTimeCur - onTimePrev)
+	timing := AnalyticsSignal{
+		Label:      "Timing",
+		Value:      fmt.Sprintf("%d%%", onTimeCur),
+		RawValue:   float64(onTimeCur),
+		Delta:      timeDelta,
+		DeltaLabel: fmt.Sprintf("%s pts", signedInt(onTimeCur-onTimePrev)),
+		Direction:  direction(timeDelta),
+	}
+
+	supDelta := float64(supportCur - supportPrev)
+	support := AnalyticsSignal{
+		Label:      "Support",
+		Value:      fmt.Sprintf("%d Kudos", supportCur),
+		RawValue:   float64(supportCur),
+		Delta:      supDelta,
+		DeltaLabel: fmt.Sprintf("%s %s", signedInt(supportCur-supportPrev), suffix),
+		Direction:  direction(supDelta),
+	}
+
+	return AnalyticsSignals{Momentum: momentum, Timing: timing, Support: support}
+}
+
+func computeProgress(unit string, curStart time.Time, nb int, cur, prev []AnalyticsTaskLite, top []string, topSet map[string]bool, hasOther bool, colorByID map[string]string, nameOf func(string) string) AnalyticsProgress {
+	buckets := make([]AnalyticsProgressBucket, nb)
+	segCounts := make([]map[string]int, nb)
+	for i := 0; i < nb; i++ {
+		buckets[i] = AnalyticsProgressBucket{
+			Label: bucketLabel(unit, curStart, i),
+			Date:  bucketStart(unit, curStart, i).Format("2006-01-02"),
+		}
+		segCounts[i] = map[string]int{}
+	}
+
+	for _, t := range cur {
+		idx := bucketIndex(unit, curStart, t.CompletedAt)
+		if idx < 0 || idx >= nb {
+			continue
+		}
+		key := t.CategoryID
+		if !topSet[key] {
+			key = otherID
+		}
+		segCounts[idx][key]++
+		buckets[idx].Total++
+	}
+
+	for i := 0; i < nb; i++ {
+		for _, cid := range top {
+			if c := segCounts[i][cid]; c > 0 {
+				buckets[i].Segments = append(buckets[i].Segments, AnalyticsProgressSegment{
+					CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid], Count: c,
+				})
+			}
+		}
+		if c := segCounts[i][otherID]; c > 0 {
+			buckets[i].Segments = append(buckets[i].Segments, AnalyticsProgressSegment{
+				CategoryID: otherID, Name: otherName, Color: otherColor, Count: c,
+			})
+		}
+	}
+
+	legend := make([]AnalyticsLegendItem, 0, len(top)+1)
+	for _, cid := range top {
+		legend = append(legend, AnalyticsLegendItem{CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid]})
+	}
+	if hasOther {
+		legend = append(legend, AnalyticsLegendItem{CategoryID: otherID, Name: otherName, Color: otherColor})
+	}
+
+	total := len(cur)
+	prevTotal := len(prev)
+	return AnalyticsProgress{
+		Total:      total,
+		PrevTotal:  prevTotal,
+		Delta:      pctChange(prevTotal, total),
+		BucketUnit: unit,
+		Buckets:    buckets,
+		Legend:     legend,
+		Takeaway:   progressTakeaway(unit, buckets, nameOf),
+	}
+}
+
+func progressTakeaway(unit string, buckets []AnalyticsProgressBucket, nameOf func(string) string) string {
+	best := -1
+	bestTotal := 0
+	for i, b := range buckets {
+		if b.Total > bestTotal {
+			bestTotal = b.Total
+			best = i
+		}
+	}
+	if best < 0 || bestTotal == 0 {
+		return "No completed tasks in this period yet."
+	}
+	b := buckets[best]
+	topName := ""
+	topCount := 0
+	for _, s := range b.Segments {
+		if s.Count > topCount {
+			topCount = s.Count
+			topName = s.Name
+		}
+	}
+	noun := map[string]string{"day": "day", "week": "week", "month": "month"}[unit]
+	if topName != "" {
+		return fmt.Sprintf("%s carried the %s: %d done, mostly %s.", b.Label, noun, bestTotal, topName)
+	}
+	return fmt.Sprintf("%s carried the %s with %d done.", b.Label, noun, bestTotal)
+}
+
+func computeShare(unit string, curStart time.Time, nb int, cur []AnalyticsTaskLite, orderedCats, top []string, topSet map[string]bool, colorByID map[string]string, nameOf func(string) string) AnalyticsCategoryShare {
+	counts := countByCategory(cur)
+	total := len(cur)
+
+	// Donut slices: top 6 categories, remainder grouped into Other.
+	slices := make([]AnalyticsShareSlice, 0, 7)
+	otherCount := 0
+	for i, cid := range orderedCats {
+		if i < 6 {
+			slices = append(slices, AnalyticsShareSlice{
+				CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid],
+				Count: counts[cid], Pct: float64(pctInt(counts[cid], total)),
+			})
+		} else {
+			otherCount += counts[cid]
+		}
+	}
+	if otherCount > 0 {
+		slices = append(slices, AnalyticsShareSlice{
+			CategoryID: otherID, Name: otherName, Color: otherColor,
+			Count: otherCount, Pct: float64(pctInt(otherCount, total)),
+		})
+	}
+
+	// Bands over time (month / sixmonth only).
+	var bands []AnalyticsShareBand
+	if unit == "week" || unit == "month" {
+		segCounts := make([]map[string]int, nb)
+		totals := make([]int, nb)
+		for i := 0; i < nb; i++ {
+			segCounts[i] = map[string]int{}
+		}
+		for _, t := range cur {
+			idx := bucketIndex(unit, curStart, t.CompletedAt)
+			if idx < 0 || idx >= nb {
+				continue
+			}
+			key := t.CategoryID
+			if !topSet[key] {
+				key = otherID
+			}
+			segCounts[idx][key]++
+			totals[idx]++
+		}
+		// Only emit bands when there's a per-bucket breakdown worth showing.
+		if unit == "month" {
+			bands = make([]AnalyticsShareBand, 0, nb)
+			for i := 0; i < nb; i++ {
+				band := AnalyticsShareBand{Label: bucketLabel(unit, curStart, i)}
+				for _, cid := range top {
+					if c := segCounts[i][cid]; c > 0 {
+						band.Slices = append(band.Slices, AnalyticsShareSlice{
+							CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid],
+							Count: c, Pct: float64(pctInt(c, totals[i])),
+						})
+					}
+				}
+				if c := segCounts[i][otherID]; c > 0 {
+					band.Slices = append(band.Slices, AnalyticsShareSlice{
+						CategoryID: otherID, Name: otherName, Color: otherColor,
+						Count: c, Pct: float64(pctInt(c, totals[i])),
+					})
+				}
+				bands = append(bands, band)
+			}
+		}
+	}
+
+	return AnalyticsCategoryShare{
+		Slices:   slices,
+		OverTime: bands,
+		Takeaway: shareTakeaway(slices),
+	}
+}
+
+func shareTakeaway(slices []AnalyticsShareSlice) string {
+	if len(slices) == 0 {
+		return "No category activity in this period yet."
+	}
+	top := slices[0]
+	if top.CategoryID == otherID {
+		return "Your focus was spread across several categories."
+	}
+	return fmt.Sprintf("%s led this period at %d%%.", top.Name, int(top.Pct))
+}
+
+func computeHeatmap(scoped []AnalyticsTaskLite, now time.Time) AnalyticsHeatmap {
+	end := startOfDay(now)
+	start := end.AddDate(0, 0, -(heatmapDays - 1))
+
+	counts := map[string]int{}
+	weekdayTotals := [7]int{}
+	total := 0
+	for _, t := range scoped {
+		d := startOfDay(t.CompletedAt)
+		if d.Before(start) || d.After(end) {
+			continue
+		}
+		key := d.Format("2006-01-02")
+		counts[key]++
+		weekdayTotals[int(d.Weekday())]++
+		total++
+	}
+
+	days := make([]AnalyticsHeatmapDay, 0, heatmapDays)
+	maxCount := 0
+	for i := 0; i < heatmapDays; i++ {
+		d := start.AddDate(0, 0, i)
+		key := d.Format("2006-01-02")
+		c := counts[key]
+		if c > maxCount {
+			maxCount = c
+		}
+		days = append(days, AnalyticsHeatmapDay{Date: key, Count: c, Level: levelForCount(c)})
+	}
+
+	return AnalyticsHeatmap{
+		Days:     days,
+		MaxCount: maxCount,
+		Total:    total,
+		Takeaway: heatmapTakeaway(weekdayTotals, total),
+	}
+}
+
+func heatmapTakeaway(weekdayTotals [7]int, total int) string {
+	if total == 0 {
+		return "No activity recorded yet."
+	}
+	type wd struct {
+		day   time.Weekday
+		count int
+	}
+	ranked := make([]wd, 0, 7)
+	for i := 0; i < 7; i++ {
+		ranked = append(ranked, wd{time.Weekday(i), weekdayTotals[i]})
+	}
+	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].count > ranked[j].count })
+	names := []string{}
+	for _, r := range ranked {
+		if r.count == 0 || len(names) >= 3 {
+			break
+		}
+		names = append(names, shortWeekday(r.day))
+	}
+	if len(names) == 0 {
+		return "No activity recorded yet."
+	}
+	return fmt.Sprintf("Most active on %s.", strings.Join(names, ", "))
+}
+
+func computeHabits(habits []AnalyticsHabitLite, inScope func(string) bool, curStart, curEnd time.Time) AnalyticsHabits {
+	rows := make([]AnalyticsHabitRow, 0, len(habits))
+	for _, h := range habits {
+		if h.CategoryID != "" && !inScope(h.CategoryID) {
+			continue
+		}
+		completed := 0
+		for _, d := range h.CompletionDates {
+			if !d.Before(curStart) && d.Before(curEnd) {
+				completed++
+			}
+		}
+		total := expectedOccurrences(h.Frequency, curStart, curEnd)
+		if total < completed {
+			total = completed
+		}
+		if total <= 0 {
+			total = maxInt(completed, 1)
+		}
+		row := AnalyticsHabitRow{
+			TemplateID:  h.TemplateID,
+			Title:       h.Title,
+			Frequency:   h.Frequency,
+			Completed:   completed,
+			Total:       total,
+			Dots:        buildDots(total, completed),
+			RhythmLabel: rhythmLabel(h.Frequency, h.Streak),
+			Status:      habitStatus(completed, total),
+		}
+		if h.NextDueAt != nil {
+			s := h.NextDueAt.Format(time.RFC3339)
+			row.NextDueAt = &s
+		}
+		rows = append(rows, row)
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		if rows[i].Completed != rows[j].Completed {
+			return rows[i].Completed > rows[j].Completed
+		}
+		return rows[i].Title < rows[j].Title
+	})
+	if len(rows) > 8 {
+		rows = rows[:8]
+	}
+
+	return AnalyticsHabits{Rows: rows, Takeaway: habitsTakeaway(rows)}
+}
+
+func expectedOccurrences(freq string, start, end time.Time) int {
+	days := int(end.Sub(start).Hours() / 24)
+	if days < 1 {
+		days = 1
+	}
+	switch strings.ToLower(freq) {
+	case "daily":
+		return days
+	case "weekly":
+		return maxInt(days/7, 1)
+	case "monthly":
+		return maxInt(days/30, 1)
+	default:
+		return days
+	}
+}
+
+func buildDots(total, completed int) []bool {
+	n := minInt(total, 12)
+	if n <= 0 {
+		return []bool{}
+	}
+	filled := minInt(completed, n)
+	dots := make([]bool, n)
+	for i := 0; i < filled; i++ {
+		dots[i] = true
+	}
+	return dots
+}
+
+func rhythmLabel(freq string, streak int) string {
+	if streak <= 0 {
+		return "Needs a reset"
+	}
+	switch strings.ToLower(freq) {
+	case "daily":
+		return fmt.Sprintf("%d-day run", streak)
+	case "weekly":
+		return fmt.Sprintf("%d weeks consistent", streak)
+	case "monthly":
+		return fmt.Sprintf("%d months kept up", streak)
+	default:
+		return fmt.Sprintf("%d kept up", streak)
+	}
+}
+
+func habitStatus(completed, total int) string {
+	if completed == 0 {
+		return "light"
+	}
+	ratio := float64(completed) / float64(total)
+	switch {
+	case ratio >= 1:
+		return "healthy"
+	case ratio >= 0.6:
+		return "steady"
+	default:
+		return "needs-reset"
+	}
+}
+
+func habitsTakeaway(rows []AnalyticsHabitRow) string {
+	if len(rows) == 0 {
+		return "No recurring tasks yet."
+	}
+	// Strongest = highest streak (parsed from completed ordering is by completed;
+	// pick the row whose status is healthy, else the first row).
+	strongest := rows[0]
+	for _, r := range rows {
+		if r.Status == "healthy" {
+			strongest = r
+			break
+		}
+	}
+	for _, r := range rows {
+		if r.Status == "needs-reset" {
+			return fmt.Sprintf("%s is your strongest rhythm. %s needs a reset.", strongest.Title, r.Title)
+		}
+	}
+	return fmt.Sprintf("%s is your strongest rhythm.", strongest.Title)
+}
+
+func computeCategoryHealth(unit string, curStart time.Time, nb int, cur []AnalyticsTaskLite, orderedCats []string, colorByID map[string]string, nameOf func(string) string, workspaceOf func(string) string) AnalyticsCategoryHealth {
+	rows := make([]AnalyticsCategoryHealthRow, 0, len(orderedCats))
+	for _, cid := range orderedCats {
+		catTasks := make([]AnalyticsTaskLite, 0)
+		spark := make([]int, nb)
+		for _, t := range cur {
+			if t.CategoryID != cid {
+				continue
+			}
+			catTasks = append(catTasks, t)
+			if idx := bucketIndex(unit, curStart, t.CompletedAt); idx >= 0 && idx < nb {
+				spark[idx]++
+			}
+		}
+		done := len(catTasks)
+		if done == 0 {
+			continue
+		}
+		wd, ot := onTimeStats(catTasks)
+		onTimePct := pctInt(ot, wd)
+		kudos := sumKudos(catTasks)
+		rows = append(rows, AnalyticsCategoryHealthRow{
+			CategoryID: cid,
+			Name:       nameOf(cid),
+			Workspace:  workspaceOf(cid),
+			Color:      colorByID[cid],
+			Done:       done,
+			OnTimePct:  onTimePct,
+			Kudos:      kudos,
+			Status:     healthStatus(done, wd, onTimePct),
+			Sparkline:  spark,
+		})
+	}
+
+	sort.SliceStable(rows, func(i, j int) bool {
+		si, sj := statusSeverity(rows[i].Status), statusSeverity(rows[j].Status)
+		if si != sj {
+			return si > sj
+		}
+		return rows[i].Done > rows[j].Done
+	})
+	if len(rows) > 8 {
+		rows = rows[:8]
+	}
+	return AnalyticsCategoryHealth{Rows: rows}
+}
+
+func healthStatus(done, withDeadline, onTimePct int) string {
+	if done == 0 {
+		return "light"
+	}
+	if withDeadline == 0 {
+		return "steady" // no deadlines to judge timing against
+	}
+	switch {
+	case onTimePct >= 85:
+		return "healthy"
+	case onTimePct >= 70:
+		return "steady"
+	case onTimePct >= 50:
+		return "needs-attention"
+	default:
+		return "slipping"
+	}
+}
+
+func statusSeverity(status string) int {
+	switch status {
+	case "slipping":
+		return 4
+	case "needs-attention", "needs-reset":
+		return 3
+	case "steady":
+		return 2
+	case "healthy":
+		return 1
+	default: // light
+		return 0
+	}
+}
+
+func computeWorkspaceHealth(cur []AnalyticsTaskLite, workspaceOf func(string) string) AnalyticsWorkspaceHealth {
+	type agg struct {
+		done         int
+		withDeadline int
+		onTime       int
+		kudos        int
+	}
+	byWs := map[string]*agg{}
+	order := []string{}
+	for _, t := range cur {
+		ws := workspaceOf(t.CategoryID)
+		if ws == "" {
+			ws = "Other"
+		}
+		a, ok := byWs[ws]
+		if !ok {
+			a = &agg{}
+			byWs[ws] = a
+			order = append(order, ws)
+		}
+		a.done++
+		a.kudos += t.KudosCount
+		if t.Deadline != nil {
+			a.withDeadline++
+			if !t.CompletedAt.After(*t.Deadline) {
+				a.onTime++
+			}
+		}
+	}
+
+	rows := make([]AnalyticsWorkspaceHealthRow, 0, len(order))
+	for _, ws := range order {
+		a := byWs[ws]
+		onTimePct := pctInt(a.onTime, a.withDeadline)
+		rows = append(rows, AnalyticsWorkspaceHealthRow{
+			Workspace: ws,
+			Done:      a.done,
+			OnTimePct: onTimePct,
+			Kudos:     a.kudos,
+			Status:    healthStatus(a.done, a.withDeadline, onTimePct),
+		})
+	}
+	sort.SliceStable(rows, func(i, j int) bool { return rows[i].Done > rows[j].Done })
+	return AnalyticsWorkspaceHealth{Rows: rows}
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/backend/internal/handlers/analytics/compute_test.go
+++ b/backend/internal/handlers/analytics/compute_test.go
@@ -1,0 +1,303 @@
+package analytics
+
+import (
+	"testing"
+	"time"
+)
+
+// fixedNow is a Wednesday (2025-05-14) used as "now" across tests so week/month
+// math is deterministic.
+var fixedNow = time.Date(2025, 5, 14, 12, 0, 0, 0, time.UTC)
+
+func ptr(t time.Time) *time.Time { return &t }
+
+func task(catID string, completed time.Time, deadline *time.Time, kudos int) AnalyticsTaskLite {
+	return AnalyticsTaskLite{CategoryID: catID, CompletedAt: completed, Deadline: deadline, KudosCount: kudos}
+}
+
+func baseCategories() []AnalyticsCategoryMeta {
+	return []AnalyticsCategoryMeta{
+		{ID: "school", Name: "School", Workspace: "Academics"},
+		{ID: "intern", Name: "Internship", Workspace: "Work"},
+		{ID: "gym", Name: "Gym", Workspace: "Personal"},
+	}
+}
+
+func TestWindowBounds_Week(t *testing.T) {
+	curStart, curEnd, prevStart, prevEnd, unit := windowBounds(RangeWeek, fixedNow)
+	if unit != "day" {
+		t.Fatalf("unit = %q, want day", unit)
+	}
+	// 2025-05-14 is a Wednesday; Monday of that week is 2025-05-12.
+	if got := curStart.Format("2006-01-02"); got != "2025-05-12" {
+		t.Errorf("curStart = %s, want 2025-05-12", got)
+	}
+	if got := curEnd.Format("2006-01-02"); got != "2025-05-19" {
+		t.Errorf("curEnd = %s, want 2025-05-19", got)
+	}
+	if got := prevStart.Format("2006-01-02"); got != "2025-05-05" {
+		t.Errorf("prevStart = %s, want 2025-05-05", got)
+	}
+	if !prevEnd.Equal(curStart) {
+		t.Errorf("prevEnd should equal curStart")
+	}
+}
+
+func TestWindowBounds_Month(t *testing.T) {
+	curStart, curEnd, prevStart, _, unit := windowBounds(RangeMonth, fixedNow)
+	if unit != "week" {
+		t.Fatalf("unit = %q, want week", unit)
+	}
+	if got := curStart.Format("2006-01-02"); got != "2025-05-01" {
+		t.Errorf("curStart = %s, want 2025-05-01", got)
+	}
+	if got := curEnd.Format("2006-01-02"); got != "2025-06-01" {
+		t.Errorf("curEnd = %s, want 2025-06-01", got)
+	}
+	if got := prevStart.Format("2006-01-02"); got != "2025-04-01" {
+		t.Errorf("prevStart = %s, want 2025-04-01", got)
+	}
+}
+
+func TestLevelForCount(t *testing.T) {
+	cases := map[int]int{0: 0, 1: 1, 2: 1, 3: 2, 4: 2, 5: 3, 6: 3, 7: 4, 20: 4}
+	for in, want := range cases {
+		if got := levelForCount(in); got != want {
+			t.Errorf("levelForCount(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestPctChangeAndPctInt(t *testing.T) {
+	if got := pctChange(0, 0); got != 0 {
+		t.Errorf("pctChange(0,0) = %v, want 0", got)
+	}
+	if got := pctChange(0, 5); got != 100 {
+		t.Errorf("pctChange(0,5) = %v, want 100", got)
+	}
+	if got := pctChange(10, 12); got != 20 {
+		t.Errorf("pctChange(10,12) = %v, want 20", got)
+	}
+	if got := pctInt(2, 4); got != 50 {
+		t.Errorf("pctInt(2,4) = %d, want 50", got)
+	}
+	if got := pctInt(1, 0); got != 0 {
+		t.Errorf("pctInt(1,0) = %d, want 0", got)
+	}
+}
+
+func TestComputeSignals_MomentumTimingSupport(t *testing.T) {
+	// 3 done this week, 2 on time of 2 with deadlines.
+	on := fixedNow
+	dl := ptr(fixedNow.Add(24 * time.Hour)) // deadline in the future => on time
+	cur := []AnalyticsTaskLite{
+		task("school", on, dl, 1),
+		task("school", on, dl, 0),
+		task("gym", on, nil, 0),
+	}
+	prev := []AnalyticsTaskLite{task("school", on.AddDate(0, 0, -7), nil, 0)} // 1 prev
+
+	sig := computeSignals(RangeWeek, cur, prev, 5, 3)
+	if sig.Momentum.RawValue != 3 {
+		t.Errorf("momentum raw = %v, want 3", sig.Momentum.RawValue)
+	}
+	if sig.Momentum.Value != "3 done" {
+		t.Errorf("momentum value = %q", sig.Momentum.Value)
+	}
+	// 1 -> 3 is +200%
+	if sig.Momentum.Delta != 200 {
+		t.Errorf("momentum delta = %v, want 200", sig.Momentum.Delta)
+	}
+	if sig.Timing.Value != "100%" {
+		t.Errorf("timing value = %q, want 100%%", sig.Timing.Value)
+	}
+	if sig.Support.Value != "5 Kudos" {
+		t.Errorf("support value = %q, want 5 Kudos", sig.Support.Value)
+	}
+	if sig.Support.DeltaLabel != "+2 vs last week" {
+		t.Errorf("support delta label = %q", sig.Support.DeltaLabel)
+	}
+}
+
+func TestComputeAnalytics_WeekProgressBucketsAndShare(t *testing.T) {
+	mon := time.Date(2025, 5, 12, 9, 0, 0, 0, time.UTC) // Monday
+	tue := time.Date(2025, 5, 13, 9, 0, 0, 0, time.UTC)
+	completed := []AnalyticsTaskLite{
+		task("school", mon, nil, 0),
+		task("school", tue, nil, 1),
+		task("intern", tue, nil, 0),
+		task("gym", mon, nil, 0),
+	}
+	in := computeInput{
+		Range:      RangeWeek,
+		Now:        fixedNow,
+		Completed:  completed,
+		Categories: baseCategories(),
+	}
+	resp := computeAnalytics(in)
+
+	if resp.Progress.Total != 4 {
+		t.Fatalf("progress total = %d, want 4", resp.Progress.Total)
+	}
+	if resp.Progress.BucketUnit != "day" {
+		t.Errorf("bucket unit = %q, want day", resp.Progress.BucketUnit)
+	}
+	if len(resp.Progress.Buckets) != 7 {
+		t.Fatalf("want 7 day buckets, got %d", len(resp.Progress.Buckets))
+	}
+	// Monday is bucket 0 with 2 done; Tuesday bucket 1 with 2 done.
+	if resp.Progress.Buckets[0].Total != 2 {
+		t.Errorf("Mon total = %d, want 2", resp.Progress.Buckets[0].Total)
+	}
+	if resp.Progress.Buckets[1].Total != 2 {
+		t.Errorf("Tue total = %d, want 2", resp.Progress.Buckets[1].Total)
+	}
+	// Share: school leads with 2/4 = 50%.
+	if len(resp.CategoryShare.Slices) == 0 || resp.CategoryShare.Slices[0].Name != "School" {
+		t.Fatalf("expected School to lead share, got %+v", resp.CategoryShare.Slices)
+	}
+	if resp.CategoryShare.Slices[0].Pct != 50 {
+		t.Errorf("School share = %v, want 50", resp.CategoryShare.Slices[0].Pct)
+	}
+}
+
+func TestComputeAnalytics_WorkspaceFilter(t *testing.T) {
+	mon := time.Date(2025, 5, 12, 9, 0, 0, 0, time.UTC)
+	completed := []AnalyticsTaskLite{
+		task("school", mon, nil, 0),
+		task("intern", mon, nil, 0),
+		task("gym", mon, nil, 0),
+	}
+	in := computeInput{
+		Range:           RangeWeek,
+		Now:             fixedNow,
+		WorkspaceFilter: "Work",
+		Completed:       completed,
+		Categories:      baseCategories(),
+	}
+	resp := computeAnalytics(in)
+	if resp.Progress.Total != 1 {
+		t.Errorf("with Work filter, total = %d, want 1 (only Internship)", resp.Progress.Total)
+	}
+	if len(resp.CategoryShare.Slices) != 1 || resp.CategoryShare.Slices[0].Name != "Internship" {
+		t.Errorf("expected only Internship slice, got %+v", resp.CategoryShare.Slices)
+	}
+}
+
+func TestComputeCategoryHealth_StatusFromOnTime(t *testing.T) {
+	mon := time.Date(2025, 5, 12, 9, 0, 0, 0, time.UTC)
+	late := ptr(mon.Add(-time.Hour))  // completed after deadline => late
+	onTime := ptr(mon.Add(time.Hour)) // completed before deadline => on time
+	completed := []AnalyticsTaskLite{
+		// school: 1 on-time of 1 with deadline => 100% healthy
+		task("school", mon, onTime, 1),
+		// intern: 0 on-time of 1 => 0% slipping
+		task("intern", mon, late, 0),
+	}
+	in := computeInput{Range: RangeWeek, Now: fixedNow, Completed: completed, Categories: baseCategories()}
+	resp := computeAnalytics(in)
+
+	got := map[string]string{}
+	for _, r := range resp.CategoryHealth.Rows {
+		got[r.Name] = r.Status
+	}
+	if got["School"] != "healthy" {
+		t.Errorf("School status = %q, want healthy", got["School"])
+	}
+	if got["Internship"] != "slipping" {
+		t.Errorf("Internship status = %q, want slipping", got["Internship"])
+	}
+	// Slipping should sort above healthy.
+	if resp.CategoryHealth.Rows[0].Name != "Internship" {
+		t.Errorf("expected Internship (slipping) first, got %q", resp.CategoryHealth.Rows[0].Name)
+	}
+}
+
+func TestComputeHabits_NoStreakWordAndRhythm(t *testing.T) {
+	d := func(day int) time.Time { return time.Date(2025, 5, day, 8, 0, 0, 0, time.UTC) }
+	habits := []AnalyticsHabitLite{
+		{
+			TemplateID:      "gym",
+			Title:           "Gym",
+			Frequency:       "weekly",
+			Streak:          9,
+			CompletionDates: []time.Time{d(12)},
+		},
+		{
+			TemplateID:      "budget",
+			Title:           "Budget Check-in",
+			Frequency:       "weekly",
+			Streak:          0,
+			CompletionDates: []time.Time{},
+		},
+	}
+	in := computeInput{Range: RangeWeek, Now: fixedNow, Habits: habits, Categories: baseCategories()}
+	resp := computeAnalytics(in)
+
+	if len(resp.Habits.Rows) != 2 {
+		t.Fatalf("want 2 habit rows, got %d", len(resp.Habits.Rows))
+	}
+	for _, r := range resp.Habits.Rows {
+		if containsStreak(r.RhythmLabel) {
+			t.Errorf("rhythm label %q must not contain the word streak", r.RhythmLabel)
+		}
+	}
+	if containsStreak(resp.Habits.Takeaway) {
+		t.Errorf("habits takeaway %q must not contain the word streak", resp.Habits.Takeaway)
+	}
+	// Gym kept its weekly rhythm => label mentions weeks consistent.
+	var gym AnalyticsHabitRow
+	for _, r := range resp.Habits.Rows {
+		if r.Title == "Gym" {
+			gym = r
+		}
+	}
+	if gym.RhythmLabel != "9 weeks consistent" {
+		t.Errorf("gym rhythm = %q, want '9 weeks consistent'", gym.RhythmLabel)
+	}
+}
+
+func TestComputeHeatmap_TrailingWindow(t *testing.T) {
+	completed := []AnalyticsTaskLite{
+		task("school", fixedNow, nil, 0),
+		task("school", fixedNow.AddDate(0, 0, -1), nil, 0),
+		task("school", fixedNow.AddDate(0, 0, -200), nil, 0), // outside 91d window
+	}
+	in := computeInput{Range: RangeWeek, Now: fixedNow, Completed: completed, Categories: baseCategories()}
+	resp := computeAnalytics(in)
+	if len(resp.Heatmap.Days) != heatmapDays {
+		t.Fatalf("heatmap days = %d, want %d", len(resp.Heatmap.Days), heatmapDays)
+	}
+	if resp.Heatmap.Total != 2 {
+		t.Errorf("heatmap total = %d, want 2 (the 200-day-old task excluded)", resp.Heatmap.Total)
+	}
+}
+
+func containsStreak(s string) bool {
+	lower := []rune(s)
+	_ = lower
+	return indexFold(s, "streak") >= 0
+}
+
+// indexFold is a tiny case-insensitive substring search to avoid importing
+// strings just for the test assertion intent.
+func indexFold(haystack, needle string) int {
+	h := toLower(haystack)
+	n := toLower(needle)
+	for i := 0; i+len(n) <= len(h); i++ {
+		if h[i:i+len(n)] == n {
+			return i
+		}
+	}
+	return -1
+}
+
+func toLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] = c + 32
+		}
+	}
+	return string(b)
+}

--- a/backend/internal/handlers/analytics/service.go
+++ b/backend/internal/handlers/analytics/service.go
@@ -1,0 +1,187 @@
+package analytics
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/abhikaboy/Kindred/internal/handlers/types"
+	"github.com/abhikaboy/Kindred/xutils"
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Service loads the raw corpus for a user and delegates the math to the pure
+// computeAnalytics function so the heavy logic stays unit-testable.
+type Service struct {
+	Completed      *mongo.Collection
+	Categories     *mongo.Collection
+	Templates      *mongo.Collection
+	Encouragements *mongo.Collection
+}
+
+func newService(collections map[string]*mongo.Collection) *Service {
+	return &Service{
+		Completed:      collections["completed-tasks"],
+		Categories:     collections["categories"],
+		Templates:      collections["template-tasks"],
+		Encouragements: collections["encouragements"],
+	}
+}
+
+// GetAnalytics builds the widget-ready dashboard payload for one user.
+func (s *Service) GetAnalytics(userID primitive.ObjectID, rng, workspace, category string) (AnalyticsResponse, error) {
+	ctx := context.Background()
+	now := xutils.NowUTC()
+
+	curStart, curEnd, prevStart, prevEnd, _ := windowBounds(rng, now)
+
+	// Load completed tasks back to the earliest window we need (the heatmap
+	// reaches further back than the previous period for short ranges).
+	loadStart := prevStart
+	if hm := startOfDay(now).AddDate(0, 0, -(heatmapDays - 1)); hm.Before(loadStart) {
+		loadStart = hm
+	}
+
+	completed, err := s.loadCompleted(ctx, userID, loadStart)
+	if err != nil {
+		return AnalyticsResponse{}, err
+	}
+	categories, err := s.loadCategories(ctx, userID)
+	if err != nil {
+		return AnalyticsResponse{}, err
+	}
+	habits, err := s.loadHabits(ctx, userID)
+	if err != nil {
+		return AnalyticsResponse{}, err
+	}
+	supportCur := s.countSupport(ctx, userID, curStart, curEnd)
+	supportPrev := s.countSupport(ctx, userID, prevStart, prevEnd)
+
+	in := computeInput{
+		Range:           rng,
+		Now:             now,
+		WorkspaceFilter: workspace,
+		CategoryFilter:  category,
+		Completed:       completed,
+		Categories:      categories,
+		Habits:          habits,
+		SupportCurrent:  supportCur,
+		SupportPrev:     supportPrev,
+	}
+	return computeAnalytics(in), nil
+}
+
+func (s *Service) loadCompleted(ctx context.Context, userID primitive.ObjectID, since time.Time) ([]AnalyticsTaskLite, error) {
+	if s.Completed == nil {
+		return nil, nil
+	}
+	filter := bson.M{
+		"user":          userID,
+		"timeCompleted": bson.M{"$gte": since},
+	}
+	cursor, err := s.Completed.Find(ctx, filter)
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	out := []AnalyticsTaskLite{}
+	for cursor.Next(ctx) {
+		var t types.TaskDocument
+		if err := cursor.Decode(&t); err != nil {
+			slog.Warn("analytics: skipping undecodable completed task", "error", err)
+			continue
+		}
+		if t.TimeCompleted == nil {
+			continue
+		}
+		catID := ""
+		if !t.CategoryID.IsZero() {
+			catID = t.CategoryID.Hex()
+		}
+		out = append(out, AnalyticsTaskLite{
+			CategoryID:  catID,
+			CompletedAt: t.TimeCompleted.UTC(),
+			Deadline:    t.Deadline,
+			KudosCount:  len(t.Encouragements),
+		})
+	}
+	return out, cursor.Err()
+}
+
+func (s *Service) loadCategories(ctx context.Context, userID primitive.ObjectID) ([]AnalyticsCategoryMeta, error) {
+	if s.Categories == nil {
+		return nil, nil
+	}
+	cursor, err := s.Categories.Find(ctx, bson.M{"user": userID})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	out := []AnalyticsCategoryMeta{}
+	for cursor.Next(ctx) {
+		var c types.CategoryDocument
+		if err := cursor.Decode(&c); err != nil {
+			slog.Warn("analytics: skipping undecodable category", "error", err)
+			continue
+		}
+		out = append(out, AnalyticsCategoryMeta{
+			ID:        c.ID.Hex(),
+			Name:      c.Name,
+			Workspace: c.WorkspaceName,
+		})
+	}
+	return out, cursor.Err()
+}
+
+func (s *Service) loadHabits(ctx context.Context, userID primitive.ObjectID) ([]AnalyticsHabitLite, error) {
+	if s.Templates == nil {
+		return nil, nil
+	}
+	cursor, err := s.Templates.Find(ctx, bson.M{"userID": userID})
+	if err != nil {
+		return nil, err
+	}
+	defer cursor.Close(ctx)
+
+	out := []AnalyticsHabitLite{}
+	for cursor.Next(ctx) {
+		var t types.TemplateTaskDocument
+		if err := cursor.Decode(&t); err != nil {
+			slog.Warn("analytics: skipping undecodable template", "error", err)
+			continue
+		}
+		catID := ""
+		if !t.CategoryID.IsZero() {
+			catID = t.CategoryID.Hex()
+		}
+		out = append(out, AnalyticsHabitLite{
+			TemplateID:      t.ID.Hex(),
+			CategoryID:      catID,
+			Title:           t.Content,
+			Frequency:       t.RecurFrequency,
+			Streak:          t.Streak,
+			CompletionDates: t.CompletionDates,
+			NextDueAt:       t.NextGenerated,
+		})
+	}
+	return out, cursor.Err()
+}
+
+func (s *Service) countSupport(ctx context.Context, userID primitive.ObjectID, start, end time.Time) int {
+	if s.Encouragements == nil {
+		return 0
+	}
+	count, err := s.Encouragements.CountDocuments(ctx, bson.M{
+		"receiver":  userID,
+		"timestamp": bson.M{"$gte": start, "$lt": end},
+	})
+	if err != nil {
+		slog.Warn("analytics: support count failed", "error", err)
+		return 0
+	}
+	return int(count)
+}

--- a/backend/internal/handlers/analytics/types.go
+++ b/backend/internal/handlers/analytics/types.go
@@ -1,0 +1,206 @@
+package analytics
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"go.mongodb.org/mongo-driver/mongo"
+)
+
+// Range values accepted by the analytics endpoint.
+const (
+	RangeWeek     = "week"
+	RangeMonth    = "month"
+	RangeSixMonth = "sixmonth"
+)
+
+// GetAnalyticsInput is the request for the dashboard endpoint. All filters are
+// optional; an empty workspace/category means "all".
+type GetAnalyticsInput struct {
+	Range     string `query:"range" enum:"week,month,sixmonth" default:"week" doc:"Time range: week, month, or sixmonth"`
+	Workspace string `query:"workspace" doc:"Workspace name filter (optional; empty = all workspaces)"`
+	Category  string `query:"category" doc:"Category ID filter (optional; empty = all categories)"`
+}
+
+type GetAnalyticsOutput struct {
+	Body AnalyticsResponse `json:"body"`
+}
+
+// AnalyticsResponse is the single widget-ready payload for the dashboard. Each
+// field maps to one widget; the frontend renders without any extra computation.
+type AnalyticsResponse struct {
+	Range           string                   `json:"range"`
+	WorkspaceFilter string                   `json:"workspaceFilter,omitempty"`
+	CategoryFilter  string                   `json:"categoryFilter,omitempty"`
+	GeneratedAt     time.Time                `json:"generatedAt"`
+	Signals         AnalyticsSignals         `json:"signals"`
+	Progress        AnalyticsProgress        `json:"progress"`
+	CategoryShare   AnalyticsCategoryShare   `json:"categoryShare"`
+	Heatmap         AnalyticsHeatmap         `json:"heatmap"`
+	Habits          AnalyticsHabits          `json:"habits"`
+	CategoryHealth  AnalyticsCategoryHealth  `json:"categoryHealth"`
+	WorkspaceHealth AnalyticsWorkspaceHealth `json:"workspaceHealth"`
+}
+
+// AnalyticsSignal is one stat in the signal strip (momentum / timing / support).
+type AnalyticsSignal struct {
+	Label      string  `json:"label"`
+	Value      string  `json:"value"`      // formatted, e.g. "34 done", "81%", "27 Kudos"
+	RawValue   float64 `json:"rawValue"`   // numeric for client-side comparisons
+	Delta      float64 `json:"delta"`      // signed delta vs the previous comparable period
+	DeltaLabel string  `json:"deltaLabel"` // e.g. "+18% vs last week", "+9 pts"
+	Direction  string  `json:"direction"`  // up | down | flat
+}
+
+type AnalyticsSignals struct {
+	Momentum AnalyticsSignal `json:"momentum"`
+	Timing   AnalyticsSignal `json:"timing"`
+	Support  AnalyticsSignal `json:"support"`
+}
+
+// AnalyticsProgressSegment is one category's slice of a single stacked bar.
+type AnalyticsProgressSegment struct {
+	CategoryID string `json:"categoryId"`
+	Name       string `json:"name"`
+	Color      string `json:"color"`
+	Count      int    `json:"count"`
+}
+
+// AnalyticsProgressBucket is one bar (a day, week, or month).
+type AnalyticsProgressBucket struct {
+	Label    string                     `json:"label"`
+	Date     string                     `json:"date"` // ISO date of bucket start (YYYY-MM-DD)
+	Total    int                        `json:"total"`
+	Segments []AnalyticsProgressSegment `json:"segments"`
+}
+
+type AnalyticsLegendItem struct {
+	CategoryID string `json:"categoryId"`
+	Name       string `json:"name"`
+	Color      string `json:"color"`
+}
+
+// AnalyticsProgress backs the stacked-bar Weekly/Monthly Progress widget.
+type AnalyticsProgress struct {
+	Total      int                       `json:"total"`
+	PrevTotal  int                       `json:"prevTotal"`
+	Delta      float64                   `json:"delta"`      // percent change vs previous period
+	BucketUnit string                    `json:"bucketUnit"` // day | week | month
+	Buckets    []AnalyticsProgressBucket `json:"buckets"`
+	Legend     []AnalyticsLegendItem     `json:"legend"`
+	Takeaway   string                    `json:"takeaway"`
+}
+
+// AnalyticsShareSlice is one wedge of the category-share donut.
+type AnalyticsShareSlice struct {
+	CategoryID string  `json:"categoryId"`
+	Name       string  `json:"name"`
+	Color      string  `json:"color"`
+	Count      int     `json:"count"`
+	Pct        float64 `json:"pct"`
+}
+
+// AnalyticsShareBand is one column of the 100% stacked band (per week/month).
+type AnalyticsShareBand struct {
+	Label  string                `json:"label"`
+	Slices []AnalyticsShareSlice `json:"slices"`
+}
+
+type AnalyticsCategoryShare struct {
+	Slices   []AnalyticsShareSlice `json:"slices"`
+	OverTime []AnalyticsShareBand  `json:"overTime"`
+	Takeaway string                `json:"takeaway"`
+}
+
+// AnalyticsHeatmapDay is one cell of the activity heatmap.
+type AnalyticsHeatmapDay struct {
+	Date  string `json:"date"` // YYYY-MM-DD
+	Count int    `json:"count"`
+	Level int    `json:"level"` // 0-4
+}
+
+type AnalyticsHeatmap struct {
+	Days     []AnalyticsHeatmapDay `json:"days"`
+	MaxCount int                   `json:"maxCount"`
+	Total    int                   `json:"total"`
+	Takeaway string                `json:"takeaway"`
+}
+
+// AnalyticsHabitRow is one recurring task in the Habits widget. Copy never uses
+// the word "streak" (see RhythmLabel).
+type AnalyticsHabitRow struct {
+	TemplateID  string  `json:"templateId"`
+	Title       string  `json:"title"`
+	Frequency   string  `json:"frequency"`
+	Completed   int     `json:"completed"`
+	Total       int     `json:"total"`
+	Dots        []bool  `json:"dots"`
+	NextDueAt   *string `json:"nextDueAt,omitempty"`
+	RhythmLabel string  `json:"rhythmLabel"`
+	Status      string  `json:"status"` // healthy | steady | needs-reset | light
+}
+
+type AnalyticsHabits struct {
+	Rows     []AnalyticsHabitRow `json:"rows"`
+	Takeaway string              `json:"takeaway"`
+}
+
+// AnalyticsCategoryHealthRow is one row of the Category Health diagnostic.
+type AnalyticsCategoryHealthRow struct {
+	CategoryID string `json:"categoryId"`
+	Name       string `json:"name"`
+	Workspace  string `json:"workspace"`
+	Color      string `json:"color"`
+	Done       int    `json:"done"`
+	OnTimePct  int    `json:"onTimePct"`
+	Kudos      int    `json:"kudos"`
+	Status     string `json:"status"` // healthy | steady | needs-attention | slipping | unsupported | light
+	Sparkline  []int  `json:"sparkline"`
+}
+
+type AnalyticsCategoryHealth struct {
+	Rows []AnalyticsCategoryHealthRow `json:"rows"`
+}
+
+// AnalyticsWorkspaceHealthRow is one row of the Workspace Health navigation widget.
+type AnalyticsWorkspaceHealthRow struct {
+	Workspace string `json:"workspace"`
+	Done      int    `json:"done"`
+	OnTimePct int    `json:"onTimePct"`
+	Kudos     int    `json:"kudos"`
+	Status    string `json:"status"`
+}
+
+type AnalyticsWorkspaceHealth struct {
+	Rows []AnalyticsWorkspaceHealthRow `json:"rows"`
+}
+
+// --- handler wiring (kept here so the package reads top-down) ---
+
+type Handler struct {
+	service *Service
+}
+
+func newHandler(service *Service) *Handler {
+	return &Handler{service: service}
+}
+
+// RegisterGetAnalyticsOperation registers GET /v1/user/analytics.
+func RegisterGetAnalyticsOperation(api huma.API, handler *Handler) {
+	huma.Register(api, huma.Operation{
+		OperationID: "get-analytics",
+		Method:      http.MethodGet,
+		Path:        "/v1/user/analytics",
+		Summary:     "Get analytics dashboard",
+		Description: "Returns the widget-ready analytics payload for the authenticated user, filtered by range, workspace, and category.",
+		Tags:        []string{"Analytics"},
+	}, handler.GetAnalytics)
+}
+
+// Routes wires the analytics handler into the API.
+func Routes(api huma.API, collections map[string]*mongo.Collection) {
+	service := newService(collections)
+	handler := newHandler(service)
+	RegisterGetAnalyticsOperation(api, handler)
+}

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/abhikaboy/Kindred/internal/config"
 	"github.com/abhikaboy/Kindred/internal/gemini"
 	activity "github.com/abhikaboy/Kindred/internal/handlers/activity"
+	analytics "github.com/abhikaboy/Kindred/internal/handlers/analytics"
 	"github.com/abhikaboy/Kindred/internal/handlers/auth"
 	Blueprint "github.com/abhikaboy/Kindred/internal/handlers/blueprint"
 	"github.com/abhikaboy/Kindred/internal/handlers/calendar"
@@ -141,6 +142,7 @@ func New(collections map[string]*mongo.Collection, stream *mongo.ChangeStream, g
 	auth.Routes(api, collections)
 	category.Routes(api, collections)
 	activity.Routes(api, collections)
+	analytics.Routes(api, collections)
 	profile.Routes(api, collections, ringService)
 	taskService := task.Routes(api, collections, geminiService, ringService)
 

--- a/frontend/__tests__/AnalyticsWidgets.test.tsx
+++ b/frontend/__tests__/AnalyticsWidgets.test.tsx
@@ -1,0 +1,109 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+
+// analyticsLayout imports AsyncStorage; stub it so the native module isn't touched.
+jest.mock("@react-native-async-storage/async-storage", () => ({
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    clear: jest.fn(() => Promise.resolve()),
+}));
+
+import { SignalStrip } from "@/components/analytics/SignalStrip";
+import { StatusPill } from "@/components/analytics/StatusPill";
+import {
+    moveItem,
+    sanitizeOrder,
+    isWidgetId,
+    DEFAULT_WIDGET_ORDER,
+} from "@/components/analytics/analyticsLayout";
+import {
+    statusLabel,
+    statusColor,
+    heatmapLevelColor,
+    directionColor,
+} from "@/components/analytics/analyticsColors";
+import type { AnalyticsSignals } from "@/api/analytics";
+
+const themed: any = {
+    primary: "#854DFF",
+    success: "#22C55E",
+    error: "#FF5C5F",
+    warning: "#F59E0B",
+    caption: "#919090",
+    lightened: "#171626",
+};
+
+describe("analyticsLayout", () => {
+    test("moveItem reorders without mutating the input", () => {
+        const arr = ["a", "b", "c"];
+        const moved = moveItem(arr, 0, 2);
+        expect(moved).toEqual(["b", "c", "a"]);
+        expect(arr).toEqual(["a", "b", "c"]);
+    });
+
+    test("moveItem ignores out-of-range moves", () => {
+        expect(moveItem(["a", "b"], 0, 5)).toEqual(["a", "b"]);
+    });
+
+    test("sanitizeOrder drops unknowns and appends new widgets", () => {
+        const result = sanitizeOrder(["heatmap", "bogus", "signals"]);
+        expect(result.slice(0, 2)).toEqual(["heatmap", "signals"]);
+        // every default widget ends up present exactly once
+        expect(new Set(result)).toEqual(new Set(DEFAULT_WIDGET_ORDER));
+        expect(result).toHaveLength(DEFAULT_WIDGET_ORDER.length);
+    });
+
+    test("isWidgetId validates membership", () => {
+        expect(isWidgetId("progress")).toBe(true);
+        expect(isWidgetId("nope")).toBe(false);
+    });
+});
+
+describe("analyticsColors", () => {
+    test("statusLabel maps kebab statuses to friendly copy", () => {
+        expect(statusLabel("needs-attention")).toBe("Needs attention");
+        expect(statusLabel("needs-reset")).toBe("Needs a reset");
+        expect(statusLabel("healthy")).toBe("Healthy");
+    });
+
+    test("statusColor distinguishes slipping from healthy", () => {
+        expect(statusColor("slipping", themed)).toBe(themed.error);
+        expect(statusColor("healthy", themed)).toBe(themed.success);
+    });
+
+    test("heatmap level 0 is empty surface, level 4 is full primary", () => {
+        expect(heatmapLevelColor(0, themed)).toBe(themed.lightened);
+        expect(heatmapLevelColor(4, themed)).toBe(themed.primary);
+        expect(heatmapLevelColor(0, themed)).not.toBe(heatmapLevelColor(4, themed));
+    });
+
+    test("directionColor reflects trend", () => {
+        expect(directionColor("up", themed)).toBe(themed.success);
+        expect(directionColor("down", themed)).toBe(themed.error);
+        expect(directionColor("flat", themed)).toBe(themed.caption);
+    });
+});
+
+describe("SignalStrip", () => {
+    const signals: AnalyticsSignals = {
+        momentum: { label: "Momentum", value: "34 done", rawValue: 34, delta: 18, deltaLabel: "+18% vs last week", direction: "up" },
+        timing: { label: "Timing", value: "81%", rawValue: 81, delta: 9, deltaLabel: "+9 pts", direction: "up" },
+        support: { label: "Support", value: "27 Kudos", rawValue: 27, delta: 6, deltaLabel: "+6 vs last week", direction: "up" },
+    };
+
+    test("renders all three signals", () => {
+        const { getByText } = render(<SignalStrip signals={signals} />);
+        getByText("Momentum");
+        getByText("34 done");
+        getByText("81%");
+        getByText("27 Kudos");
+    });
+});
+
+describe("StatusPill", () => {
+    test("renders the friendly status label", () => {
+        const { getByText } = render(<StatusPill status="slipping" />);
+        getByText("Slipping");
+    });
+});

--- a/frontend/api/analytics.ts
+++ b/frontend/api/analytics.ts
@@ -1,0 +1,59 @@
+import client from "./client";
+import { withAuthHeaders } from "./utils";
+import { createLogger } from "@/utils/logger";
+import { components } from "./generated/types";
+
+const logger = createLogger("AnalyticsAPI");
+
+// Widget-ready dashboard payload, generated from the backend OpenAPI spec.
+export type AnalyticsResponse = components["schemas"]["AnalyticsResponse"];
+export type AnalyticsSignal = components["schemas"]["AnalyticsSignal"];
+export type AnalyticsSignals = components["schemas"]["AnalyticsSignals"];
+export type AnalyticsProgress = components["schemas"]["AnalyticsProgress"];
+export type AnalyticsProgressBucket = components["schemas"]["AnalyticsProgressBucket"];
+export type AnalyticsProgressSegment = components["schemas"]["AnalyticsProgressSegment"];
+export type AnalyticsLegendItem = components["schemas"]["AnalyticsLegendItem"];
+export type AnalyticsCategoryShare = components["schemas"]["AnalyticsCategoryShare"];
+export type AnalyticsShareSlice = components["schemas"]["AnalyticsShareSlice"];
+export type AnalyticsShareBand = components["schemas"]["AnalyticsShareBand"];
+export type AnalyticsHeatmap = components["schemas"]["AnalyticsHeatmap"];
+export type AnalyticsHeatmapDay = components["schemas"]["AnalyticsHeatmapDay"];
+export type AnalyticsHabits = components["schemas"]["AnalyticsHabits"];
+export type AnalyticsHabitRow = components["schemas"]["AnalyticsHabitRow"];
+export type AnalyticsCategoryHealth = components["schemas"]["AnalyticsCategoryHealth"];
+export type AnalyticsCategoryHealthRow = components["schemas"]["AnalyticsCategoryHealthRow"];
+export type AnalyticsWorkspaceHealth = components["schemas"]["AnalyticsWorkspaceHealth"];
+export type AnalyticsWorkspaceHealthRow = components["schemas"]["AnalyticsWorkspaceHealthRow"];
+
+export type AnalyticsRange = "week" | "month" | "sixmonth";
+
+export interface AnalyticsFilters {
+    range: AnalyticsRange;
+    workspace?: string;
+    category?: string;
+}
+
+/**
+ * Fetch the analytics dashboard payload.
+ * API: GET /v1/user/analytics?range=&workspace=&category=
+ */
+export const getAnalytics = async (filters: AnalyticsFilters): Promise<AnalyticsResponse> => {
+    const query: Record<string, any> = { range: filters.range };
+    if (filters.workspace) query.workspace = filters.workspace;
+    if (filters.category) query.category = filters.category;
+
+    try {
+        const { data, error } = await client.GET("/v1/user/analytics" as any, {
+            params: withAuthHeaders({ query }),
+        });
+
+        if (error) {
+            throw new Error(`Failed to fetch analytics: ${JSON.stringify(error)}`);
+        }
+
+        return data as AnalyticsResponse;
+    } catch (error) {
+        logger.error("Error fetching analytics", error);
+        throw error;
+    }
+};

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -1571,6 +1571,53 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/analytics:
+        get:
+            tags:
+                - Analytics
+            summary: Get analytics dashboard
+            description: Returns the widget-ready analytics payload for the authenticated user, filtered by range, workspace, and category.
+            operationId: get-analytics
+            parameters:
+                - name: range
+                  in: query
+                  description: 'Time range: week, month, or sixmonth'
+                  explode: false
+                  schema:
+                    type: string
+                    description: 'Time range: week, month, or sixmonth'
+                    default: week
+                    enum:
+                        - week
+                        - month
+                        - sixmonth
+                - name: workspace
+                  in: query
+                  description: Workspace name filter (optional; empty = all workspaces)
+                  explode: false
+                  schema:
+                    type: string
+                    description: Workspace name filter (optional; empty = all workspaces)
+                - name: category
+                  in: query
+                  description: Category ID filter (optional; empty = all categories)
+                  explode: false
+                  schema:
+                    type: string
+                    description: Category ID filter (optional; empty = all categories)
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AnalyticsResponse'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/blueprints:
         post:
             tags:
@@ -7254,6 +7301,393 @@ components:
                     type: string
             required:
                 - emoji
+        AnalyticsCategoryHealth:
+            type: object
+            additionalProperties: false
+            properties:
+                rows:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsCategoryHealthRow'
+            required:
+                - rows
+        AnalyticsCategoryHealthRow:
+            type: object
+            additionalProperties: false
+            properties:
+                categoryId:
+                    type: string
+                color:
+                    type: string
+                done:
+                    type: integer
+                    format: int64
+                kudos:
+                    type: integer
+                    format: int64
+                name:
+                    type: string
+                onTimePct:
+                    type: integer
+                    format: int64
+                sparkline:
+                    type: array
+                    items:
+                        type: integer
+                        format: int64
+                status:
+                    type: string
+                workspace:
+                    type: string
+            required:
+                - categoryId
+                - name
+                - workspace
+                - color
+                - done
+                - onTimePct
+                - kudos
+                - status
+                - sparkline
+        AnalyticsCategoryShare:
+            type: object
+            additionalProperties: false
+            properties:
+                overTime:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsShareBand'
+                slices:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsShareSlice'
+                takeaway:
+                    type: string
+            required:
+                - slices
+                - overTime
+                - takeaway
+        AnalyticsHabitRow:
+            type: object
+            additionalProperties: false
+            properties:
+                completed:
+                    type: integer
+                    format: int64
+                dots:
+                    type: array
+                    items:
+                        type: boolean
+                frequency:
+                    type: string
+                nextDueAt:
+                    type: string
+                rhythmLabel:
+                    type: string
+                status:
+                    type: string
+                templateId:
+                    type: string
+                title:
+                    type: string
+                total:
+                    type: integer
+                    format: int64
+            required:
+                - templateId
+                - title
+                - frequency
+                - completed
+                - total
+                - dots
+                - rhythmLabel
+                - status
+        AnalyticsHabits:
+            type: object
+            additionalProperties: false
+            properties:
+                rows:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsHabitRow'
+                takeaway:
+                    type: string
+            required:
+                - rows
+                - takeaway
+        AnalyticsHeatmap:
+            type: object
+            additionalProperties: false
+            properties:
+                days:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsHeatmapDay'
+                maxCount:
+                    type: integer
+                    format: int64
+                takeaway:
+                    type: string
+                total:
+                    type: integer
+                    format: int64
+            required:
+                - days
+                - maxCount
+                - total
+                - takeaway
+        AnalyticsHeatmapDay:
+            type: object
+            additionalProperties: false
+            properties:
+                count:
+                    type: integer
+                    format: int64
+                date:
+                    type: string
+                level:
+                    type: integer
+                    format: int64
+            required:
+                - date
+                - count
+                - level
+        AnalyticsLegendItem:
+            type: object
+            additionalProperties: false
+            properties:
+                categoryId:
+                    type: string
+                color:
+                    type: string
+                name:
+                    type: string
+            required:
+                - categoryId
+                - name
+                - color
+        AnalyticsProgress:
+            type: object
+            additionalProperties: false
+            properties:
+                bucketUnit:
+                    type: string
+                buckets:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsProgressBucket'
+                delta:
+                    type: number
+                    format: double
+                legend:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsLegendItem'
+                prevTotal:
+                    type: integer
+                    format: int64
+                takeaway:
+                    type: string
+                total:
+                    type: integer
+                    format: int64
+            required:
+                - total
+                - prevTotal
+                - delta
+                - bucketUnit
+                - buckets
+                - legend
+                - takeaway
+        AnalyticsProgressBucket:
+            type: object
+            additionalProperties: false
+            properties:
+                date:
+                    type: string
+                label:
+                    type: string
+                segments:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsProgressSegment'
+                total:
+                    type: integer
+                    format: int64
+            required:
+                - label
+                - date
+                - total
+                - segments
+        AnalyticsProgressSegment:
+            type: object
+            additionalProperties: false
+            properties:
+                categoryId:
+                    type: string
+                color:
+                    type: string
+                count:
+                    type: integer
+                    format: int64
+                name:
+                    type: string
+            required:
+                - categoryId
+                - name
+                - color
+                - count
+        AnalyticsResponse:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/AnalyticsResponse.json
+                    readOnly: true
+                categoryFilter:
+                    type: string
+                categoryHealth:
+                    $ref: '#/components/schemas/AnalyticsCategoryHealth'
+                categoryShare:
+                    $ref: '#/components/schemas/AnalyticsCategoryShare'
+                generatedAt:
+                    type: string
+                    format: date-time
+                habits:
+                    $ref: '#/components/schemas/AnalyticsHabits'
+                heatmap:
+                    $ref: '#/components/schemas/AnalyticsHeatmap'
+                progress:
+                    $ref: '#/components/schemas/AnalyticsProgress'
+                range:
+                    type: string
+                signals:
+                    $ref: '#/components/schemas/AnalyticsSignals'
+                workspaceFilter:
+                    type: string
+                workspaceHealth:
+                    $ref: '#/components/schemas/AnalyticsWorkspaceHealth'
+            required:
+                - range
+                - generatedAt
+                - signals
+                - progress
+                - categoryShare
+                - heatmap
+                - habits
+                - categoryHealth
+                - workspaceHealth
+        AnalyticsShareBand:
+            type: object
+            additionalProperties: false
+            properties:
+                label:
+                    type: string
+                slices:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsShareSlice'
+            required:
+                - label
+                - slices
+        AnalyticsShareSlice:
+            type: object
+            additionalProperties: false
+            properties:
+                categoryId:
+                    type: string
+                color:
+                    type: string
+                count:
+                    type: integer
+                    format: int64
+                name:
+                    type: string
+                pct:
+                    type: number
+                    format: double
+            required:
+                - categoryId
+                - name
+                - color
+                - count
+                - pct
+        AnalyticsSignal:
+            type: object
+            additionalProperties: false
+            properties:
+                delta:
+                    type: number
+                    format: double
+                deltaLabel:
+                    type: string
+                direction:
+                    type: string
+                label:
+                    type: string
+                rawValue:
+                    type: number
+                    format: double
+                value:
+                    type: string
+            required:
+                - label
+                - value
+                - rawValue
+                - delta
+                - deltaLabel
+                - direction
+        AnalyticsSignals:
+            type: object
+            additionalProperties: false
+            properties:
+                momentum:
+                    $ref: '#/components/schemas/AnalyticsSignal'
+                support:
+                    $ref: '#/components/schemas/AnalyticsSignal'
+                timing:
+                    $ref: '#/components/schemas/AnalyticsSignal'
+            required:
+                - momentum
+                - timing
+                - support
+        AnalyticsWorkspaceHealth:
+            type: object
+            additionalProperties: false
+            properties:
+                rows:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsWorkspaceHealthRow'
+            required:
+                - rows
+        AnalyticsWorkspaceHealthRow:
+            type: object
+            additionalProperties: false
+            properties:
+                done:
+                    type: integer
+                    format: int64
+                kudos:
+                    type: integer
+                    format: int64
+                onTimePct:
+                    type: integer
+                    format: int64
+                status:
+                    type: string
+                workspace:
+                    type: string
+            required:
+                - workspace
+                - done
+                - onTimePct
+                - kudos
+                - status
         ApplyReferralCodeInputBody:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -948,6 +948,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/analytics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get analytics dashboard
+         * @description Returns the widget-ready analytics payload for the authenticated user, filtered by range, workspace, and category.
+         */
+        get: operations["get-analytics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/blueprints": {
         parameters: {
             query?: never;
@@ -3565,6 +3585,152 @@ export interface components {
              */
             readonly $schema?: string;
             emoji: string;
+        };
+        AnalyticsCategoryHealth: {
+            rows: components["schemas"]["AnalyticsCategoryHealthRow"][];
+        };
+        AnalyticsCategoryHealthRow: {
+            categoryId: string;
+            color: string;
+            /** Format: int64 */
+            done: number;
+            /** Format: int64 */
+            kudos: number;
+            name: string;
+            /** Format: int64 */
+            onTimePct: number;
+            sparkline: number[];
+            status: string;
+            workspace: string;
+        };
+        AnalyticsCategoryShare: {
+            overTime: components["schemas"]["AnalyticsShareBand"][];
+            slices: components["schemas"]["AnalyticsShareSlice"][];
+            takeaway: string;
+        };
+        AnalyticsHabitRow: {
+            /** Format: int64 */
+            completed: number;
+            dots: boolean[];
+            frequency: string;
+            nextDueAt?: string;
+            rhythmLabel: string;
+            status: string;
+            templateId: string;
+            title: string;
+            /** Format: int64 */
+            total: number;
+        };
+        AnalyticsHabits: {
+            rows: components["schemas"]["AnalyticsHabitRow"][];
+            takeaway: string;
+        };
+        AnalyticsHeatmap: {
+            days: components["schemas"]["AnalyticsHeatmapDay"][];
+            /** Format: int64 */
+            maxCount: number;
+            takeaway: string;
+            /** Format: int64 */
+            total: number;
+        };
+        AnalyticsHeatmapDay: {
+            /** Format: int64 */
+            count: number;
+            date: string;
+            /** Format: int64 */
+            level: number;
+        };
+        AnalyticsLegendItem: {
+            categoryId: string;
+            color: string;
+            name: string;
+        };
+        AnalyticsProgress: {
+            bucketUnit: string;
+            buckets: components["schemas"]["AnalyticsProgressBucket"][];
+            /** Format: double */
+            delta: number;
+            legend: components["schemas"]["AnalyticsLegendItem"][];
+            /** Format: int64 */
+            prevTotal: number;
+            takeaway: string;
+            /** Format: int64 */
+            total: number;
+        };
+        AnalyticsProgressBucket: {
+            date: string;
+            label: string;
+            segments: components["schemas"]["AnalyticsProgressSegment"][];
+            /** Format: int64 */
+            total: number;
+        };
+        AnalyticsProgressSegment: {
+            categoryId: string;
+            color: string;
+            /** Format: int64 */
+            count: number;
+            name: string;
+        };
+        AnalyticsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/AnalyticsResponse.json
+             */
+            readonly $schema?: string;
+            categoryFilter?: string;
+            categoryHealth: components["schemas"]["AnalyticsCategoryHealth"];
+            categoryShare: components["schemas"]["AnalyticsCategoryShare"];
+            /** Format: date-time */
+            generatedAt: string;
+            habits: components["schemas"]["AnalyticsHabits"];
+            heatmap: components["schemas"]["AnalyticsHeatmap"];
+            progress: components["schemas"]["AnalyticsProgress"];
+            range: string;
+            signals: components["schemas"]["AnalyticsSignals"];
+            workspaceFilter?: string;
+            workspaceHealth: components["schemas"]["AnalyticsWorkspaceHealth"];
+        };
+        AnalyticsShareBand: {
+            label: string;
+            slices: components["schemas"]["AnalyticsShareSlice"][];
+        };
+        AnalyticsShareSlice: {
+            categoryId: string;
+            color: string;
+            /** Format: int64 */
+            count: number;
+            name: string;
+            /** Format: double */
+            pct: number;
+        };
+        AnalyticsSignal: {
+            /** Format: double */
+            delta: number;
+            deltaLabel: string;
+            direction: string;
+            label: string;
+            /** Format: double */
+            rawValue: number;
+            value: string;
+        };
+        AnalyticsSignals: {
+            momentum: components["schemas"]["AnalyticsSignal"];
+            support: components["schemas"]["AnalyticsSignal"];
+            timing: components["schemas"]["AnalyticsSignal"];
+        };
+        AnalyticsWorkspaceHealth: {
+            rows: components["schemas"]["AnalyticsWorkspaceHealthRow"][];
+        };
+        AnalyticsWorkspaceHealthRow: {
+            /** Format: int64 */
+            done: number;
+            /** Format: int64 */
+            kudos: number;
+            /** Format: int64 */
+            onTimePct: number;
+            status: string;
+            workspace: string;
         };
         ApplyReferralCodeInputBody: {
             /**
@@ -9544,6 +9710,42 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DeleteAccountOutputBody"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-analytics": {
+        parameters: {
+            query?: {
+                /** @description Time range: week, month, or sixmonth */
+                range?: "week" | "month" | "sixmonth";
+                /** @description Workspace name filter (optional; empty = all workspaces) */
+                workspace?: string;
+                /** @description Category ID filter (optional; empty = all categories) */
+                category?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsResponse"];
                 };
             };
             /** @description Error */

--- a/frontend/app/(logged-in)/(tabs)/(activity)/edit.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/edit.tsx
@@ -1,0 +1,178 @@
+import React from "react";
+import { View, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { router } from "expo-router";
+import { ArrowUp, ArrowDown, EyeSlash, Plus } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAuth } from "@/hooks/useAuth";
+import { useAnalyticsLayout, WidgetId, WIDGET_TITLES } from "@/components/analytics/analyticsLayout";
+
+export default function EditAnalytics() {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const insets = useSafeAreaInsets();
+    const { user } = useAuth();
+    const { order, hidden, moveWidget, toggleHidden, reset } = useAnalyticsLayout(user?._id);
+
+    const visible = order.filter((id) => !hidden.includes(id));
+
+    return (
+        <View style={[styles.container, { paddingTop: insets.top + 8 }]}>
+            <View style={styles.header}>
+                <TouchableOpacity onPress={reset} activeOpacity={0.7}>
+                    <ThemedText type="default" style={{ color: ThemedColor.caption }}>
+                        Reset
+                    </ThemedText>
+                </TouchableOpacity>
+                <ThemedText type="fancyFrauncesSubheading">Edit Analytics</ThemedText>
+                <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                        Done
+                    </ThemedText>
+                </TouchableOpacity>
+            </View>
+
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={[styles.body, { paddingBottom: insets.bottom + 40 }]}>
+                <ThemedText type="caption" style={styles.hint}>
+                    Reorder your cards or hide the ones you don't want to see.
+                </ThemedText>
+
+                <ThemedText type="defaultSemiBold" style={styles.sectionLabel}>
+                    Visible
+                </ThemedText>
+                {visible.map((id) => (
+                    <VisibleRow
+                        key={id}
+                        id={id}
+                        index={order.indexOf(id)}
+                        isFirst={order.indexOf(id) === 0}
+                        isLast={order.indexOf(id) === order.length - 1}
+                        onMoveUp={() => moveWidget(order.indexOf(id), order.indexOf(id) - 1)}
+                        onMoveDown={() => moveWidget(order.indexOf(id), order.indexOf(id) + 1)}
+                        onHide={() => toggleHidden(id)}
+                    />
+                ))}
+
+                {hidden.length > 0 ? (
+                    <>
+                        <ThemedText type="defaultSemiBold" style={styles.sectionLabel}>
+                            Add Cards
+                        </ThemedText>
+                        {hidden.map((id) => (
+                            <HiddenRow key={id} id={id} onAdd={() => toggleHidden(id)} />
+                        ))}
+                    </>
+                ) : null}
+            </ScrollView>
+        </View>
+    );
+}
+
+interface VisibleRowProps {
+    id: WidgetId;
+    index: number;
+    isFirst: boolean;
+    isLast: boolean;
+    onMoveUp: () => void;
+    onMoveDown: () => void;
+    onHide: () => void;
+}
+
+function VisibleRow({ id, isFirst, isLast, onMoveUp, onMoveDown, onHide }: VisibleRowProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            <ThemedText type="default" style={styles.rowTitle}>
+                {WIDGET_TITLES[id]}
+            </ThemedText>
+            <View style={styles.actions}>
+                <TouchableOpacity disabled={isFirst} onPress={onMoveUp} activeOpacity={0.7}>
+                    <ArrowUp size={20} color={isFirst ? ThemedColor.tertiary : ThemedColor.text} weight="bold" />
+                </TouchableOpacity>
+                <TouchableOpacity disabled={isLast} onPress={onMoveDown} activeOpacity={0.7}>
+                    <ArrowDown size={20} color={isLast ? ThemedColor.tertiary : ThemedColor.text} weight="bold" />
+                </TouchableOpacity>
+                <TouchableOpacity onPress={onHide} activeOpacity={0.7}>
+                    <EyeSlash size={20} color={ThemedColor.caption} weight="bold" />
+                </TouchableOpacity>
+            </View>
+        </View>
+    );
+}
+
+function HiddenRow({ id, onAdd }: { id: WidgetId; onAdd: () => void }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            <ThemedText type="default" style={[styles.rowTitle, { color: ThemedColor.caption }]}>
+                {WIDGET_TITLES[id]}
+            </ThemedText>
+            <TouchableOpacity onPress={onAdd} activeOpacity={0.7} style={styles.addButton}>
+                <Plus size={18} color={ThemedColor.primary} weight="bold" />
+                <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                    Add
+                </ThemedText>
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            backgroundColor: ThemedColor.background,
+        },
+        header: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingHorizontal: 20,
+            paddingBottom: 12,
+        },
+        body: {
+            paddingHorizontal: 20,
+        },
+        hint: {
+            marginBottom: 16,
+            lineHeight: 18,
+        },
+        sectionLabel: {
+            marginTop: 12,
+            marginBottom: 8,
+            fontSize: 13,
+            textTransform: "uppercase",
+            letterSpacing: 0.5,
+            color: ThemedColor.caption,
+        },
+        row: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+            marginBottom: 10,
+        },
+        rowTitle: {
+            fontSize: 15,
+        },
+        actions: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 18,
+        },
+        addButton: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+        },
+    });

--- a/frontend/app/(logged-in)/(tabs)/(activity)/index.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/index.tsx
@@ -1,13 +1,14 @@
-import { Redirect } from "expo-router";
-import { useAuth } from "@/hooks/useAuth";
+import React from "react";
 import { View, ActivityIndicator } from "react-native";
+import { useAuth } from "@/hooks/useAuth";
 import { useThemeColor } from "@/hooks/useThemeColor";
+import { AnalyticsHome } from "@/components/analytics/AnalyticsHome";
 
 export default function ActivityIndex() {
     const { user } = useAuth();
     const ThemedColor = useThemeColor();
 
-    // Show loading while user data is being fetched
+    // Wait for the user before rendering the dashboard (layout + queries key off it).
     if (!user) {
         return (
             <View style={{ flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: ThemedColor.background }}>
@@ -16,6 +17,5 @@ export default function ActivityIndex() {
         );
     }
 
-    // Redirect to the user's activity page
-    return <Redirect href={`/(activity)/${user._id}`} />;
+    return <AnalyticsHome />;
 }

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -88,6 +88,7 @@
         "react-native-emoji-selector": "^0.2.0",
         "react-native-gesture-handler": "~2.30.0",
         "react-native-get-random-values": "^1.11.0",
+        "react-native-gifted-charts": "^1.4.77",
         "react-native-modal": "^14.0.0-rc.1",
         "react-native-otp-entry": "^1.8.5",
         "react-native-pager-view": "8.0.0",
@@ -1497,6 +1498,8 @@
 
     "getenv": ["getenv@2.0.0", "", {}, "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ=="],
 
+    "gifted-charts-core": ["gifted-charts-core@0.1.81", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-svg": "*" } }, "sha512-plgJSbKB0Lxp2KQ/Fvj1qbOhiy6wxPiZ0Av60iFHpSSu6YlJjYhwczx5w2/iJQdZYb851OFMHgN/pgTNVLv6dA=="],
+
     "glob": ["glob@9.3.5", "", { "dependencies": { "fs.realpath": "^1.0.0", "minimatch": "^8.0.2", "minipass": "^4.2.4", "path-scurry": "^1.6.1" } }, "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
@@ -2108,6 +2111,8 @@
     "react-native-gesture-handler": ["react-native-gesture-handler@2.30.1", "", { "dependencies": { "@egjs/hammerjs": "^2.0.17", "hoist-non-react-statics": "^3.3.0", "invariant": "^2.2.4" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-xIUBDo5ktmJs++0fZlavQNvDEE4PsihWhSeJsJtoz4Q6p0MiTM9TgrTgfEgzRR36qGPytFoeq+ShLrVwGdpUdA=="],
 
     "react-native-get-random-values": ["react-native-get-random-values@1.11.0", "", { "dependencies": { "fast-base64-decode": "^1.0.0" }, "peerDependencies": { "react-native": ">=0.56" } }, "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ=="],
+
+    "react-native-gifted-charts": ["react-native-gifted-charts@1.4.77", "", { "dependencies": { "gifted-charts-core": "0.1.81" }, "peerDependencies": { "expo-linear-gradient": "*", "react": "*", "react-native": "*", "react-native-linear-gradient": "*", "react-native-svg": "*" }, "optionalPeers": ["expo-linear-gradient", "react-native-linear-gradient"] }, "sha512-Ul4juHO0Gicng139i61AzQ3h4kLM25dzid1rU+d3d7PuHsI4UypgeChz/luaHMZaWgXkALjq6DLqaM2Y2AEhrA=="],
 
     "react-native-is-edge-to-edge": ["react-native-is-edge-to-edge@1.3.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA=="],
 

--- a/frontend/components/analytics/ActivityHeatmapWidget.tsx
+++ b/frontend/components/analytics/ActivityHeatmapWidget.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsHeatmap } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { MonthHeatmap } from "./charts/MonthHeatmap";
+import { heatmapLevelColor } from "./analyticsColors";
+
+export function ActivityHeatmapWidget({ heatmap }: { heatmap: AnalyticsHeatmap }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    return (
+        <WidgetCard title="Activity heatmap" takeaway={heatmap.takeaway}>
+            <MonthHeatmap days={heatmap.days} />
+            <View style={styles.legend}>
+                <ThemedText type="caption">Less</ThemedText>
+                {[0, 1, 2, 3, 4].map((level) => (
+                    <View key={level} style={[styles.cell, { backgroundColor: heatmapLevelColor(level, ThemedColor) }]} />
+                ))}
+                <ThemedText type="caption">More</ThemedText>
+            </View>
+        </WidgetCard>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        legend: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            marginTop: 12,
+        },
+        cell: {
+            width: 12,
+            height: 12,
+            borderRadius: 3,
+        },
+    });

--- a/frontend/components/analytics/AnalyticsHome.tsx
+++ b/frontend/components/analytics/AnalyticsHome.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from "react";
+import { View, ScrollView, StyleSheet, ActivityIndicator, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { router, type Href } from "expo-router";
+import { PencilSimple } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAuth } from "@/hooks/useAuth";
+import { useTasks } from "@/contexts/tasksContext";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsRange, AnalyticsResponse } from "@/api/analytics";
+import { WorkspaceSelector } from "./WorkspaceSelector";
+import { RangeSwitcher } from "./RangeSwitcher";
+import { FilterChips } from "./FilterChips";
+import { useAnalyticsLayout, WidgetId } from "./analyticsLayout";
+import { SignalStrip } from "./SignalStrip";
+import { WeeklyProgressWidget } from "./WeeklyProgressWidget";
+import { CategoryShareWidget } from "./CategoryShareWidget";
+import { ActivityHeatmapWidget } from "./ActivityHeatmapWidget";
+import { HabitsWidget } from "./HabitsWidget";
+import { CategoryHealthWidget } from "./CategoryHealthWidget";
+import { WorkspaceHealthWidget } from "./WorkspaceHealthWidget";
+
+const EDIT_HREF = "/(activity)/edit" as Href;
+
+export function AnalyticsHome() {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const insets = useSafeAreaInsets();
+
+    const { user } = useAuth();
+    const { workspaces } = useTasks();
+
+    const [range, setRange] = useState<AnalyticsRange>("week");
+    const [workspace, setWorkspace] = useState<string | undefined>(undefined);
+    const [category, setCategory] = useState<string | undefined>(undefined);
+
+    const { data, isLoading, isError, refetch } = useAnalyticsData({ range, workspace, category });
+    const layout = useAnalyticsLayout(user?._id);
+
+    const workspaceNames = useMemo(() => workspaces.map((w: any) => w.name), [workspaces]);
+    const filterCategories = useMemo(() => {
+        const source = workspace
+            ? workspaces.find((w: any) => w.name === workspace)?.categories ?? []
+            : workspaces.flatMap((w: any) => w.categories ?? []);
+        return source.map((c: any) => ({ id: c.id, name: c.name }));
+    }, [workspaces, workspace]);
+
+    const onSelectWorkspace = (ws?: string) => {
+        setWorkspace(ws);
+        setCategory(undefined);
+    };
+
+    return (
+        <View style={[styles.container, { paddingTop: insets.top + 8 }]}>
+            <View style={styles.header}>
+                <ThemedText type="fancyFrauncesHeading">Analytics</ThemedText>
+                <TouchableOpacity
+                    style={styles.editButton}
+                    activeOpacity={0.7}
+                    onPress={() => router.push(EDIT_HREF)}>
+                    <PencilSimple size={18} color={ThemedColor.primary} weight="bold" />
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                        Edit
+                    </ThemedText>
+                </TouchableOpacity>
+            </View>
+
+            <View style={styles.controls}>
+                <WorkspaceSelector workspaces={workspaceNames} selected={workspace} onSelect={onSelectWorkspace} />
+                <RangeSwitcher range={range} onChange={setRange} />
+            </View>
+
+            <View style={styles.chips}>
+                <FilterChips categories={filterCategories} selected={category} onSelect={setCategory} />
+            </View>
+
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={[styles.feed, { paddingBottom: insets.bottom + 110 }]}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={styles.center} />
+                ) : isError || !data ? (
+                    <View style={styles.center}>
+                        <ThemedText type="caption">Couldn't load analytics.</ThemedText>
+                        <TouchableOpacity onPress={() => refetch()} activeOpacity={0.7} style={styles.retry}>
+                            <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                                Try again
+                            </ThemedText>
+                        </TouchableOpacity>
+                    </View>
+                ) : (
+                    layout.visible.map((id) => (
+                        <WidgetRenderer
+                            key={id}
+                            id={id}
+                            data={data}
+                            range={range}
+                            onSelectCategory={setCategory}
+                        />
+                    ))
+                )}
+            </ScrollView>
+        </View>
+    );
+}
+
+interface WidgetRendererProps {
+    id: WidgetId;
+    data: AnalyticsResponse;
+    range: AnalyticsRange;
+    onSelectCategory: (categoryId: string) => void;
+}
+
+/** Maps a widget id to its component — a proper component, not an inline helper. */
+function WidgetRenderer({ id, data, range, onSelectCategory }: WidgetRendererProps) {
+    switch (id) {
+        case "signals":
+            return <SignalStrip signals={data.signals} />;
+        case "progress":
+            return <WeeklyProgressWidget progress={data.progress} range={range} />;
+        case "categoryShare":
+            return <CategoryShareWidget share={data.categoryShare} range={range} onSelectCategory={onSelectCategory} />;
+        case "habits":
+            return <HabitsWidget habits={data.habits} />;
+        case "heatmap":
+            return <ActivityHeatmapWidget heatmap={data.heatmap} />;
+        case "categoryHealth":
+            return <CategoryHealthWidget categoryHealth={data.categoryHealth} onSelectCategory={onSelectCategory} />;
+        case "workspaceHealth":
+            return <WorkspaceHealthWidget workspaceHealth={data.workspaceHealth} />;
+        default:
+            return null;
+    }
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            backgroundColor: ThemedColor.background,
+        },
+        header: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingHorizontal: 20,
+        },
+        editButton: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+        },
+        controls: {
+            paddingHorizontal: 20,
+            marginTop: 8,
+        },
+        chips: {
+            paddingLeft: 20,
+            marginTop: 4,
+        },
+        feed: {
+            paddingHorizontal: 20,
+            paddingTop: 12,
+        },
+        center: {
+            alignItems: "center",
+            justifyContent: "center",
+            paddingVertical: 60,
+            gap: 12,
+        },
+        retry: {
+            paddingVertical: 8,
+            paddingHorizontal: 16,
+        },
+    });

--- a/frontend/components/analytics/CategoryHealthWidget.tsx
+++ b/frontend/components/analytics/CategoryHealthWidget.tsx
@@ -1,0 +1,104 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsCategoryHealth, AnalyticsCategoryHealthRow } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { StatusPill } from "./StatusPill";
+import { Sparkline } from "./charts/Sparkline";
+
+interface Props {
+    categoryHealth: AnalyticsCategoryHealth;
+    onSelectCategory?: (categoryId: string) => void;
+}
+
+export function CategoryHealthWidget({ categoryHealth, onSelectCategory }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    if (categoryHealth.rows.length === 0) {
+        return (
+            <WidgetCard title="Category health">
+                <ThemedText type="caption">No category activity in this period yet.</ThemedText>
+            </WidgetCard>
+        );
+    }
+
+    return (
+        <WidgetCard title="Category health">
+            <View style={styles.list}>
+                {categoryHealth.rows.map((row) => (
+                    <CategoryHealthRowItem key={row.categoryId} row={row} onSelectCategory={onSelectCategory} />
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+function CategoryHealthRowItem({
+    row,
+    onSelectCategory,
+}: {
+    row: AnalyticsCategoryHealthRow;
+    onSelectCategory?: (categoryId: string) => void;
+}) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <TouchableOpacity
+            style={styles.row}
+            activeOpacity={0.6}
+            disabled={!onSelectCategory}
+            onPress={() => onSelectCategory?.(row.categoryId)}>
+            <View style={styles.left}>
+                <View style={[styles.dot, { backgroundColor: row.color }]} />
+                <View style={styles.nameCol}>
+                    <ThemedText type="defaultSemiBold" style={styles.name}>
+                        {row.name}
+                    </ThemedText>
+                    <ThemedText type="caption">{row.onTimePct}% on time · {row.kudos} Kudos</ThemedText>
+                </View>
+            </View>
+            <View style={styles.right}>
+                <Sparkline data={row.sparkline} color={row.color} width={48} height={20} />
+                <StatusPill status={row.status} />
+            </View>
+        </TouchableOpacity>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        list: {
+            gap: 14,
+        },
+        row: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 10,
+        },
+        left: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            flexShrink: 1,
+        },
+        nameCol: {
+            flexShrink: 1,
+            gap: 2,
+        },
+        name: {
+            fontSize: 15,
+        },
+        right: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 8,
+        },
+        dot: {
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+        },
+    });

--- a/frontend/components/analytics/CategoryShareWidget.tsx
+++ b/frontend/components/analytics/CategoryShareWidget.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsCategoryShare, AnalyticsRange, AnalyticsShareSlice } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { DonutChart } from "./charts/DonutChart";
+import { StackedBandChart } from "./charts/StackedBandChart";
+
+interface Props {
+    share: AnalyticsCategoryShare;
+    range: AnalyticsRange;
+    onSelectCategory?: (categoryId: string) => void;
+}
+
+export function CategoryShareWidget({ share, range, onSelectCategory }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    const title = range === "week" ? "Where your time went" : "Category share";
+    const total = share.slices.reduce((sum, s) => sum + s.count, 0);
+    const useBands = range !== "week" && share.overTime.length > 0;
+
+    return (
+        <WidgetCard title={title} takeaway={share.takeaway}>
+            {useBands ? (
+                <StackedBandChart bands={share.overTime} />
+            ) : (
+                <View style={styles.donutRow}>
+                    <DonutChart slices={share.slices} total={total} />
+                    <View style={styles.legend}>
+                        {share.slices.map((slice) => (
+                            <ShareLegendRow key={slice.categoryId} slice={slice} onSelectCategory={onSelectCategory} />
+                        ))}
+                    </View>
+                </View>
+            )}
+        </WidgetCard>
+    );
+}
+
+function ShareLegendRow({
+    slice,
+    onSelectCategory,
+}: {
+    slice: AnalyticsShareSlice;
+    onSelectCategory?: (categoryId: string) => void;
+}) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const tappable = !!onSelectCategory && slice.categoryId !== "other";
+
+    return (
+        <TouchableOpacity
+            style={styles.legendRow}
+            disabled={!tappable}
+            activeOpacity={0.6}
+            onPress={() => tappable && onSelectCategory?.(slice.categoryId)}>
+            <View style={styles.legendLeft}>
+                <View style={[styles.dot, { backgroundColor: slice.color }]} />
+                <ThemedText type="default" style={styles.legendName}>
+                    {slice.name}
+                </ThemedText>
+            </View>
+            <ThemedText type="defaultSemiBold">{Math.round(slice.pct)}%</ThemedText>
+        </TouchableOpacity>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        donutRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 16,
+        },
+        legend: {
+            flex: 1,
+            gap: 10,
+        },
+        legendRow: {
+            flexDirection: "row",
+            alignItems: "center",
+            justifyContent: "space-between",
+        },
+        legendLeft: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 8,
+            flexShrink: 1,
+        },
+        legendName: {
+            fontSize: 14,
+            flexShrink: 1,
+        },
+        dot: {
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+        },
+    });

--- a/frontend/components/analytics/FilterChips.tsx
+++ b/frontend/components/analytics/FilterChips.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+interface CategoryChip {
+    id: string;
+    name: string;
+}
+
+interface Props {
+    categories: CategoryChip[];
+    selected?: string;
+    onSelect: (categoryId?: string) => void;
+}
+
+export function FilterChips({ categories, selected, onSelect }: Props) {
+    return (
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.row}>
+            <Chip label="All" active={!selected} onPress={() => onSelect(undefined)} />
+            {categories.map((c) => (
+                <Chip key={c.id} label={c.name} active={selected === c.id} onPress={() => onSelect(c.id)} />
+            ))}
+        </ScrollView>
+    );
+}
+
+function Chip({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+    const ThemedColor = useThemeColor() as any;
+    return (
+        <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={onPress}
+            style={[
+                styles.chip,
+                {
+                    backgroundColor: active ? ThemedColor.primary : ThemedColor.lightened,
+                    borderColor: active ? ThemedColor.primary : ThemedColor.tertiary,
+                },
+            ]}>
+            <ThemedText type={active ? "defaultSemiBold" : "default"} style={{ color: active ? ThemedColor.buttonText : ThemedColor.text, fontSize: 13 }}>
+                {label}
+            </ThemedText>
+        </TouchableOpacity>
+    );
+}
+
+const styles = StyleSheet.create({
+    row: {
+        gap: 8,
+        paddingVertical: 4,
+        paddingRight: 16,
+    },
+    chip: {
+        paddingHorizontal: 14,
+        paddingVertical: 7,
+        borderRadius: 999,
+        borderWidth: 1,
+    },
+});

--- a/frontend/components/analytics/HabitsWidget.tsx
+++ b/frontend/components/analytics/HabitsWidget.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsHabits, AnalyticsHabitRow } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+
+interface Props {
+    habits: AnalyticsHabits;
+    onPress?: () => void;
+}
+
+export function HabitsWidget({ habits, onPress }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    return (
+        <WidgetCard
+            title="Habits & recurring"
+            takeaway={habits.takeaway}
+            cta={onPress ? { label: "View habits", onPress } : undefined}>
+            {habits.rows.length === 0 ? (
+                <ThemedText type="caption">No recurring tasks yet.</ThemedText>
+            ) : (
+                <View style={styles.list}>
+                    {habits.rows.map((row) => (
+                        <HabitRow key={row.templateId} row={row} />
+                    ))}
+                </View>
+            )}
+        </WidgetCard>
+    );
+}
+
+function HabitRow({ row }: { row: AnalyticsHabitRow }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            <View style={styles.rowText}>
+                <ThemedText type="defaultSemiBold" style={styles.title}>
+                    {row.title}
+                </ThemedText>
+                <ThemedText type="caption">{row.rhythmLabel}</ThemedText>
+            </View>
+            <View style={styles.dots}>
+                {row.dots.map((filled, i) => (
+                    <View
+                        key={i}
+                        style={[
+                            styles.dot,
+                            { backgroundColor: filled ? ThemedColor.primary : ThemedColor.tertiary },
+                        ]}
+                    />
+                ))}
+            </View>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        list: {
+            gap: 14,
+        },
+        row: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 12,
+        },
+        rowText: {
+            flexShrink: 1,
+            gap: 2,
+        },
+        title: {
+            fontSize: 15,
+        },
+        dots: {
+            flexDirection: "row",
+            gap: 5,
+            flexWrap: "wrap",
+            maxWidth: 140,
+            justifyContent: "flex-end",
+        },
+        dot: {
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+        },
+    });

--- a/frontend/components/analytics/RangeSwitcher.tsx
+++ b/frontend/components/analytics/RangeSwitcher.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import SegmentedControl from "@/components/ui/SegmentedControl";
+import { AnalyticsRange } from "@/api/analytics";
+
+const OPTIONS: { label: string; range: AnalyticsRange }[] = [
+    { label: "W", range: "week" },
+    { label: "M", range: "month" },
+    { label: "6M", range: "sixmonth" },
+];
+
+export function RangeSwitcher({ range, onChange }: { range: AnalyticsRange; onChange: (r: AnalyticsRange) => void }) {
+    const selectedLabel = OPTIONS.find((o) => o.range === range)?.label ?? "W";
+    return (
+        <SegmentedControl
+            options={OPTIONS.map((o) => o.label)}
+            selectedOption={selectedLabel}
+            size="small"
+            accent
+            onOptionPress={(opt) => {
+                const match = OPTIONS.find((o) => o.label === opt);
+                if (match) onChange(match.range);
+            }}
+        />
+    );
+}

--- a/frontend/components/analytics/SignalStrip.tsx
+++ b/frontend/components/analytics/SignalStrip.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsSignal, AnalyticsSignals } from "@/api/analytics";
+import { directionColor } from "./analyticsColors";
+
+/** Momentum / Timing / Support headline strip. */
+export function SignalStrip({ signals }: { signals: AnalyticsSignals }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            <SignalCard signal={signals.momentum} />
+            <SignalCard signal={signals.timing} />
+            <SignalCard signal={signals.support} />
+        </View>
+    );
+}
+
+function SignalCard({ signal }: { signal: AnalyticsSignal }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.card}>
+            <ThemedText type="caption">{signal.label}</ThemedText>
+            <ThemedText type="fancyFrauncesSubheading" style={styles.value}>
+                {signal.value}
+            </ThemedText>
+            <ThemedText type="caption" style={{ color: directionColor(signal.direction, ThemedColor), fontSize: 11 }}>
+                {signal.deltaLabel}
+            </ThemedText>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            flexDirection: "row",
+            gap: 10,
+            marginBottom: 16,
+        },
+        card: {
+            flex: 1,
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+            padding: 12,
+            gap: 2,
+        },
+        value: {
+            fontSize: 22,
+            marginVertical: 2,
+        },
+    });

--- a/frontend/components/analytics/StatusPill.tsx
+++ b/frontend/components/analytics/StatusPill.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { statusColor, statusLabel } from "./analyticsColors";
+
+/** Small colored pill for a health/rhythm status. */
+export function StatusPill({ status }: { status: string }) {
+    const ThemedColor = useThemeColor() as any;
+    const color = statusColor(status, ThemedColor);
+    return (
+        <View style={[styles.pill, { backgroundColor: color + "22", borderColor: color + "55" }]}>
+            <ThemedText type="caption" style={{ color, fontSize: 11 }}>
+                {statusLabel(status)}
+            </ThemedText>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    pill: {
+        paddingHorizontal: 10,
+        paddingVertical: 4,
+        borderRadius: 999,
+        borderWidth: 1,
+    },
+});

--- a/frontend/components/analytics/WeeklyProgressWidget.tsx
+++ b/frontend/components/analytics/WeeklyProgressWidget.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsProgress, AnalyticsRange, AnalyticsLegendItem } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { StackedBarChart } from "./charts/StackedBarChart";
+import { directionColor } from "./analyticsColors";
+
+const TITLES: Record<AnalyticsRange, string> = {
+    week: "Weekly progress",
+    month: "Monthly progress",
+    sixmonth: "6-month progress",
+};
+
+const SUFFIX: Record<AnalyticsRange, string> = {
+    week: "vs last week",
+    month: "vs last month",
+    sixmonth: "vs prior 6 months",
+};
+
+function deltaText(delta: number, range: AnalyticsRange): string {
+    const sign = delta >= 0 ? "+" : "";
+    return `${sign}${Math.round(delta)}% ${SUFFIX[range]}`;
+}
+
+interface Props {
+    progress: AnalyticsProgress;
+    range: AnalyticsRange;
+}
+
+export function WeeklyProgressWidget({ progress, range }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const dir = progress.delta > 0 ? "up" : progress.delta < 0 ? "down" : "flat";
+
+    return (
+        <WidgetCard title={TITLES[range]} takeaway={progress.takeaway}>
+            <View style={styles.statRow}>
+                <ThemedText type="fancyFrauncesHeading" style={styles.stat}>
+                    {progress.total}
+                </ThemedText>
+                <ThemedText type="caption" style={{ color: directionColor(dir, ThemedColor) }}>
+                    {deltaText(progress.delta, range)}
+                </ThemedText>
+            </View>
+
+            <StackedBarChart buckets={progress.buckets} />
+
+            <View style={styles.legend}>
+                {progress.legend.map((item) => (
+                    <LegendChip key={item.categoryId} item={item} />
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+function LegendChip({ item }: { item: AnalyticsLegendItem }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.chip}>
+            <View style={[styles.dot, { backgroundColor: item.color }]} />
+            <ThemedText type="caption">{item.name}</ThemedText>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        statRow: {
+            flexDirection: "row",
+            alignItems: "baseline",
+            gap: 10,
+            marginBottom: 8,
+        },
+        stat: {
+            fontSize: 30,
+        },
+        legend: {
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: 12,
+            marginTop: 12,
+        },
+        chip: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 6,
+        },
+        dot: {
+            width: 10,
+            height: 10,
+            borderRadius: 5,
+        },
+    });

--- a/frontend/components/analytics/WidgetCard.tsx
+++ b/frontend/components/analytics/WidgetCard.tsx
@@ -1,0 +1,90 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { CaretRight } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+interface WidgetCardCTA {
+    label: string;
+    onPress: () => void;
+}
+
+interface WidgetCardProps {
+    title: string;
+    headerRight?: React.ReactNode;
+    takeaway?: string;
+    cta?: WidgetCardCTA;
+    onPress?: () => void;
+    children: React.ReactNode;
+}
+
+/**
+ * Shared shell for every analytics widget: title row, visualization, optional
+ * one-line takeaway and CTA. Left-aligned, dark-elevated surface.
+ */
+export function WidgetCard({ title, headerRight, takeaway, cta, onPress, children }: WidgetCardProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    const Container: any = onPress ? TouchableOpacity : View;
+    const containerProps = onPress ? { onPress, activeOpacity: 0.85 } : {};
+
+    return (
+        <Container style={styles.card} {...containerProps}>
+            <View style={styles.header}>
+                <ThemedText type="defaultSemiBold" style={styles.title}>
+                    {title}
+                </ThemedText>
+                {headerRight}
+            </View>
+
+            {children}
+
+            {takeaway ? (
+                <ThemedText type="caption" style={styles.takeaway}>
+                    {takeaway}
+                </ThemedText>
+            ) : null}
+
+            {cta ? (
+                <TouchableOpacity style={styles.cta} onPress={cta.onPress} activeOpacity={0.7}>
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                        {cta.label}
+                    </ThemedText>
+                    <CaretRight size={16} color={ThemedColor.primary} weight="bold" />
+                </TouchableOpacity>
+            ) : null}
+        </Container>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        card: {
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 24,
+            padding: 16,
+            marginBottom: 16,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+        },
+        header: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginBottom: 12,
+        },
+        title: {
+            fontSize: 17,
+        },
+        takeaway: {
+            marginTop: 12,
+            lineHeight: 18,
+        },
+        cta: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            marginTop: 12,
+        },
+    });

--- a/frontend/components/analytics/WorkspaceHealthWidget.tsx
+++ b/frontend/components/analytics/WorkspaceHealthWidget.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsWorkspaceHealth, AnalyticsWorkspaceHealthRow } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { StatusPill } from "./StatusPill";
+
+interface Props {
+    workspaceHealth: AnalyticsWorkspaceHealth;
+    onSelectWorkspace?: (workspace: string) => void;
+}
+
+export function WorkspaceHealthWidget({ workspaceHealth, onSelectWorkspace }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    if (workspaceHealth.rows.length === 0) {
+        return (
+            <WidgetCard title="Workspace health">
+                <ThemedText type="caption">No workspace activity in this period yet.</ThemedText>
+            </WidgetCard>
+        );
+    }
+
+    return (
+        <WidgetCard title="Workspace health">
+            <View style={styles.list}>
+                {workspaceHealth.rows.map((row) => (
+                    <WorkspaceHealthRowItem key={row.workspace} row={row} onSelectWorkspace={onSelectWorkspace} />
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+function WorkspaceHealthRowItem({
+    row,
+    onSelectWorkspace,
+}: {
+    row: AnalyticsWorkspaceHealthRow;
+    onSelectWorkspace?: (workspace: string) => void;
+}) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <TouchableOpacity
+            style={styles.row}
+            activeOpacity={0.6}
+            disabled={!onSelectWorkspace}
+            onPress={() => onSelectWorkspace?.(row.workspace)}>
+            <View style={styles.nameCol}>
+                <ThemedText type="defaultSemiBold" style={styles.name}>
+                    {row.workspace}
+                </ThemedText>
+                <ThemedText type="caption">{row.done} done · {row.onTimePct}% on time · {row.kudos} Kudos</ThemedText>
+            </View>
+            <StatusPill status={row.status} />
+        </TouchableOpacity>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        list: {
+            gap: 14,
+        },
+        row: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            gap: 10,
+        },
+        nameCol: {
+            flexShrink: 1,
+            gap: 2,
+        },
+        name: {
+            fontSize: 15,
+        },
+    });

--- a/frontend/components/analytics/WorkspaceSelector.tsx
+++ b/frontend/components/analytics/WorkspaceSelector.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from "react";
+import { View, StyleSheet, TouchableOpacity, Modal, Pressable } from "react-native";
+import { CaretDown, Check } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+interface Props {
+    workspaces: string[];
+    selected?: string;
+    onSelect: (workspace?: string) => void;
+}
+
+const ALL_LABEL = "All Workspaces";
+
+export function WorkspaceSelector({ workspaces, selected, onSelect }: Props) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const [open, setOpen] = useState(false);
+
+    const choose = (ws?: string) => {
+        onSelect(ws);
+        setOpen(false);
+    };
+
+    return (
+        <>
+            <TouchableOpacity style={styles.trigger} activeOpacity={0.7} onPress={() => setOpen(true)}>
+                <ThemedText type="defaultSemiBold">{selected ?? ALL_LABEL}</ThemedText>
+                <CaretDown size={16} color={ThemedColor.text} weight="bold" />
+            </TouchableOpacity>
+
+            <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+                <Pressable style={styles.overlay} onPress={() => setOpen(false)}>
+                    <View style={styles.sheet}>
+                        <WorkspaceOption label={ALL_LABEL} active={!selected} onPress={() => choose(undefined)} />
+                        {workspaces.map((ws) => (
+                            <WorkspaceOption key={ws} label={ws} active={selected === ws} onPress={() => choose(ws)} />
+                        ))}
+                    </View>
+                </Pressable>
+            </Modal>
+        </>
+    );
+}
+
+function WorkspaceOption({ label, active, onPress }: { label: string; active: boolean; onPress: () => void }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <TouchableOpacity style={styles.option} activeOpacity={0.7} onPress={onPress}>
+            <ThemedText type={active ? "defaultSemiBold" : "default"}>{label}</ThemedText>
+            {active ? <Check size={18} color={ThemedColor.primary} weight="bold" /> : null}
+        </TouchableOpacity>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        trigger: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 6,
+            alignSelf: "flex-start",
+        },
+        overlay: {
+            flex: 1,
+            backgroundColor: "#00000066",
+            justifyContent: "flex-start",
+            paddingTop: 160,
+            paddingHorizontal: 24,
+        },
+        sheet: {
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+            paddingVertical: 6,
+        },
+        option: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            paddingHorizontal: 16,
+            paddingVertical: 14,
+        },
+    });

--- a/frontend/components/analytics/analyticsColors.ts
+++ b/frontend/components/analytics/analyticsColors.ts
@@ -1,0 +1,69 @@
+// Shared color + label helpers for the analytics widgets. Keeps the dark-mode
+// purple scale and status palette in one place.
+
+export type ThemedColors = Record<string, string>;
+
+// Heatmap intensity 0-4 mapped onto the Kindred purple, empty cells use the
+// card-elevated surface so they read as "no activity".
+export function heatmapLevelColor(level: number, ThemedColor: ThemedColors): string {
+    const primary = ThemedColor.primary ?? "#854DFF";
+    switch (level) {
+        case 1:
+            return primary + "33";
+        case 2:
+            return primary + "66";
+        case 3:
+            return primary + "99";
+        case 4:
+            return primary;
+        default:
+            return ThemedColor.lightened ?? "#171626";
+    }
+}
+
+// Status pill color. Avoids gray on light-purple by keeping grays on card bg.
+export function statusColor(status: string, ThemedColor: ThemedColors): string {
+    switch (status) {
+        case "healthy":
+            return ThemedColor.success ?? "#22C55E";
+        case "steady":
+            return ThemedColor.primary ?? "#854DFF";
+        case "needs-attention":
+        case "needs-reset":
+            return ThemedColor.warning ?? "#F59E0B";
+        case "slipping":
+            return ThemedColor.error ?? "#FF5C5F";
+        default: // unsupported | light
+            return ThemedColor.caption ?? "#919090";
+    }
+}
+
+export function statusLabel(status: string): string {
+    switch (status) {
+        case "healthy":
+            return "Healthy";
+        case "steady":
+            return "Steady";
+        case "needs-attention":
+            return "Needs attention";
+        case "needs-reset":
+            return "Needs a reset";
+        case "slipping":
+            return "Slipping";
+        case "unsupported":
+            return "Unsupported";
+        default:
+            return "Light";
+    }
+}
+
+export function directionColor(direction: string, ThemedColor: ThemedColors): string {
+    switch (direction) {
+        case "up":
+            return ThemedColor.success ?? "#22C55E";
+        case "down":
+            return ThemedColor.error ?? "#FF5C5F";
+        default:
+            return ThemedColor.caption ?? "#919090";
+    }
+}

--- a/frontend/components/analytics/analyticsLayout.ts
+++ b/frontend/components/analytics/analyticsLayout.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useState } from "react";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export type WidgetId =
+    | "signals"
+    | "progress"
+    | "categoryShare"
+    | "habits"
+    | "heatmap"
+    | "categoryHealth"
+    | "workspaceHealth";
+
+export const DEFAULT_WIDGET_ORDER: WidgetId[] = [
+    "signals",
+    "progress",
+    "categoryShare",
+    "habits",
+    "heatmap",
+    "categoryHealth",
+    "workspaceHealth",
+];
+
+export const WIDGET_TITLES: Record<WidgetId, string> = {
+    signals: "Signal strip",
+    progress: "Weekly progress",
+    categoryShare: "Category share",
+    habits: "Habits & recurring",
+    heatmap: "Activity heatmap",
+    categoryHealth: "Category health",
+    workspaceHealth: "Workspace health",
+};
+
+export function isWidgetId(value: unknown): value is WidgetId {
+    return typeof value === "string" && (DEFAULT_WIDGET_ORDER as string[]).includes(value);
+}
+
+/** Pure array move; returns a new array with the item shifted from→to. */
+export function moveItem<T>(arr: T[], from: number, to: number): T[] {
+    if (from < 0 || from >= arr.length || to < 0 || to >= arr.length || from === to) {
+        return arr.slice();
+    }
+    const next = arr.slice();
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    return next;
+}
+
+/** Drop unknown ids and append any newly-added widgets so the list stays valid. */
+export function sanitizeOrder(order: unknown): WidgetId[] {
+    const arr = Array.isArray(order) ? order.filter(isWidgetId) : [];
+    const seen = new Set(arr);
+    for (const id of DEFAULT_WIDGET_ORDER) {
+        if (!seen.has(id)) arr.push(id);
+    }
+    return arr;
+}
+
+const keyFor = (userId?: string) => (userId ? `analytics_layout_${userId}` : null);
+
+/**
+ * Persisted, reorderable widget layout. Stored locally (AsyncStorage) for
+ * Phase 1; server sync is a later phase.
+ */
+export function useAnalyticsLayout(userId?: string) {
+    const [order, setOrder] = useState<WidgetId[]>(DEFAULT_WIDGET_ORDER);
+    const [hidden, setHidden] = useState<WidgetId[]>([]);
+    const [loaded, setLoaded] = useState(false);
+    const key = keyFor(userId);
+
+    useEffect(() => {
+        let active = true;
+        (async () => {
+            if (!key) {
+                setLoaded(true);
+                return;
+            }
+            try {
+                const raw = await AsyncStorage.getItem(key);
+                if (active && raw) {
+                    const parsed = JSON.parse(raw);
+                    setOrder(sanitizeOrder(parsed.order));
+                    setHidden(Array.isArray(parsed.hidden) ? parsed.hidden.filter(isWidgetId) : []);
+                }
+            } catch {
+                // fall back to defaults
+            } finally {
+                if (active) setLoaded(true);
+            }
+        })();
+        return () => {
+            active = false;
+        };
+    }, [key]);
+
+    const persist = useCallback(
+        (o: WidgetId[], h: WidgetId[]) => {
+            if (key) AsyncStorage.setItem(key, JSON.stringify({ order: o, hidden: h })).catch(() => {});
+        },
+        [key],
+    );
+
+    const moveWidget = useCallback(
+        (from: number, to: number) => {
+            setOrder((prev) => {
+                const next = moveItem(prev, from, to);
+                persist(next, hidden);
+                return next;
+            });
+        },
+        [hidden, persist],
+    );
+
+    const toggleHidden = useCallback(
+        (id: WidgetId) => {
+            setHidden((prev) => {
+                const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
+                persist(order, next);
+                return next;
+            });
+        },
+        [order, persist],
+    );
+
+    const reset = useCallback(() => {
+        setOrder(DEFAULT_WIDGET_ORDER);
+        setHidden([]);
+        persist(DEFAULT_WIDGET_ORDER, []);
+    }, [persist]);
+
+    const visible = order.filter((id) => !hidden.includes(id));
+
+    return { order, hidden, visible, loaded, moveWidget, toggleHidden, reset };
+}

--- a/frontend/components/analytics/charts/DonutChart.tsx
+++ b/frontend/components/analytics/charts/DonutChart.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { View } from "react-native";
+import { PieChart } from "react-native-gifted-charts";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+interface DonutSlice {
+    color: string;
+    count: number;
+}
+
+interface DonutChartProps {
+    slices: DonutSlice[];
+    total: number;
+    size?: number;
+}
+
+/** Category-share donut with the period total in the center. */
+export function DonutChart({ slices, total, size = 140 }: DonutChartProps) {
+    const ThemedColor = useThemeColor() as any;
+
+    const data = slices.filter((s) => s.count > 0).map((s) => ({ value: s.count, color: s.color }));
+    const safeData = data.length > 0 ? data : [{ value: 1, color: ThemedColor.lightened }];
+
+    return (
+        <PieChart
+            data={safeData as any}
+            donut
+            radius={size / 2}
+            innerRadius={size / 2 - 22}
+            innerCircleColor={ThemedColor.lightenedCard}
+            centerLabelComponent={() => (
+                <View style={{ alignItems: "center" }}>
+                    <ThemedText type="fancyFrauncesSubheading">{String(total)}</ThemedText>
+                    <ThemedText type="caption">tasks</ThemedText>
+                </View>
+            )}
+        />
+    );
+}

--- a/frontend/components/analytics/charts/MonthHeatmap.tsx
+++ b/frontend/components/analytics/charts/MonthHeatmap.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { AnalyticsHeatmapDay } from "@/api/analytics";
+import { heatmapLevelColor } from "../analyticsColors";
+
+interface MonthHeatmapProps {
+    days: AnalyticsHeatmapDay[];
+}
+
+/** Trailing-quarter activity grid: columns of 7 days, colored by intensity. */
+export function MonthHeatmap({ days }: MonthHeatmapProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    const columns: AnalyticsHeatmapDay[][] = [];
+    for (let i = 0; i < days.length; i += 7) {
+        columns.push(days.slice(i, i + 7));
+    }
+
+    return (
+        <View style={styles.grid}>
+            {columns.map((col, ci) => (
+                <View key={ci} style={styles.column}>
+                    {col.map((d) => (
+                        <View
+                            key={d.date}
+                            style={[styles.cell, { backgroundColor: heatmapLevelColor(d.level, ThemedColor) }]}
+                        />
+                    ))}
+                </View>
+            ))}
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        grid: {
+            flexDirection: "row",
+            gap: 4,
+        },
+        column: {
+            gap: 4,
+        },
+        cell: {
+            width: 12,
+            height: 12,
+            borderRadius: 3,
+        },
+    });

--- a/frontend/components/analytics/charts/Sparkline.tsx
+++ b/frontend/components/analytics/charts/Sparkline.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import Svg, { Polyline } from "react-native-svg";
+
+interface SparklineProps {
+    data: number[];
+    color: string;
+    width?: number;
+    height?: number;
+}
+
+/** Tiny completion-trend line for category-health rows. */
+export function Sparkline({ data, color, width = 64, height = 24 }: SparklineProps) {
+    if (data.length === 0) {
+        return null;
+    }
+    const max = Math.max(1, ...data);
+    const step = data.length > 1 ? width / (data.length - 1) : width;
+    const points = data
+        .map((v, i) => `${(i * step).toFixed(1)},${(height - (v / max) * height).toFixed(1)}`)
+        .join(" ");
+
+    return (
+        <Svg width={width} height={height}>
+            <Polyline
+                points={points}
+                fill="none"
+                stroke={color}
+                strokeWidth={2}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+            />
+        </Svg>
+    );
+}

--- a/frontend/components/analytics/charts/StackedBandChart.tsx
+++ b/frontend/components/analytics/charts/StackedBandChart.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsShareBand } from "@/api/analytics";
+
+interface StackedBandChartProps {
+    bands: AnalyticsShareBand[];
+}
+
+/** 100% stacked bands per week/month — one horizontal bar per bucket. */
+export function StackedBandChart({ bands }: StackedBandChartProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    return (
+        <View style={styles.container}>
+            {bands.map((band) => (
+                <BandRow key={band.label} band={band} ThemedColor={ThemedColor} />
+            ))}
+        </View>
+    );
+}
+
+function BandRow({ band, ThemedColor }: { band: AnalyticsShareBand; ThemedColor: any }) {
+    const styles = stylesheet(ThemedColor);
+    const total = band.slices.reduce((sum, s) => sum + s.count, 0);
+
+    return (
+        <View style={styles.row}>
+            <ThemedText type="caption" style={styles.label}>
+                {band.label}
+            </ThemedText>
+            <View style={styles.bar}>
+                {total === 0 ? (
+                    <View style={[styles.segment, { flex: 1, backgroundColor: ThemedColor.lightened }]} />
+                ) : (
+                    band.slices.map((s, i) => (
+                        <View
+                            key={s.categoryId + i}
+                            style={[styles.segment, { flex: Math.max(s.count, 0.0001), backgroundColor: s.color }]}
+                        />
+                    ))
+                )}
+            </View>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        container: {
+            gap: 10,
+        },
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+        },
+        label: {
+            width: 40,
+        },
+        bar: {
+            flex: 1,
+            height: 16,
+            flexDirection: "row",
+            borderRadius: 8,
+            overflow: "hidden",
+        },
+        segment: {
+            height: "100%",
+        },
+    });

--- a/frontend/components/analytics/charts/StackedBarChart.tsx
+++ b/frontend/components/analytics/charts/StackedBarChart.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { View } from "react-native";
+import { BarChart } from "react-native-gifted-charts";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { AnalyticsProgressBucket } from "@/api/analytics";
+
+interface StackedBarChartProps {
+    buckets: AnalyticsProgressBucket[];
+    height?: number;
+}
+
+/** Stacked bars by day/week/month, segmented by category color. */
+export function StackedBarChart({ buckets, height = 160 }: StackedBarChartProps) {
+    const ThemedColor = useThemeColor() as any;
+
+    const stackData = buckets.map((b) => ({
+        label: b.label,
+        stacks:
+            b.segments.length > 0
+                ? b.segments.map((s) => ({ value: s.count, color: s.color }))
+                : [{ value: 0, color: "transparent" }],
+    }));
+
+    const peak = Math.max(1, ...buckets.map((b) => b.total));
+    const maxValue = peak <= 3 ? 3 : Math.ceil(peak / 3) * 3;
+
+    return (
+        <View>
+            <BarChart
+                stackData={stackData as any}
+                height={height}
+                barWidth={18}
+                spacing={buckets.length > 7 ? 10 : 16}
+                initialSpacing={8}
+                endSpacing={4}
+                barBorderRadius={4}
+                hideRules
+                hideYAxisText
+                yAxisThickness={0}
+                xAxisThickness={0}
+                noOfSections={3}
+                maxValue={maxValue}
+                disableScroll
+                xAxisLabelTextStyle={{ color: ThemedColor.caption, fontSize: 11 }}
+            />
+        </View>
+    );
+}

--- a/frontend/hooks/useAnalyticsData.ts
+++ b/frontend/hooks/useAnalyticsData.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { getAnalytics, AnalyticsFilters } from "@/api/analytics";
+
+/**
+ * React Query hook for the analytics dashboard. Named to avoid clobbering the
+ * PostHog `useAnalytics` hook.
+ */
+export function useAnalyticsData(filters: AnalyticsFilters) {
+    return useQuery({
+        queryKey: ["analytics", filters.range, filters.workspace ?? "all", filters.category ?? "all"],
+        queryFn: () => getAnalytics(filters),
+        staleTime: 60_000,
+    });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,6 +101,7 @@
     "react-native-emoji-selector": "^0.2.0",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-get-random-values": "^1.11.0",
+    "react-native-gifted-charts": "^1.4.77",
     "react-native-modal": "^14.0.0-rc.1",
     "react-native-otp-entry": "^1.8.5",
     "react-native-pager-view": "8.0.0",


### PR DESCRIPTION
## What

Rebuilds the Activity tab as a customizable, single-column **widget dashboard** — Phase 1 (Widget Dashboard Foundation) of the Kindred Analytics spec. Frontend **and** backend.

## Backend — `internal/handlers/analytics/`

- New endpoint **`GET /v1/user/analytics?range=week|month|sixmonth&workspace=&category=`** returning one widget-ready payload.
- `compute.go` is a **DB-free, table-tested** pure layer; `service.go` aggregates from `completed-tasks`, `template-tasks`, `categories`, and `encouragements`.
- Produces: signal strip (momentum/timing/support + deltas), stacked progress (day/week/month buckets by category), category share (donut + 100% bands), activity heatmap (trailing 13 weeks), habits (rhythm copy — **no "streak"**), and category/workspace health.
- Takeaways are **deterministic rule strings** (no AI). All DTOs prefixed `Analytics*` to avoid the Huma duplicate-type panic. Regenerated `api-spec.yaml` + `generated/types.ts`.

## Frontend — `components/analytics/` + `(activity)`

- `(activity)/index.tsx` now renders `<AnalyticsHome/>` (was a redirect); `[id].tsx` stays as the other-user view.
- W/M/6M range switcher, workspace dropdown, category filter chips, and 7 widgets — tappable where they filter in-screen.
- Charts via **react-native-gifted-charts** (stacked bars, donut) + custom SVG `Sparkline`/`MonthHeatmap`.
- **Edit / Add-Cards shell** (`(activity)/edit.tsx`): reorder + show/hide, persisted to AsyncStorage (`analytics_layout_${userId}`).

## Verification

- Backend: `go build ./...` ✓, `go test -short -race ./internal/handlers/analytics/...` ✓, OpenAPI generation registers all routes with no panic ✓, pre-commit hook (gofmt/go vet/unit tests) ✓.
- Frontend: `tsc --noEmit` → only the 14 pre-existing DatePager errors, **zero new** ✓; new Jest suite **10/10** ✓.

## Scope

Phase 1 only. Deferred to their own PRs: Phase 2 drilldowns (workspace/category/insight detail, habits screen), Phase 3 social (Ask for Support, Kudos Effect, Weekly Review, Friend View), Phase 4 personalization (server-synced layout, Add Cards gallery, AI detectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)