### PR TITLE
analytics: empty-data fix + dashboard polish + Phase 2 drilldowns

### DIFF
--- a/backend/internal/handlers/analytics/compute.go
+++ b/backend/internal/handlers/analytics/compute.go
@@ -424,8 +424,9 @@ func computeProgress(unit string, curStart time.Time, nb int, cur, prev []Analyt
 	segCounts := make([]map[string]int, nb)
 	for i := 0; i < nb; i++ {
 		buckets[i] = AnalyticsProgressBucket{
-			Label: bucketLabel(unit, curStart, i),
-			Date:  bucketStart(unit, curStart, i).Format("2006-01-02"),
+			Label:    bucketLabel(unit, curStart, i),
+			Date:     bucketStart(unit, curStart, i).Format("2006-01-02"),
+			Segments: []AnalyticsProgressSegment{},
 		}
 		segCounts[i] = map[string]int{}
 	}
@@ -531,8 +532,8 @@ func computeShare(unit string, curStart time.Time, nb int, cur []AnalyticsTaskLi
 		})
 	}
 
-	// Bands over time (month / sixmonth only).
-	var bands []AnalyticsShareBand
+	// 100% stacked bands per bucket (month range → weekly bands, sixmonth → monthly).
+	bands := []AnalyticsShareBand{}
 	if unit == "week" || unit == "month" {
 		segCounts := make([]map[string]int, nb)
 		totals := make([]int, nb)
@@ -551,27 +552,23 @@ func computeShare(unit string, curStart time.Time, nb int, cur []AnalyticsTaskLi
 			segCounts[idx][key]++
 			totals[idx]++
 		}
-		// Only emit bands when there's a per-bucket breakdown worth showing.
-		if unit == "month" {
-			bands = make([]AnalyticsShareBand, 0, nb)
-			for i := 0; i < nb; i++ {
-				band := AnalyticsShareBand{Label: bucketLabel(unit, curStart, i)}
-				for _, cid := range top {
-					if c := segCounts[i][cid]; c > 0 {
-						band.Slices = append(band.Slices, AnalyticsShareSlice{
-							CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid],
-							Count: c, Pct: float64(pctInt(c, totals[i])),
-						})
-					}
-				}
-				if c := segCounts[i][otherID]; c > 0 {
+		for i := 0; i < nb; i++ {
+			band := AnalyticsShareBand{Label: bucketLabel(unit, curStart, i), Slices: []AnalyticsShareSlice{}}
+			for _, cid := range top {
+				if c := segCounts[i][cid]; c > 0 {
 					band.Slices = append(band.Slices, AnalyticsShareSlice{
-						CategoryID: otherID, Name: otherName, Color: otherColor,
+						CategoryID: cid, Name: nameOf(cid), Color: colorByID[cid],
 						Count: c, Pct: float64(pctInt(c, totals[i])),
 					})
 				}
-				bands = append(bands, band)
 			}
+			if c := segCounts[i][otherID]; c > 0 {
+				band.Slices = append(band.Slices, AnalyticsShareSlice{
+					CategoryID: otherID, Name: otherName, Color: otherColor,
+					Count: c, Pct: float64(pctInt(c, totals[i])),
+				})
+			}
+			bands = append(bands, band)
 		}
 	}
 

--- a/backend/internal/handlers/analytics/compute_empty_test.go
+++ b/backend/internal/handlers/analytics/compute_empty_test.go
@@ -1,0 +1,76 @@
+package analytics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// With no completed tasks, every array field must serialize as [] (not null),
+// so the frontend can iterate without null guards. Regression for the
+// `segments: null` crash.
+func TestComputeAnalytics_EmptyDataEmitsEmptySlices(t *testing.T) {
+	resp := computeAnalytics(computeInput{
+		Range:      RangeWeek,
+		Now:        fixedNow,
+		Completed:  nil,
+		Categories: baseCategories(),
+		Habits:     nil,
+	})
+
+	if resp.Progress.Buckets == nil {
+		t.Fatal("progress.buckets is nil")
+	}
+	for i, b := range resp.Progress.Buckets {
+		if b.Segments == nil {
+			t.Errorf("bucket %d segments is nil, want empty slice", i)
+		}
+	}
+	if resp.Progress.Legend == nil {
+		t.Error("progress.legend is nil")
+	}
+	if resp.CategoryShare.Slices == nil {
+		t.Error("categoryShare.slices is nil")
+	}
+	if resp.CategoryShare.OverTime == nil {
+		t.Error("categoryShare.overTime is nil")
+	}
+	if resp.Heatmap.Days == nil {
+		t.Error("heatmap.days is nil")
+	}
+	if resp.Habits.Rows == nil {
+		t.Error("habits.rows is nil")
+	}
+	if resp.CategoryHealth.Rows == nil {
+		t.Error("categoryHealth.rows is nil")
+	}
+	if resp.WorkspaceHealth.Rows == nil {
+		t.Error("workspaceHealth.rows is nil")
+	}
+
+	// The marshaled payload must contain no JSON null arrays for these keys.
+	blob, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	for _, bad := range []string{`"segments":null`, `"overTime":null`, `"buckets":null`, `"days":null`, `"rows":null`} {
+		if strings.Contains(string(blob), bad) {
+			t.Errorf("payload contains %s", bad)
+		}
+	}
+}
+
+// Month range produces weekly bands (previously only sixmonth did).
+func TestComputeShare_MonthRangeHasBands(t *testing.T) {
+	// 2025-05-12 is in week-of-month bucket 1 (days 8-14 -> index 1).
+	mid := fixedNow // 2025-05-14
+	resp := computeAnalytics(computeInput{
+		Range:      RangeMonth,
+		Now:        fixedNow,
+		Completed:  []AnalyticsTaskLite{task("school", mid, nil, 0)},
+		Categories: baseCategories(),
+	})
+	if len(resp.CategoryShare.OverTime) == 0 {
+		t.Fatal("month range should emit weekly bands")
+	}
+}

--- a/frontend/__tests__/AnalyticsWidgets.test.tsx
+++ b/frontend/__tests__/AnalyticsWidgets.test.tsx
@@ -47,8 +47,8 @@ describe("analyticsLayout", () => {
     });
 
     test("sanitizeOrder drops unknowns and appends new widgets", () => {
-        const result = sanitizeOrder(["heatmap", "bogus", "signals"]);
-        expect(result.slice(0, 2)).toEqual(["heatmap", "signals"]);
+        const result = sanitizeOrder(["heatmap", "bogus", "progress"]);
+        expect(result.slice(0, 2)).toEqual(["heatmap", "progress"]);
         // every default widget ends up present exactly once
         expect(new Set(result)).toEqual(new Set(DEFAULT_WIDGET_ORDER));
         expect(result).toHaveLength(DEFAULT_WIDGET_ORDER.length);

--- a/frontend/components/analytics/ActivityHeatmapWidget.tsx
+++ b/frontend/components/analytics/ActivityHeatmapWidget.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, StyleSheet } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { ThemedText } from "@/components/ThemedText";
@@ -6,32 +6,53 @@ import { AnalyticsHeatmap } from "@/api/analytics";
 import { WidgetCard } from "./WidgetCard";
 import { MonthHeatmap } from "./charts/MonthHeatmap";
 import { heatmapLevelColor } from "./analyticsColors";
+import CompletedTasksBottomSheetModal from "@/components/modals/CompletedTasksBottomSheetModal";
 
 export function ActivityHeatmapWidget({ heatmap }: { heatmap: AnalyticsHeatmap }) {
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
+    const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+    const [modalVisible, setModalVisible] = useState(false);
+
+    const onSelectDay = (date: Date) => {
+        setSelectedDate(date);
+        setModalVisible(true);
+    };
 
     return (
         <WidgetCard title="Activity heatmap" takeaway={heatmap.takeaway}>
-            <MonthHeatmap days={heatmap.days} />
-            <View style={styles.legend}>
-                <ThemedText type="caption">Less</ThemedText>
-                {[0, 1, 2, 3, 4].map((level) => (
-                    <View key={level} style={[styles.cell, { backgroundColor: heatmapLevelColor(level, ThemedColor) }]} />
-                ))}
-                <ThemedText type="caption">More</ThemedText>
+            <MonthHeatmap days={heatmap.days} onSelectDay={onSelectDay} />
+
+            <View style={styles.footer}>
+                <ThemedText type="caption">Tap a day to see what you finished</ThemedText>
+                <View style={styles.legend}>
+                    <ThemedText type="caption">Less</ThemedText>
+                    {[0, 1, 2, 3, 4].map((level) => (
+                        <View key={level} style={[styles.cell, { backgroundColor: heatmapLevelColor(level, ThemedColor) }]} />
+                    ))}
+                    <ThemedText type="caption">More</ThemedText>
+                </View>
             </View>
+
+            <CompletedTasksBottomSheetModal visible={modalVisible} setVisible={setModalVisible} date={selectedDate} />
         </WidgetCard>
     );
 }
 
 const stylesheet = (ThemedColor: any) =>
     StyleSheet.create({
+        footer: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginTop: 12,
+            flexWrap: "wrap",
+            gap: 8,
+        },
         legend: {
             flexDirection: "row",
             alignItems: "center",
             gap: 4,
-            marginTop: 12,
         },
         cell: {
             width: 12,

--- a/frontend/components/analytics/AnalyticsHome.tsx
+++ b/frontend/components/analytics/AnalyticsHome.tsx
@@ -13,7 +13,6 @@ import { WorkspaceSelector } from "./WorkspaceSelector";
 import { RangeSwitcher } from "./RangeSwitcher";
 import { FilterChips } from "./FilterChips";
 import { useAnalyticsLayout, WidgetId } from "./analyticsLayout";
-import { SignalStrip } from "./SignalStrip";
 import { WeeklyProgressWidget } from "./WeeklyProgressWidget";
 import { CategoryShareWidget } from "./CategoryShareWidget";
 import { ActivityHeatmapWidget } from "./ActivityHeatmapWidget";
@@ -115,8 +114,6 @@ interface WidgetRendererProps {
 /** Maps a widget id to its component — a proper component, not an inline helper. */
 function WidgetRenderer({ id, data, range, onSelectCategory }: WidgetRendererProps) {
     switch (id) {
-        case "signals":
-            return <SignalStrip signals={data.signals} />;
         case "progress":
             return <WeeklyProgressWidget progress={data.progress} range={range} />;
         case "categoryShare":

--- a/frontend/components/analytics/CategoryHealthWidget.tsx
+++ b/frontend/components/analytics/CategoryHealthWidget.tsx
@@ -16,7 +16,8 @@ export function CategoryHealthWidget({ categoryHealth, onSelectCategory }: Props
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
 
-    if (categoryHealth.rows.length === 0) {
+    const rows = categoryHealth.rows ?? [];
+    if (rows.length === 0) {
         return (
             <WidgetCard title="Category health">
                 <ThemedText type="caption">No category activity in this period yet.</ThemedText>
@@ -27,7 +28,7 @@ export function CategoryHealthWidget({ categoryHealth, onSelectCategory }: Props
     return (
         <WidgetCard title="Category health">
             <View style={styles.list}>
-                {categoryHealth.rows.map((row) => (
+                {rows.map((row) => (
                     <CategoryHealthRowItem key={row.categoryId} row={row} onSelectCategory={onSelectCategory} />
                 ))}
             </View>
@@ -60,7 +61,7 @@ function CategoryHealthRowItem({
                 </View>
             </View>
             <View style={styles.right}>
-                <Sparkline data={row.sparkline} color={row.color} width={48} height={20} />
+                <Sparkline data={row.sparkline ?? []} color={row.color} width={48} height={20} />
                 <StatusPill status={row.status} />
             </View>
         </TouchableOpacity>

--- a/frontend/components/analytics/CategoryShareWidget.tsx
+++ b/frontend/components/analytics/CategoryShareWidget.tsx
@@ -18,18 +18,20 @@ export function CategoryShareWidget({ share, range, onSelectCategory }: Props) {
     const styles = stylesheet(ThemedColor);
 
     const title = range === "week" ? "Where your time went" : "Category share";
-    const total = share.slices.reduce((sum, s) => sum + s.count, 0);
-    const useBands = range !== "week" && share.overTime.length > 0;
+    const slices = share.slices ?? [];
+    const overTime = share.overTime ?? [];
+    const total = slices.reduce((sum, s) => sum + s.count, 0);
+    const useBands = range !== "week" && overTime.length > 0;
 
     return (
         <WidgetCard title={title} takeaway={share.takeaway}>
             {useBands ? (
-                <StackedBandChart bands={share.overTime} />
+                <StackedBandChart bands={overTime} />
             ) : (
                 <View style={styles.donutRow}>
-                    <DonutChart slices={share.slices} total={total} />
+                    <DonutChart slices={slices} total={total} />
                     <View style={styles.legend}>
-                        {share.slices.map((slice) => (
+                        {slices.map((slice) => (
                             <ShareLegendRow key={slice.categoryId} slice={slice} onSelectCategory={onSelectCategory} />
                         ))}
                     </View>

--- a/frontend/components/analytics/HabitsWidget.tsx
+++ b/frontend/components/analytics/HabitsWidget.tsx
@@ -19,11 +19,11 @@ export function HabitsWidget({ habits, onPress }: Props) {
             title="Habits & recurring"
             takeaway={habits.takeaway}
             cta={onPress ? { label: "View habits", onPress } : undefined}>
-            {habits.rows.length === 0 ? (
+            {(habits.rows ?? []).length === 0 ? (
                 <ThemedText type="caption">No recurring tasks yet.</ThemedText>
             ) : (
                 <View style={styles.list}>
-                    {habits.rows.map((row) => (
+                    {(habits.rows ?? []).map((row) => (
                         <HabitRow key={row.templateId} row={row} />
                     ))}
                 </View>
@@ -44,7 +44,7 @@ function HabitRow({ row }: { row: AnalyticsHabitRow }) {
                 <ThemedText type="caption">{row.rhythmLabel}</ThemedText>
             </View>
             <View style={styles.dots}>
-                {row.dots.map((filled, i) => (
+                {(row.dots ?? []).map((filled, i) => (
                     <View
                         key={i}
                         style={[

--- a/frontend/components/analytics/WeeklyProgressWidget.tsx
+++ b/frontend/components/analytics/WeeklyProgressWidget.tsx
@@ -48,7 +48,7 @@ export function WeeklyProgressWidget({ progress, range }: Props) {
             <StackedBarChart buckets={progress.buckets} />
 
             <View style={styles.legend}>
-                {progress.legend.map((item) => (
+                {(progress.legend ?? []).map((item) => (
                     <LegendChip key={item.categoryId} item={item} />
                 ))}
             </View>

--- a/frontend/components/analytics/WidgetCard.tsx
+++ b/frontend/components/analytics/WidgetCard.tsx
@@ -67,6 +67,7 @@ const stylesheet = (ThemedColor: any) =>
             marginBottom: 16,
             borderWidth: 1,
             borderColor: ThemedColor.tertiary,
+            boxShadow: ThemedColor.shadowSmall,
         },
         header: {
             flexDirection: "row",

--- a/frontend/components/analytics/WorkspaceHealthWidget.tsx
+++ b/frontend/components/analytics/WorkspaceHealthWidget.tsx
@@ -15,7 +15,8 @@ export function WorkspaceHealthWidget({ workspaceHealth, onSelectWorkspace }: Pr
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
 
-    if (workspaceHealth.rows.length === 0) {
+    const rows = workspaceHealth.rows ?? [];
+    if (rows.length === 0) {
         return (
             <WidgetCard title="Workspace health">
                 <ThemedText type="caption">No workspace activity in this period yet.</ThemedText>
@@ -26,7 +27,7 @@ export function WorkspaceHealthWidget({ workspaceHealth, onSelectWorkspace }: Pr
     return (
         <WidgetCard title="Workspace health">
             <View style={styles.list}>
-                {workspaceHealth.rows.map((row) => (
+                {rows.map((row) => (
                     <WorkspaceHealthRowItem key={row.workspace} row={row} onSelectWorkspace={onSelectWorkspace} />
                 ))}
             </View>

--- a/frontend/components/analytics/analyticsLayout.ts
+++ b/frontend/components/analytics/analyticsLayout.ts
@@ -2,18 +2,16 @@ import { useCallback, useEffect, useState } from "react";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
 export type WidgetId =
-    | "signals"
-    | "progress"
     | "categoryShare"
+    | "progress"
     | "habits"
     | "heatmap"
     | "categoryHealth"
     | "workspaceHealth";
 
 export const DEFAULT_WIDGET_ORDER: WidgetId[] = [
-    "signals",
-    "progress",
     "categoryShare",
+    "progress",
     "habits",
     "heatmap",
     "categoryHealth",
@@ -21,9 +19,8 @@ export const DEFAULT_WIDGET_ORDER: WidgetId[] = [
 ];
 
 export const WIDGET_TITLES: Record<WidgetId, string> = {
-    signals: "Signal strip",
-    progress: "Weekly progress",
-    categoryShare: "Category share",
+    categoryShare: "Where your time went",
+    progress: "Progress",
     habits: "Habits & recurring",
     heatmap: "Activity heatmap",
     categoryHealth: "Category health",
@@ -55,7 +52,9 @@ export function sanitizeOrder(order: unknown): WidgetId[] {
     return arr;
 }
 
-const keyFor = (userId?: string) => (userId ? `analytics_layout_${userId}` : null);
+// v2: dropped the signal strip and reordered (Category Share first). The key
+// bump resets stale persisted layouts to the new default.
+const keyFor = (userId?: string) => (userId ? `analytics_layout_v2_${userId}` : null);
 
 /**
  * Persisted, reorderable widget layout. Stored locally (AsyncStorage) for

--- a/frontend/components/analytics/charts/MonthHeatmap.tsx
+++ b/frontend/components/analytics/charts/MonthHeatmap.tsx
@@ -1,33 +1,63 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
 import { AnalyticsHeatmapDay } from "@/api/analytics";
 import { heatmapLevelColor } from "../analyticsColors";
 
 interface MonthHeatmapProps {
     days: AnalyticsHeatmapDay[];
+    onSelectDay?: (date: Date) => void;
+    weeks?: number;
 }
 
-/** Trailing-quarter activity grid: columns of 7 days, colored by intensity. */
-export function MonthHeatmap({ days }: MonthHeatmapProps) {
+const WEEKDAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+const CELL = 16;
+const GAP = 4;
+
+function parseLocalDate(iso: string): Date {
+    const [y, m, d] = iso.split("-").map((n) => parseInt(n, 10));
+    return new Date(y, (m || 1) - 1, d || 1);
+}
+
+// Mon=0 ... Sun=6
+function mondayIndex(date: Date): number {
+    return (date.getDay() + 6) % 7;
+}
+
+/** Monday-aligned calendar grid (weekday columns, week rows). Cells with
+ * activity are tappable to inspect that day. */
+export function MonthHeatmap({ days, onSelectDay, weeks = 10 }: MonthHeatmapProps) {
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
-
     const safeDays = days ?? [];
-    const columns: AnalyticsHeatmapDay[][] = [];
-    for (let i = 0; i < safeDays.length; i += 7) {
-        columns.push(safeDays.slice(i, i + 7));
+
+    if (safeDays.length === 0) {
+        return null;
     }
 
+    const firstMon = mondayIndex(parseLocalDate(safeDays[0].date));
+    const cells: (AnalyticsHeatmapDay | null)[] = [];
+    for (let i = 0; i < firstMon; i++) cells.push(null);
+    safeDays.forEach((d) => cells.push(d));
+
+    const rows: (AnalyticsHeatmapDay | null)[][] = [];
+    for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+    const shown = rows.slice(-weeks);
+
     return (
-        <View style={styles.grid}>
-            {columns.map((col, ci) => (
-                <View key={ci} style={styles.column}>
-                    {col.map((d) => (
-                        <View
-                            key={d.date}
-                            style={[styles.cell, { backgroundColor: heatmapLevelColor(d.level, ThemedColor) }]}
-                        />
+        <View>
+            <View style={styles.headerRow}>
+                {WEEKDAY_LABELS.map((label, i) => (
+                    <ThemedText key={i} type="caption" style={styles.headerLabel}>
+                        {label}
+                    </ThemedText>
+                ))}
+            </View>
+            {shown.map((week, wi) => (
+                <View key={wi} style={styles.weekRow}>
+                    {Array.from({ length: 7 }).map((_, di) => (
+                        <HeatCell key={di} day={week[di] ?? null} onSelectDay={onSelectDay} ThemedColor={ThemedColor} />
                     ))}
                 </View>
             ))}
@@ -35,18 +65,54 @@ export function MonthHeatmap({ days }: MonthHeatmapProps) {
     );
 }
 
+function HeatCell({
+    day,
+    onSelectDay,
+    ThemedColor,
+}: {
+    day: AnalyticsHeatmapDay | null;
+    onSelectDay?: (date: Date) => void;
+    ThemedColor: any;
+}) {
+    if (!day) {
+        return <View style={{ width: CELL, height: CELL }} />;
+    }
+    const empty = day.level === 0;
+    const tappable = day.count > 0 && !!onSelectDay;
+    return (
+        <TouchableOpacity
+            disabled={!tappable}
+            activeOpacity={0.6}
+            onPress={() => onSelectDay?.(parseLocalDate(day.date))}>
+            <View
+                style={{
+                    width: CELL,
+                    height: CELL,
+                    borderRadius: 4,
+                    backgroundColor: heatmapLevelColor(day.level, ThemedColor),
+                    borderWidth: empty ? StyleSheet.hairlineWidth : 0,
+                    borderColor: ThemedColor.tertiary,
+                }}
+            />
+        </TouchableOpacity>
+    );
+}
+
 const stylesheet = (ThemedColor: any) =>
     StyleSheet.create({
-        grid: {
+        headerRow: {
             flexDirection: "row",
-            gap: 4,
+            gap: GAP,
+            marginBottom: GAP,
         },
-        column: {
-            gap: 4,
+        headerLabel: {
+            width: CELL,
+            textAlign: "center",
+            fontSize: 10,
         },
-        cell: {
-            width: 12,
-            height: 12,
-            borderRadius: 3,
+        weekRow: {
+            flexDirection: "row",
+            gap: GAP,
+            marginBottom: GAP,
         },
     });

--- a/frontend/components/analytics/charts/MonthHeatmap.tsx
+++ b/frontend/components/analytics/charts/MonthHeatmap.tsx
@@ -13,9 +13,10 @@ export function MonthHeatmap({ days }: MonthHeatmapProps) {
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
 
+    const safeDays = days ?? [];
     const columns: AnalyticsHeatmapDay[][] = [];
-    for (let i = 0; i < days.length; i += 7) {
-        columns.push(days.slice(i, i + 7));
+    for (let i = 0; i < safeDays.length; i += 7) {
+        columns.push(safeDays.slice(i, i + 7));
     }
 
     return (

--- a/frontend/components/analytics/charts/StackedBandChart.tsx
+++ b/frontend/components/analytics/charts/StackedBandChart.tsx
@@ -15,7 +15,7 @@ export function StackedBandChart({ bands }: StackedBandChartProps) {
 
     return (
         <View style={styles.container}>
-            {bands.map((band) => (
+            {(bands ?? []).map((band) => (
                 <BandRow key={band.label} band={band} ThemedColor={ThemedColor} />
             ))}
         </View>
@@ -24,7 +24,8 @@ export function StackedBandChart({ bands }: StackedBandChartProps) {
 
 function BandRow({ band, ThemedColor }: { band: AnalyticsShareBand; ThemedColor: any }) {
     const styles = stylesheet(ThemedColor);
-    const total = band.slices.reduce((sum, s) => sum + s.count, 0);
+    const slices = band.slices ?? [];
+    const total = slices.reduce((sum, s) => sum + s.count, 0);
 
     return (
         <View style={styles.row}>
@@ -35,7 +36,7 @@ function BandRow({ band, ThemedColor }: { band: AnalyticsShareBand; ThemedColor:
                 {total === 0 ? (
                     <View style={[styles.segment, { flex: 1, backgroundColor: ThemedColor.lightened }]} />
                 ) : (
-                    band.slices.map((s, i) => (
+                    slices.map((s, i) => (
                         <View
                             key={s.categoryId + i}
                             style={[styles.segment, { flex: Math.max(s.count, 0.0001), backgroundColor: s.color }]}

--- a/frontend/components/analytics/charts/StackedBarChart.tsx
+++ b/frontend/components/analytics/charts/StackedBarChart.tsx
@@ -13,15 +13,19 @@ interface StackedBarChartProps {
 export function StackedBarChart({ buckets, height = 160 }: StackedBarChartProps) {
     const ThemedColor = useThemeColor() as any;
 
-    const stackData = buckets.map((b) => ({
-        label: b.label,
-        stacks:
-            b.segments.length > 0
-                ? b.segments.map((s) => ({ value: s.count, color: s.color }))
-                : [{ value: 0, color: "transparent" }],
-    }));
+    const safeBuckets = buckets ?? [];
+    const stackData = safeBuckets.map((b) => {
+        const segments = b.segments ?? [];
+        return {
+            label: b.label,
+            stacks:
+                segments.length > 0
+                    ? segments.map((s) => ({ value: s.count, color: s.color }))
+                    : [{ value: 0, color: "transparent" }],
+        };
+    });
 
-    const peak = Math.max(1, ...buckets.map((b) => b.total));
+    const peak = Math.max(1, ...safeBuckets.map((b) => b.total ?? 0));
     const maxValue = peak <= 3 ? 3 : Math.ceil(peak / 3) * 3;
 
     return (


### PR DESCRIPTION
## Problem

The merged dashboard crashes with `Cannot read property 'length' of null` in `StackedBarChart` when a user has empty/sparse completed-task data. Root cause: **empty Go slices marshal to JSON `null`, not `[]`** — so a bucket with no completions sends `segments: null`, and the default week view sends `categoryShare.overTime: null`. The widgets then blow up on `.length` / `.map`.

## Fix (both sides)

- **Backend** (`compute.go`): emit `[]` (not nil) for per-bucket `segments` and the share `bands`; also build weekly bands for the **month** range (previously only sixmonth produced bands).
- **Frontend**: defensive `?? []` guards on every response array the widgets iterate (`segments`, `overTime`, band `slices`, `buckets`, `legend`, `days`, `rows`, `dots`, `sparkline`) so a null payload can never crash the dashboard — works even before the backend redeploys.
- **Tests**: regression asserting empty-data produces no `null` arrays in the marshaled payload, plus month-range bands.

## Verification

- `go test ./internal/handlers/analytics/...` ✓ (incl. new regressions), pre-commit hook (gofmt/vet/tests) ✓
- `tsc --noEmit` → 14 pre-existing DatePager errors, **zero new** ✓; Jest 10/10 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)