### PR TITLE
feat(songs): preview clips in the song picker

### DIFF
--- a/frontend/__tests__/SongPickerModal.test.tsx
+++ b/frontend/__tests__/SongPickerModal.test.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react-native";
+import SongPickerModal from "@/components/profile/song/SongPickerModal";
+import { searchSongs } from "@/api/itunes";
+
+// One shared mock player so we can assert source swaps and playback control.
+const mockPlayer = {
+    loop: false,
+    play: jest.fn(),
+    pause: jest.fn(),
+    replaceAsync: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock("expo-video", () => ({
+    useVideoPlayer: (_source: unknown, setup?: (p: unknown) => void) => {
+        setup?.(mockPlayer);
+        return mockPlayer;
+    },
+    VideoView: "VideoView",
+}));
+
+jest.mock("expo-image", () => ({ Image: "Image" }));
+jest.mock("react-native-worklets", () => require("react-native-worklets/src/mock"));
+jest.mock("react-native-reanimated", () => require("react-native-reanimated/mock"));
+
+jest.mock("@/api/itunes", () => ({ searchSongs: jest.fn() }));
+
+const songA = {
+    id: 1,
+    title: "Song A",
+    artist: "Artist A",
+    previewUrl: "https://x/a.m4a",
+    artworkUrl: "https://x/a.jpg",
+};
+const songB = {
+    id: 2,
+    title: "Song B",
+    artist: "Artist B",
+    previewUrl: "https://x/b.m4a",
+    artworkUrl: "https://x/b.jpg",
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    (searchSongs as jest.Mock).mockResolvedValue([songA, songB]);
+});
+
+async function renderWithResults() {
+    const onSelect = jest.fn();
+    const onClose = jest.fn();
+    const view = render(<SongPickerModal visible onClose={onClose} onSelect={onSelect} />);
+    fireEvent.changeText(view.getByPlaceholderText("Search songs or artists"), "song");
+    await waitFor(() => view.getByText("Song A"));
+    return { ...view, onSelect, onClose };
+}
+
+describe("SongPickerModal", () => {
+    test("tapping a row previews its clip; tapping it again stops", async () => {
+        const { getByText } = await renderWithResults();
+        mockPlayer.pause.mockClear(); // the debounced search pauses on every keystroke
+
+        fireEvent.press(getByText("Song A"));
+        expect(mockPlayer.replaceAsync).toHaveBeenCalledWith(songA.previewUrl);
+        await waitFor(() => expect(mockPlayer.play).toHaveBeenCalled());
+        expect(mockPlayer.pause).not.toHaveBeenCalled();
+
+        fireEvent.press(getByText("Song A"));
+        expect(mockPlayer.pause).toHaveBeenCalledTimes(1);
+    });
+
+    test("tapping a different row swaps the source", async () => {
+        const { getByText } = await renderWithResults();
+
+        fireEvent.press(getByText("Song A"));
+        fireEvent.press(getByText("Song B"));
+        expect(mockPlayer.replaceAsync).toHaveBeenLastCalledWith(songB.previewUrl);
+    });
+
+    test("the + button selects and closes; a row tap does not select", async () => {
+        const { getByText, getByLabelText, onSelect, onClose } = await renderWithResults();
+
+        fireEvent.press(getByText("Song A"));
+        expect(onSelect).not.toHaveBeenCalled();
+
+        fireEvent.press(getByLabelText("Use Song A"));
+        expect(onSelect).toHaveBeenCalledWith(songA);
+        expect(onClose).toHaveBeenCalled();
+    });
+});

--- a/frontend/components/profile/song/SongPickerModal.tsx
+++ b/frontend/components/profile/song/SongPickerModal.tsx
@@ -1,10 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { Modal, View, TextInput, FlatList, TouchableOpacity, StyleSheet, ActivityIndicator } from "react-native";
 import { Image } from "expo-image";
+import { useVideoPlayer, VideoView } from "expo-video";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { MagnifyingGlass, MusicNote, X } from "phosphor-react-native";
+import { MagnifyingGlass, MusicNote, X, Play, Pause, PlusCircle } from "phosphor-react-native";
 import { searchSongs, type Song } from "@/api/itunes";
+import Equalizer from "./Equalizer";
 
 export default function SongPickerModal({
     visible,
@@ -19,9 +21,19 @@ export default function SongPickerModal({
     const [term, setTerm] = useState("");
     const [results, setResults] = useState<Song[]>([]);
     const [loading, setLoading] = useState(false);
+    const [previewId, setPreviewId] = useState<number | null>(null);
+
+    // One shared player for the whole list — tapping a row swaps its source
+    // rather than mounting a player per result.
+    const player = useVideoPlayer(null, (p) => {
+        p.loop = true;
+    });
 
     // Debounced search straight to the public iTunes API — no backend needed.
+    // Any in-flight preview stops when the query changes.
     useEffect(() => {
+        player.pause();
+        setPreviewId(null);
         if (!term.trim()) {
             setResults([]);
             return;
@@ -41,9 +53,29 @@ export default function SongPickerModal({
             clearTimeout(handle);
             controller.abort();
         };
-    }, [term]);
+    }, [term, player]);
+
+    // Never let a preview leak past a dismiss.
+    useEffect(() => {
+        if (!visible) {
+            player.pause();
+            setPreviewId(null);
+        }
+    }, [visible, player]);
+
+    const togglePreview = (song: Song) => {
+        if (previewId === song.id) {
+            player.pause();
+            setPreviewId(null);
+            return;
+        }
+        setPreviewId(song.id);
+        player.replaceAsync(song.previewUrl).then(() => player.play());
+    };
 
     const pick = (song: Song) => {
+        player.pause();
+        setPreviewId(null);
         onSelect(song);
         setTerm("");
         setResults([]);
@@ -81,32 +113,53 @@ export default function SongPickerModal({
                     keyExtractor={(item) => String(item.id)}
                     keyboardShouldPersistTaps="handled"
                     contentContainerStyle={styles.listContent}
-                    renderItem={({ item }) => (
-                        <TouchableOpacity
-                            style={[styles.row, { borderBottomColor: ThemedColor.tertiary }]}
-                            onPress={() => pick(item)}
-                            activeOpacity={0.7}>
-                            <View style={[styles.rowArt, { backgroundColor: ThemedColor.lightened }]}>
-                                {item.artworkUrl ? (
-                                    <Image
-                                        source={{ uri: item.artworkUrl }}
-                                        style={StyleSheet.absoluteFill}
-                                        contentFit="cover"
-                                    />
-                                ) : (
-                                    <MusicNote size={18} color={ThemedColor.caption} weight="fill" />
-                                )}
+                    renderItem={({ item }) => {
+                        const previewing = previewId === item.id;
+                        return (
+                            <View style={[styles.row, { borderBottomColor: ThemedColor.tertiary }]}>
+                                <TouchableOpacity
+                                    style={styles.rowMain}
+                                    onPress={() => togglePreview(item)}
+                                    activeOpacity={0.7}>
+                                    <View style={[styles.rowArt, { backgroundColor: ThemedColor.lightened }]}>
+                                        {item.artworkUrl ? (
+                                            <Image
+                                                source={{ uri: item.artworkUrl }}
+                                                style={StyleSheet.absoluteFill}
+                                                contentFit="cover"
+                                            />
+                                        ) : (
+                                            <MusicNote size={18} color={ThemedColor.caption} weight="fill" />
+                                        )}
+                                        <View style={styles.playOverlay}>
+                                            {previewing ? (
+                                                <Pause size={14} color="#fff" weight="fill" />
+                                            ) : (
+                                                <Play size={14} color="#fff" weight="fill" />
+                                            )}
+                                        </View>
+                                    </View>
+                                    <View style={styles.rowText}>
+                                        <ThemedText type="defaultSemiBold" numberOfLines={1}>
+                                            {item.title}
+                                        </ThemedText>
+                                        <ThemedText type="caption" numberOfLines={1}>
+                                            {item.artist}
+                                        </ThemedText>
+                                    </View>
+                                    {previewing && <Equalizer playing color={ThemedColor.primary} size={14} />}
+                                </TouchableOpacity>
+                                <TouchableOpacity
+                                    onPress={() => pick(item)}
+                                    hitSlop={8}
+                                    style={styles.addBtn}
+                                    activeOpacity={0.7}
+                                    accessibilityLabel={`Use ${item.title}`}>
+                                    <PlusCircle size={28} color={ThemedColor.primary} weight="fill" />
+                                </TouchableOpacity>
                             </View>
-                            <View style={styles.rowText}>
-                                <ThemedText type="defaultSemiBold" numberOfLines={1}>
-                                    {item.title}
-                                </ThemedText>
-                                <ThemedText type="caption" numberOfLines={1}>
-                                    {item.artist}
-                                </ThemedText>
-                            </View>
-                        </TouchableOpacity>
-                    )}
+                        );
+                    }}
                     ListEmptyComponent={
                         !loading && term.trim() ? (
                             <ThemedText type="caption" style={styles.empty}>
@@ -115,6 +168,8 @@ export default function SongPickerModal({
                         ) : null
                     }
                 />
+
+                <VideoView player={player} style={styles.hiddenVideo} />
             </View>
         </Modal>
     );
@@ -154,9 +209,14 @@ const styles = StyleSheet.create({
     row: {
         flexDirection: "row",
         alignItems: "center",
+        borderBottomWidth: 0.5,
+    },
+    rowMain: {
+        flex: 1,
+        flexDirection: "row",
+        alignItems: "center",
         gap: 12,
         paddingVertical: 10,
-        borderBottomWidth: 0.5,
     },
     rowArt: {
         width: 44,
@@ -166,11 +226,27 @@ const styles = StyleSheet.create({
         alignItems: "center",
         justifyContent: "center",
     },
+    playOverlay: {
+        ...StyleSheet.absoluteFillObject,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "rgba(0,0,0,0.25)",
+    },
     rowText: {
         flex: 1,
         gap: 2,
     },
+    addBtn: {
+        paddingLeft: 12,
+        paddingVertical: 10,
+    },
     empty: {
         marginTop: 24,
+    },
+    hiddenVideo: {
+        width: 1,
+        height: 1,
+        opacity: 0,
+        position: "absolute",
     },
 });


### PR DESCRIPTION
## What

You can now **preview a song before using it** in the picker — both for the profile song widget and post tagging (they share `SongPickerModal`).

- **Tap a result row** → plays/pauses its 30s preview. One shared `expo-video` player drives the whole list; its source is swapped per tap via `replaceAsync` (no player-per-row). The active row shows a play/pause overlay on the artwork plus the existing `Equalizer`.
- **Tap the new `+` button** → commits the selection (`onSelect` + close), keeping selection deliberate and separate from previewing.
- Preview always stops on dismiss, on select, and when the search term changes — audio never leaks out of the sheet.

No API/backend changes, and no caller changes: both surfaces inherit preview through the shared component.

## Testing

- New `frontend/__tests__/SongPickerModal.test.tsx` (3 tests): row tap previews & toggles, tapping a different row swaps the source, and `+` selects/closes while a row tap does not select. **All pass.**
- `tsc --noEmit`: no new errors (only the pre-existing DatePager baseline remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)