### PR TITLE
fix(modals): remove double horizontal padding in reaction/congrats sheets

### DIFF
--- a/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
+++ b/frontend/components/modals/CongratulatorsBottomSheetModal.tsx
@@ -107,7 +107,7 @@ export default function CongratulatorsBottomSheetModal({ visible, setVisible, ku
 
 const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
     StyleSheet.create({
-        container: { paddingHorizontal: 20, paddingBottom: 16, gap: 12, minHeight: 200 },
+        container: { paddingBottom: 16, gap: 12, minHeight: 200 },
         title: { marginBottom: 4 },
         row: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 10 },
         avatar: { width: 40, height: 40, borderRadius: 20, backgroundColor: ThemedColor.tertiary },

--- a/frontend/components/modals/ReactionsBottomSheetModal.tsx
+++ b/frontend/components/modals/ReactionsBottomSheetModal.tsx
@@ -100,7 +100,7 @@ export default function ReactionsBottomSheetModal({
 
 const createStyles = (ThemedColor: ReturnType<typeof useThemeColor>) =>
     StyleSheet.create({
-        container: { paddingHorizontal: 20, paddingBottom: 16, gap: 12, minHeight: 200 },
+        container: { paddingBottom: 16, gap: 12, minHeight: 200 },
         title: { marginBottom: 4 },
         chipRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
         chip: { paddingHorizontal: 12, paddingVertical: 6, borderRadius: 999, borderWidth: 1 },


### PR DESCRIPTION
## What

The "who reacted" and "who congratulated" bottom sheets had 40px of horizontal padding instead of 20.

`DefaultModal` already applies `paddingHorizontal: 20`, but the inner `container` style re-added another `paddingHorizontal: 20`. Removed the redundant inner padding — the same approach `CustomAlert.tsx` already documents (`paddingHorizontal: 0 // Remove double padding since DefaultModal adds it`).

## Changes
- `ReactionsBottomSheetModal.tsx` — drop `paddingHorizontal: 20` from `container`
- `CongratulatorsBottomSheetModal.tsx` — drop `paddingHorizontal: 20` from `container`

## Notes
The tagging surface (`TagFriendsModal`) was checked and is fine — it's a full-screen `Modal` with a single 16px pad, not `DefaultModal`, so no doubling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)