### PR TITLE
feat(activity): analytics dashboard expansion + assorted WIP

### DIFF
--- a/backend/internal/xsentry/middleware.go
+++ b/backend/internal/xsentry/middleware.go
@@ -81,11 +81,19 @@ func FiberMiddleware() fiber.Handler {
 			scope.SetContext("response", responseCtx)
 		})
 
-		// Huma writes validation failures (422) and handler 400s straight to the
-		// response — they never reach Fiber's ErrorHandler or slog.Error, so they'd
-		// be invisible otherwise. The scope above already carries the response body
-		// (field-level validation detail), user, and route.
-		if shouldReportClientError(statusCode) {
+		// Huma writes 5xx, validation failures (422), and handler 400s straight to
+		// the response — they never reach Fiber's ErrorHandler, and only reach
+		// Sentry if the handler also happened to slog.Error. Capturing here
+		// guarantees every internal error is recorded with full request context
+		// (route, user, body). The message groups per status+endpoint, so 5xx that a
+		// handler also logged stay low-cardinality rather than flooding.
+		switch {
+		case shouldReportServerError(statusCode):
+			hub.WithScope(func(scope *sentry.Scope) {
+				scope.SetLevel(sentry.LevelError)
+				hub.CaptureMessage(fmt.Sprintf("HTTP %d: %s %s", statusCode, c.Method(), c.Route().Path))
+			})
+		case shouldReportClientError(statusCode):
 			hub.WithScope(func(scope *sentry.Scope) {
 				scope.SetLevel(sentry.LevelWarning)
 				hub.CaptureMessage(fmt.Sprintf("HTTP %d: %s %s", statusCode, c.Method(), c.Route().Path))
@@ -94,6 +102,12 @@ func FiberMiddleware() fiber.Handler {
 
 		return err
 	}
+}
+
+// shouldReportServerError reports every 5xx — these are always unexpected and
+// worth a Sentry event regardless of whether the handler logged the error.
+func shouldReportServerError(status int) bool {
+	return status >= fiber.StatusInternalServerError
 }
 
 // shouldReportClientError picks the client errors that signal a frontend/backend

--- a/backend/internal/xsentry/middleware_test.go
+++ b/backend/internal/xsentry/middleware_test.go
@@ -1,0 +1,100 @@
+package xsentry
+
+import (
+	"context"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/gofiber/fiber/v2"
+)
+
+// mockTransport records every event the Sentry client would have sent.
+type mockTransport struct {
+	mu     sync.Mutex
+	events []*sentry.Event
+}
+
+func (t *mockTransport) Configure(sentry.ClientOptions) {}
+func (t *mockTransport) SendEvent(e *sentry.Event) {
+	t.mu.Lock()
+	t.events = append(t.events, e)
+	t.mu.Unlock()
+}
+func (t *mockTransport) Flush(time.Duration) bool              { return true }
+func (t *mockTransport) FlushWithContext(context.Context) bool { return true }
+func (t *mockTransport) Close()                                {}
+func (t *mockTransport) captured() []*sentry.Event             { t.mu.Lock(); defer t.mu.Unlock(); return t.events }
+
+// bindMockTransport wires a mock client onto the current hub for the duration of
+// the test and returns the recorder. The middleware clones CurrentHub, so this
+// is the seam the captured events flow through.
+func bindMockTransport(t *testing.T) *mockTransport {
+	t.Helper()
+	transport := &mockTransport{}
+	client, err := sentry.NewClient(sentry.ClientOptions{
+		Dsn:        "https://test@test.ingest.sentry.io/1",
+		Transport:  transport,
+		SampleRate: 1.0,
+	})
+	if err != nil {
+		t.Fatalf("new sentry client: %v", err)
+	}
+	prev := sentry.CurrentHub().Client()
+	sentry.CurrentHub().BindClient(client)
+	t.Cleanup(func() { sentry.CurrentHub().BindClient(prev) })
+	return transport
+}
+
+func TestFiberMiddleware_CapturesByStatus(t *testing.T) {
+	cases := []struct {
+		name      string
+		path      string
+		status    int
+		wantEvent bool
+		wantLevel sentry.Level
+	}{
+		{"success is quiet", "/ok", fiber.StatusOK, false, ""},
+		{"not found is quiet", "/missing", fiber.StatusNotFound, false, ""},
+		{"unauthorized is quiet", "/unauth", fiber.StatusUnauthorized, false, ""},
+		{"bad request warns", "/bad", fiber.StatusBadRequest, true, sentry.LevelWarning},
+		{"validation warns", "/invalid", fiber.StatusUnprocessableEntity, true, sentry.LevelWarning},
+		{"internal error reports", "/boom", fiber.StatusInternalServerError, true, sentry.LevelError},
+		{"bad gateway reports", "/gateway", fiber.StatusBadGateway, true, sentry.LevelError},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := bindMockTransport(t)
+
+			app := fiber.New()
+			app.Use(FiberMiddleware())
+			status := tc.status
+			app.Get(tc.path, func(c *fiber.Ctx) error { return c.SendStatus(status) })
+
+			resp, err := app.Test(httptest.NewRequest("GET", tc.path, nil))
+			if err != nil {
+				t.Fatalf("request: %v", err)
+			}
+			if resp.StatusCode != tc.status {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.status)
+			}
+
+			events := transport.captured()
+			if !tc.wantEvent {
+				if len(events) != 0 {
+					t.Fatalf("expected no event for %d, got %d", tc.status, len(events))
+				}
+				return
+			}
+			if len(events) != 1 {
+				t.Fatalf("expected exactly 1 event for %d, got %d", tc.status, len(events))
+			}
+			if got := events[0].Level; got != tc.wantLevel {
+				t.Errorf("level = %q, want %q", got, tc.wantLevel)
+			}
+		})
+	}
+}

--- a/frontend/__tests__/AnalyticsWidgets.test.tsx
+++ b/frontend/__tests__/AnalyticsWidgets.test.tsx
@@ -1,16 +1,9 @@
 import React from "react";
 import { render } from "@testing-library/react-native";
-
-// analyticsLayout imports AsyncStorage; stub it so the native module isn't touched.
-jest.mock("@react-native-async-storage/async-storage", () => ({
-    getItem: jest.fn(() => Promise.resolve(null)),
-    setItem: jest.fn(() => Promise.resolve()),
-    removeItem: jest.fn(() => Promise.resolve()),
-    clear: jest.fn(() => Promise.resolve()),
-}));
-
 import { SignalStrip } from "@/components/analytics/SignalStrip";
 import { StatusPill } from "@/components/analytics/StatusPill";
+import { StatCards } from "@/components/analytics/StatCards";
+import { TasksNeedingAttentionWidget } from "@/components/analytics/TasksNeedingAttentionWidget";
 import {
     moveItem,
     sanitizeOrder,
@@ -47,8 +40,8 @@ describe("analyticsLayout", () => {
     });
 
     test("sanitizeOrder drops unknowns and appends new widgets", () => {
-        const result = sanitizeOrder(["heatmap", "bogus", "signals"]);
-        expect(result.slice(0, 2)).toEqual(["heatmap", "signals"]);
+        const result = sanitizeOrder(["heatmap", "bogus", "progress"]);
+        expect(result.slice(0, 2)).toEqual(["heatmap", "progress"]);
         // every default widget ends up present exactly once
         expect(new Set(result)).toEqual(new Set(DEFAULT_WIDGET_ORDER));
         expect(result).toHaveLength(DEFAULT_WIDGET_ORDER.length);
@@ -105,5 +98,48 @@ describe("StatusPill", () => {
     test("renders the friendly status label", () => {
         const { getByText } = render(<StatusPill status="slipping" />);
         getByText("Slipping");
+    });
+});
+
+describe("StatCards", () => {
+    test("renders label/value pairs", () => {
+        const { getByText } = render(
+            <StatCards
+                items={[
+                    { label: "Done", value: "8" },
+                    { label: "On time", value: "68%" },
+                ]}
+            />,
+        );
+        getByText("Done");
+        getByText("8");
+        getByText("On time");
+        getByText("68%");
+    });
+});
+
+describe("TasksNeedingAttentionWidget", () => {
+    test("shows an empty state when nothing is flagged", () => {
+        const { getByText } = render(<TasksNeedingAttentionWidget attention={{ tasks: [] }} />);
+        getByText(/Nothing needs attention/);
+    });
+
+    test("renders a flagged task with its reasons", () => {
+        const attention: any = {
+            tasks: [
+                {
+                    id: "1",
+                    title: "Problem Set",
+                    workspace: "School",
+                    category: "Assignments",
+                    categoryId: "c1",
+                    daysOpen: 6,
+                    reasons: ["No Kudos", "Open 6 days"],
+                },
+            ],
+        };
+        const { getByText } = render(<TasksNeedingAttentionWidget attention={attention} />);
+        getByText("Problem Set");
+        getByText("No Kudos");
     });
 });

--- a/frontend/__tests__/TaggedUsersChips.test.tsx
+++ b/frontend/__tests__/TaggedUsersChips.test.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import TaggedUsersChips from "@/components/inputs/TaggedUsersChips";
+
+// expose the resolved image uri so we can assert the avatar was given a source
+jest.mock("@/components/CachedImage", () => {
+    const { View } = require("react-native");
+    return {
+        __esModule: true,
+        default: (props: any) => <View testID="avatar" accessibilityLabel={props.source?.uri} />,
+    };
+});
+
+describe("TaggedUsersChips", () => {
+    it("shows the tagged user's avatar from their profile picture", () => {
+        const { getByText, getByTestId } = render(
+            <TaggedUsersChips
+                users={[{ id: "u1", handle: "@sarah", profile_picture: "https://cdn/sarah.jpg" }]}
+                onRemove={() => {}}
+            />
+        );
+        expect(getByText("@sarah")).toBeTruthy();
+        expect(getByTestId("avatar").props.accessibilityLabel).toBe("https://cdn/sarah.jpg");
+    });
+
+    it("falls back to a placeholder when there is no profile picture", () => {
+        const { getByText, queryByTestId } = render(
+            <TaggedUsersChips users={[{ id: "u2", handle: "@nopic" }]} onRemove={() => {}} />
+        );
+        expect(getByText("@nopic")).toBeTruthy();
+        expect(queryByTestId("avatar")).toBeNull();
+    });
+});

--- a/frontend/__tests__/endOfDay.test.ts
+++ b/frontend/__tests__/endOfDay.test.ts
@@ -13,25 +13,32 @@ const task = (over: Partial<Task>): Task =>
 describe("isEndOfDayWindow", () => {
     it("is false before the trigger hour", () => {
         expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR - 1, 59))).toBe(false);
+        expect(isEndOfDayWindow(new Date(2026, 5, 10, 12, 0))).toBe(false);
     });
 
-    it("is true from the trigger hour until midnight", () => {
+    it("is true from 8PM through the early morning", () => {
         expect(isEndOfDayWindow(new Date(2026, 5, 10, END_OF_DAY_HOUR, 0))).toBe(true);
         expect(isEndOfDayWindow(new Date(2026, 5, 10, 23, 59))).toBe(true);
+        expect(isEndOfDayWindow(new Date(2026, 5, 11, 0, 1))).toBe(true);
+        expect(isEndOfDayWindow(new Date(2026, 5, 11, 5, 59))).toBe(true);
     });
 
-    it("resets after midnight", () => {
-        expect(isEndOfDayWindow(new Date(2026, 5, 11, 0, 1))).toBe(false);
+    it("closes at 6AM", () => {
+        expect(isEndOfDayWindow(new Date(2026, 5, 11, 6, 0))).toBe(false);
     });
 });
 
 describe("endOfDayDismissKey", () => {
-    it("encodes the local date", () => {
+    it("encodes the local date in the evening", () => {
         expect(endOfDayDismissKey(new Date(2026, 5, 10, 21, 0))).toBe("eod-dismissed-2026-06-10");
     });
 
-    it("differs across days so the card returns the next evening", () => {
-        expect(endOfDayDismissKey(new Date(2026, 5, 10))).not.toBe(endOfDayDismissKey(new Date(2026, 5, 11)));
+    it("anchors post-midnight hours to the evening the window opened", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 11, 1, 0))).toBe("eod-dismissed-2026-06-10");
+    });
+
+    it("differs across nights so the card returns the next evening", () => {
+        expect(endOfDayDismissKey(new Date(2026, 5, 10, 21))).not.toBe(endOfDayDismissKey(new Date(2026, 5, 11, 21)));
     });
 });
 

--- a/frontend/__tests__/postMedia.test.ts
+++ b/frontend/__tests__/postMedia.test.ts
@@ -1,0 +1,29 @@
+import { postCover } from "@/utils/postMedia";
+import type { MediaItem } from "@/api/media";
+
+const img = (url: string): MediaItem => ({ type: "image", url, width: 0, height: 0 }) as MediaItem;
+const vid = (url: string, thumbnailUrl?: string): MediaItem =>
+    ({ type: "video", url, thumbnailUrl, width: 0, height: 0 }) as MediaItem;
+
+describe("postCover", () => {
+    it("uses the first image's url for an image post", () => {
+        expect(postCover({ media: [img("a.jpg"), img("b.jpg")] })).toEqual({ url: "a.jpg", isVideo: false });
+    });
+
+    it("uses a video's poster thumbnail and flags it as video", () => {
+        expect(postCover({ media: [vid("clip.mp4", "poster.jpg")] })).toEqual({ url: "poster.jpg", isVideo: true });
+    });
+
+    it("falls back to legacy images[] when media[] is absent", () => {
+        expect(postCover({ images: ["legacy.jpg"] })).toEqual({ url: "legacy.jpg", isVideo: false });
+    });
+
+    it("skips a posterless video so a later image can cover the post", () => {
+        expect(postCover({ media: [vid("clip.mp4"), img("b.jpg")] })).toEqual({ url: "b.jpg", isVideo: false });
+    });
+
+    it("returns null when there is nothing displayable", () => {
+        expect(postCover({ media: [], images: [] })).toBeNull();
+        expect(postCover({ media: [vid("clip.mp4")] })).toBeNull();
+    });
+});

--- a/frontend/api/analytics.ts
+++ b/frontend/api/analytics.ts
@@ -24,6 +24,14 @@ export type AnalyticsCategoryHealth = components["schemas"]["AnalyticsCategoryHe
 export type AnalyticsCategoryHealthRow = components["schemas"]["AnalyticsCategoryHealthRow"];
 export type AnalyticsWorkspaceHealth = components["schemas"]["AnalyticsWorkspaceHealth"];
 export type AnalyticsWorkspaceHealthRow = components["schemas"]["AnalyticsWorkspaceHealthRow"];
+export type AnalyticsBestTime = components["schemas"]["AnalyticsBestTime"];
+export type AnalyticsBestTimeCell = components["schemas"]["AnalyticsBestTimeCell"];
+export type AnalyticsAttention = components["schemas"]["AnalyticsAttention"];
+export type AnalyticsAttentionTask = components["schemas"]["AnalyticsAttentionTask"];
+export type AnalyticsKudosEffect = components["schemas"]["AnalyticsKudosEffect"];
+export type AnalyticsSupportCoverage = components["schemas"]["AnalyticsSupportCoverage"];
+export type AnalyticsSupporter = components["schemas"]["AnalyticsSupporter"];
+export type AnalyticsLayout = components["schemas"]["AnalyticsLayout"];
 
 export type AnalyticsRange = "week" | "month" | "sixmonth";
 
@@ -56,4 +64,32 @@ export const getAnalytics = async (filters: AnalyticsFilters): Promise<Analytics
         logger.error("Error fetching analytics", error);
         throw error;
     }
+};
+
+/** Fetch the user's saved dashboard layout (empty order = use client default). */
+export const getAnalyticsLayout = async (): Promise<AnalyticsLayout> => {
+    try {
+        const { data, error } = await client.GET("/v1/user/analytics/layout" as any, {
+            params: withAuthHeaders(),
+        });
+        if (error) {
+            throw new Error(`Failed to fetch layout: ${JSON.stringify(error)}`);
+        }
+        return data as AnalyticsLayout;
+    } catch (error) {
+        logger.error("Error fetching analytics layout", error);
+        throw error;
+    }
+};
+
+/** Persist the user's dashboard layout (order + hidden). */
+export const saveAnalyticsLayout = async (layout: AnalyticsLayout): Promise<AnalyticsLayout> => {
+    const { data, error } = await client.PUT("/v1/user/analytics/layout" as any, {
+        params: withAuthHeaders(),
+        body: layout,
+    });
+    if (error) {
+        throw new Error(`Failed to save layout: ${JSON.stringify(error)}`);
+    }
+    return data as AnalyticsLayout;
 };

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -1618,6 +1618,51 @@ paths:
                         application/problem+json:
                             schema:
                                 $ref: '#/components/schemas/ErrorModel'
+    /v1/user/analytics/layout:
+        get:
+            tags:
+                - Analytics
+            summary: Get analytics dashboard layout
+            description: Returns the authenticated user's saved widget order and hidden widgets.
+            operationId: get-analytics-layout
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AnalyticsLayout'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
+        put:
+            tags:
+                - Analytics
+            summary: Update analytics dashboard layout
+            description: Persists the user's widget order and hidden widgets.
+            operationId: update-analytics-layout
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: '#/components/schemas/AnalyticsLayout'
+                required: true
+            responses:
+                "200":
+                    description: OK
+                    content:
+                        application/json:
+                            schema:
+                                $ref: '#/components/schemas/AnalyticsLayout'
+                default:
+                    description: Error
+                    content:
+                        application/problem+json:
+                            schema:
+                                $ref: '#/components/schemas/ErrorModel'
     /v1/user/blueprints:
         post:
             tags:
@@ -7301,6 +7346,85 @@ components:
                     type: string
             required:
                 - emoji
+        AnalyticsAttention:
+            type: object
+            additionalProperties: false
+            properties:
+                tasks:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsAttentionTask'
+            required:
+                - tasks
+        AnalyticsAttentionTask:
+            type: object
+            additionalProperties: false
+            properties:
+                category:
+                    type: string
+                categoryId:
+                    type: string
+                daysOpen:
+                    type: integer
+                    format: int64
+                deadline:
+                    type: string
+                id:
+                    type: string
+                reasons:
+                    type: array
+                    items:
+                        type: string
+                title:
+                    type: string
+                workspace:
+                    type: string
+            required:
+                - id
+                - title
+                - workspace
+                - category
+                - categoryId
+                - daysOpen
+                - reasons
+        AnalyticsBestTime:
+            type: object
+            additionalProperties: false
+            properties:
+                cells:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsBestTimeCell'
+                maxCount:
+                    type: integer
+                    format: int64
+                takeaway:
+                    type: string
+            required:
+                - cells
+                - maxCount
+                - takeaway
+        AnalyticsBestTimeCell:
+            type: object
+            additionalProperties: false
+            properties:
+                count:
+                    type: integer
+                    format: int64
+                hour:
+                    type: integer
+                    format: int64
+                level:
+                    type: integer
+                    format: int64
+                weekday:
+                    type: integer
+                    format: int64
+            required:
+                - weekday
+                - hour
+                - count
+                - level
         AnalyticsCategoryHealth:
             type: object
             additionalProperties: false
@@ -7452,6 +7576,55 @@ components:
                 - date
                 - count
                 - level
+        AnalyticsKudosEffect:
+            type: object
+            additionalProperties: false
+            properties:
+                hasComparison:
+                    type: boolean
+                takeaway:
+                    type: string
+                withCount:
+                    type: integer
+                    format: int64
+                withKudosMedianHours:
+                    type: number
+                    format: double
+                withoutCount:
+                    type: integer
+                    format: int64
+                withoutKudosMedianHours:
+                    type: number
+                    format: double
+            required:
+                - withKudosMedianHours
+                - withoutKudosMedianHours
+                - withCount
+                - withoutCount
+                - hasComparison
+                - takeaway
+        AnalyticsLayout:
+            type: object
+            additionalProperties: false
+            properties:
+                $schema:
+                    type: string
+                    description: A URL to the JSON Schema for this object.
+                    format: uri
+                    examples:
+                        - https://example.com/schemas/AnalyticsLayout.json
+                    readOnly: true
+                hidden:
+                    type: array
+                    items:
+                        type: string
+                order:
+                    type: array
+                    items:
+                        type: string
+            required:
+                - order
+                - hidden
         AnalyticsLegendItem:
             type: object
             additionalProperties: false
@@ -7548,6 +7721,10 @@ components:
                     examples:
                         - https://example.com/schemas/AnalyticsResponse.json
                     readOnly: true
+                attention:
+                    $ref: '#/components/schemas/AnalyticsAttention'
+                bestTime:
+                    $ref: '#/components/schemas/AnalyticsBestTime'
                 categoryFilter:
                     type: string
                 categoryHealth:
@@ -7561,12 +7738,20 @@ components:
                     $ref: '#/components/schemas/AnalyticsHabits'
                 heatmap:
                     $ref: '#/components/schemas/AnalyticsHeatmap'
+                kudosEffect:
+                    $ref: '#/components/schemas/AnalyticsKudosEffect'
                 progress:
                     $ref: '#/components/schemas/AnalyticsProgress'
                 range:
                     type: string
                 signals:
                     $ref: '#/components/schemas/AnalyticsSignals'
+                supportCoverage:
+                    $ref: '#/components/schemas/AnalyticsSupportCoverage'
+                topSupporters:
+                    type: array
+                    items:
+                        $ref: '#/components/schemas/AnalyticsSupporter'
                 workspaceFilter:
                     type: string
                 workspaceHealth:
@@ -7581,6 +7766,11 @@ components:
                 - habits
                 - categoryHealth
                 - workspaceHealth
+                - bestTime
+                - attention
+                - kudosEffect
+                - supportCoverage
+                - topSupporters
         AnalyticsShareBand:
             type: object
             additionalProperties: false
@@ -7655,6 +7845,44 @@ components:
                 - momentum
                 - timing
                 - support
+        AnalyticsSupportCoverage:
+            type: object
+            additionalProperties: false
+            properties:
+                pct:
+                    type: integer
+                    format: int64
+                supported:
+                    type: integer
+                    format: int64
+                takeaway:
+                    type: string
+                total:
+                    type: integer
+                    format: int64
+            required:
+                - pct
+                - supported
+                - total
+                - takeaway
+        AnalyticsSupporter:
+            type: object
+            additionalProperties: false
+            properties:
+                count:
+                    type: integer
+                    format: int64
+                icon:
+                    type: string
+                id:
+                    type: string
+                name:
+                    type: string
+            required:
+                - id
+                - name
+                - icon
+                - count
         AnalyticsWorkspaceHealth:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -968,6 +968,30 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/user/analytics/layout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get analytics dashboard layout
+         * @description Returns the authenticated user's saved widget order and hidden widgets.
+         */
+        get: operations["get-analytics-layout"];
+        /**
+         * Update analytics dashboard layout
+         * @description Persists the user's widget order and hidden widgets.
+         */
+        put: operations["update-analytics-layout"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/user/blueprints": {
         parameters: {
             query?: never;
@@ -3586,6 +3610,36 @@ export interface components {
             readonly $schema?: string;
             emoji: string;
         };
+        AnalyticsAttention: {
+            tasks: components["schemas"]["AnalyticsAttentionTask"][];
+        };
+        AnalyticsAttentionTask: {
+            category: string;
+            categoryId: string;
+            /** Format: int64 */
+            daysOpen: number;
+            deadline?: string;
+            id: string;
+            reasons: string[];
+            title: string;
+            workspace: string;
+        };
+        AnalyticsBestTime: {
+            cells: components["schemas"]["AnalyticsBestTimeCell"][];
+            /** Format: int64 */
+            maxCount: number;
+            takeaway: string;
+        };
+        AnalyticsBestTimeCell: {
+            /** Format: int64 */
+            count: number;
+            /** Format: int64 */
+            hour: number;
+            /** Format: int64 */
+            level: number;
+            /** Format: int64 */
+            weekday: number;
+        };
         AnalyticsCategoryHealth: {
             rows: components["schemas"]["AnalyticsCategoryHealthRow"][];
         };
@@ -3640,6 +3694,28 @@ export interface components {
             /** Format: int64 */
             level: number;
         };
+        AnalyticsKudosEffect: {
+            hasComparison: boolean;
+            takeaway: string;
+            /** Format: int64 */
+            withCount: number;
+            /** Format: double */
+            withKudosMedianHours: number;
+            /** Format: int64 */
+            withoutCount: number;
+            /** Format: double */
+            withoutKudosMedianHours: number;
+        };
+        AnalyticsLayout: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/schemas/AnalyticsLayout.json
+             */
+            readonly $schema?: string;
+            hidden: string[];
+            order: string[];
+        };
         AnalyticsLegendItem: {
             categoryId: string;
             color: string;
@@ -3678,6 +3754,8 @@ export interface components {
              * @example https://example.com/schemas/AnalyticsResponse.json
              */
             readonly $schema?: string;
+            attention: components["schemas"]["AnalyticsAttention"];
+            bestTime: components["schemas"]["AnalyticsBestTime"];
             categoryFilter?: string;
             categoryHealth: components["schemas"]["AnalyticsCategoryHealth"];
             categoryShare: components["schemas"]["AnalyticsCategoryShare"];
@@ -3685,9 +3763,12 @@ export interface components {
             generatedAt: string;
             habits: components["schemas"]["AnalyticsHabits"];
             heatmap: components["schemas"]["AnalyticsHeatmap"];
+            kudosEffect: components["schemas"]["AnalyticsKudosEffect"];
             progress: components["schemas"]["AnalyticsProgress"];
             range: string;
             signals: components["schemas"]["AnalyticsSignals"];
+            supportCoverage: components["schemas"]["AnalyticsSupportCoverage"];
+            topSupporters: components["schemas"]["AnalyticsSupporter"][];
             workspaceFilter?: string;
             workspaceHealth: components["schemas"]["AnalyticsWorkspaceHealth"];
         };
@@ -3718,6 +3799,22 @@ export interface components {
             momentum: components["schemas"]["AnalyticsSignal"];
             support: components["schemas"]["AnalyticsSignal"];
             timing: components["schemas"]["AnalyticsSignal"];
+        };
+        AnalyticsSupportCoverage: {
+            /** Format: int64 */
+            pct: number;
+            /** Format: int64 */
+            supported: number;
+            takeaway: string;
+            /** Format: int64 */
+            total: number;
+        };
+        AnalyticsSupporter: {
+            /** Format: int64 */
+            count: number;
+            icon: string;
+            id: string;
+            name: string;
         };
         AnalyticsWorkspaceHealth: {
             rows: components["schemas"]["AnalyticsWorkspaceHealthRow"][];
@@ -9761,6 +9858,68 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnalyticsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "get-analytics-layout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsLayout"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ErrorModel"];
+                };
+            };
+        };
+    };
+    "update-analytics-layout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AnalyticsLayout"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnalyticsLayout"];
                 };
             };
             /** @description Error */

--- a/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/[id].tsx
@@ -17,6 +17,7 @@ import { buildTagAggregates, selectedTagTemplateIds } from "@/utils/tagBreakdown
 import { useAuth } from "@/hooks/useAuth";
 import { RecurringTaskCard } from "@/components/activity/RecurringTaskCard";
 import CalendarMonth, { CELL_SIZE, GRID_GAP } from "@/components/activity/CalendarMonth";
+import { FriendView } from "@/components/analytics/FriendView";
 
 const month_names = [
     "January", "February", "March", "April", "May", "June",
@@ -384,7 +385,20 @@ const Activity = () => {
     );
 };
 
-export default Activity;
+// Route wrapper: viewing another user shows the privacy-safe minimal Friend
+// View; your own id falls through to the full activity screen.
+export default function ActivityRoute() {
+    const { user } = useAuth();
+    const params = useLocalSearchParams();
+    const friendId = params.id as string;
+    const displayName = params.displayName as string | undefined;
+    const isFriend = !!displayName && friendId !== user?._id;
+
+    if (isFriend) {
+        return <FriendView userId={friendId} displayName={displayName} handle={params.handle as string | undefined} />;
+    }
+    return <Activity />;
+}
 
 // --- Page Styles ---
 

--- a/frontend/app/(logged-in)/(tabs)/(activity)/add-cards.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/add-cards.tsx
@@ -1,0 +1,178 @@
+import React, { useState } from "react";
+import { View, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Plus, Check } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAuth } from "@/hooks/useAuth";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import {
+    DEFAULT_WIDGET_ORDER,
+    WIDGET_TITLES,
+    WIDGET_META,
+    WIDGET_CATEGORIES,
+    WidgetId,
+} from "@/components/analytics/analyticsLayout";
+import { useAnalyticsLayout } from "@/hooks/useAnalyticsLayout";
+
+const TABS = ["All", "Popular", ...WIDGET_CATEGORIES] as const;
+type Tab = (typeof TABS)[number];
+
+export default function AddCards() {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const insets = useSafeAreaInsets();
+    const { user } = useAuth();
+    const { addWidget, toggleHidden, isVisible } = useAnalyticsLayout(user?._id);
+    const [tab, setTab] = useState<Tab>("All");
+
+    const widgets = DEFAULT_WIDGET_ORDER.filter((id) => {
+        if (tab === "All") return true;
+        if (tab === "Popular") return WIDGET_META[id].popular;
+        return WIDGET_META[id].category === tab;
+    });
+
+    const onToggle = (id: WidgetId) => {
+        if (isVisible(id)) {
+            toggleHidden(id);
+        } else {
+            addWidget(id);
+        }
+    };
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title="Add Cards" />
+            <View style={styles.tabsWrap}>
+                <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.tabs}>
+                    {TABS.map((t) => (
+                        <TouchableOpacity
+                            key={t}
+                            activeOpacity={0.7}
+                            onPress={() => setTab(t)}
+                            style={[
+                                styles.tab,
+                                {
+                                    backgroundColor: tab === t ? ThemedColor.primary : ThemedColor.lightened,
+                                    borderColor: tab === t ? ThemedColor.primary : ThemedColor.tertiary,
+                                },
+                            ]}>
+                            <ThemedText
+                                type={tab === t ? "defaultSemiBold" : "default"}
+                                style={{ color: tab === t ? ThemedColor.buttonText : ThemedColor.text, fontSize: 13 }}>
+                                {t}
+                            </ThemedText>
+                        </TouchableOpacity>
+                    ))}
+                </ScrollView>
+            </View>
+
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 12, paddingBottom: insets.bottom + 110 }}>
+                {widgets.map((id) => (
+                    <GalleryCard key={id} id={id} added={isVisible(id)} onToggle={() => onToggle(id)} />
+                ))}
+            </ScrollView>
+        </View>
+    );
+}
+
+function GalleryCard({ id, added, onToggle }: { id: WidgetId; added: boolean; onToggle: () => void }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.card}>
+            <View style={styles.cardText}>
+                <ThemedText type="defaultSemiBold" style={styles.cardTitle}>
+                    {WIDGET_TITLES[id]}
+                </ThemedText>
+                <ThemedText type="caption" style={styles.cardDesc}>
+                    {WIDGET_META[id].description}
+                </ThemedText>
+                <View style={styles.categoryChip}>
+                    <ThemedText type="caption" style={{ color: ThemedColor.primary, fontSize: 11 }}>
+                        {WIDGET_META[id].category}
+                    </ThemedText>
+                </View>
+            </View>
+            <TouchableOpacity
+                activeOpacity={0.8}
+                onPress={onToggle}
+                style={[
+                    styles.toggle,
+                    added
+                        ? { backgroundColor: ThemedColor.lightened, borderColor: ThemedColor.tertiary }
+                        : { backgroundColor: ThemedColor.primary, borderColor: ThemedColor.primary },
+                ]}>
+                {added ? (
+                    <Check size={16} color={ThemedColor.text} weight="bold" />
+                ) : (
+                    <Plus size={16} color={ThemedColor.buttonText} weight="bold" />
+                )}
+                <ThemedText
+                    type="defaultSemiBold"
+                    style={{ color: added ? ThemedColor.text : ThemedColor.buttonText, fontSize: 13 }}>
+                    {added ? "Added" : "Add"}
+                </ThemedText>
+            </TouchableOpacity>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        tabsWrap: {
+            paddingLeft: 20,
+        },
+        tabs: {
+            gap: 8,
+            paddingRight: 20,
+            paddingVertical: 4,
+        },
+        tab: {
+            paddingHorizontal: 14,
+            paddingVertical: 7,
+            borderRadius: 999,
+            borderWidth: 1,
+        },
+        card: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 12,
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+            padding: 16,
+            marginBottom: 12,
+            boxShadow: ThemedColor.shadowSmall,
+        },
+        cardText: {
+            flex: 1,
+            gap: 4,
+        },
+        cardTitle: {
+            fontSize: 16,
+        },
+        cardDesc: {
+            lineHeight: 18,
+        },
+        categoryChip: {
+            alignSelf: "flex-start",
+            backgroundColor: ThemedColor.primary + "1A",
+            paddingHorizontal: 8,
+            paddingVertical: 3,
+            borderRadius: 999,
+            marginTop: 2,
+        },
+        toggle: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 4,
+            paddingHorizontal: 14,
+            paddingVertical: 10,
+            borderRadius: 999,
+            borderWidth: 1,
+        },
+    });

--- a/frontend/app/(logged-in)/(tabs)/(activity)/category/[categoryId].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/category/[categoryId].tsx
@@ -1,0 +1,63 @@
+import React, { useMemo, useState } from "react";
+import { View, ScrollView, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useLocalSearchParams } from "expo-router";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useTasks } from "@/contexts/tasksContext";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsRange } from "@/api/analytics";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import { RangeSwitcher } from "@/components/analytics/RangeSwitcher";
+import { StatCards } from "@/components/analytics/StatCards";
+import { CompletionTrendWidget } from "@/components/analytics/CompletionTrendWidget";
+import { ActivityHeatmapWidget } from "@/components/analytics/ActivityHeatmapWidget";
+import { BestTimeWidget } from "@/components/analytics/BestTimeWidget";
+import { TasksNeedingAttentionWidget } from "@/components/analytics/TasksNeedingAttentionWidget";
+
+export default function CategoryDetail() {
+    const ThemedColor = useThemeColor() as any;
+    const insets = useSafeAreaInsets();
+    const { categoryId } = useLocalSearchParams<{ categoryId: string }>();
+    const { workspaces } = useTasks();
+    const [range, setRange] = useState<AnalyticsRange>("week");
+    const { data, isLoading, isError } = useAnalyticsData({ range, category: categoryId });
+
+    const categoryName = useMemo(() => {
+        const all = workspaces.flatMap((w: any) => w.categories ?? []);
+        return all.find((c: any) => c.id === categoryId)?.name ?? "Category";
+    }, [workspaces, categoryId]);
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title={categoryName} />
+            <View style={{ paddingHorizontal: 20 }}>
+                <RangeSwitcher range={range} onChange={setRange} />
+            </View>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 16, paddingBottom: insets.bottom + 110 }}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={{ marginTop: 60 }} />
+                ) : isError || !data ? (
+                    <ThemedText type="caption">Couldn't load this category.</ThemedText>
+                ) : (
+                    <>
+                        <StatCards
+                            items={[
+                                { label: "Done", value: String(data.progress.total) },
+                                { label: "On time", value: data.signals.timing.value },
+                                { label: "Kudos", value: String(Math.round(data.signals.support.rawValue)) },
+                                { label: "Needs attn", value: String((data.attention.tasks ?? []).length) },
+                            ]}
+                        />
+                        <CompletionTrendWidget progress={data.progress} />
+                        <ActivityHeatmapWidget heatmap={data.heatmap} />
+                        <BestTimeWidget bestTime={data.bestTime} />
+                        <TasksNeedingAttentionWidget attention={data.attention} />
+                    </>
+                )}
+            </ScrollView>
+        </View>
+    );
+}

--- a/frontend/app/(logged-in)/(tabs)/(activity)/edit.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/edit.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { View, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { router } from "expo-router";
+import { router, type Href } from "expo-router";
 import { ArrowUp, ArrowDown, EyeSlash, Plus } from "phosphor-react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { ThemedText } from "@/components/ThemedText";
 import { useAuth } from "@/hooks/useAuth";
-import { useAnalyticsLayout, WidgetId, WIDGET_TITLES } from "@/components/analytics/analyticsLayout";
+import { WidgetId, WIDGET_TITLES } from "@/components/analytics/analyticsLayout";
+import { useAnalyticsLayout } from "@/hooks/useAnalyticsLayout";
 
 export default function EditAnalytics() {
     const ThemedColor = useThemeColor() as any;
@@ -56,16 +57,15 @@ export default function EditAnalytics() {
                     />
                 ))}
 
-                {hidden.length > 0 ? (
-                    <>
-                        <ThemedText type="defaultSemiBold" style={styles.sectionLabel}>
-                            Add Cards
-                        </ThemedText>
-                        {hidden.map((id) => (
-                            <HiddenRow key={id} id={id} onAdd={() => toggleHidden(id)} />
-                        ))}
-                    </>
-                ) : null}
+                <TouchableOpacity
+                    style={styles.browseButton}
+                    activeOpacity={0.8}
+                    onPress={() => router.push("/(activity)/add-cards" as Href)}>
+                    <Plus size={18} color={ThemedColor.primary} weight="bold" />
+                    <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
+                        Browse cards to add
+                    </ThemedText>
+                </TouchableOpacity>
             </ScrollView>
         </View>
     );
@@ -100,24 +100,6 @@ function VisibleRow({ id, isFirst, isLast, onMoveUp, onMoveDown, onHide }: Visib
                     <EyeSlash size={20} color={ThemedColor.caption} weight="bold" />
                 </TouchableOpacity>
             </View>
-        </View>
-    );
-}
-
-function HiddenRow({ id, onAdd }: { id: WidgetId; onAdd: () => void }) {
-    const ThemedColor = useThemeColor() as any;
-    const styles = stylesheet(ThemedColor);
-    return (
-        <View style={styles.row}>
-            <ThemedText type="default" style={[styles.rowTitle, { color: ThemedColor.caption }]}>
-                {WIDGET_TITLES[id]}
-            </ThemedText>
-            <TouchableOpacity onPress={onAdd} activeOpacity={0.7} style={styles.addButton}>
-                <Plus size={18} color={ThemedColor.primary} weight="bold" />
-                <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.primary }}>
-                    Add
-                </ThemedText>
-            </TouchableOpacity>
         </View>
     );
 }
@@ -170,9 +152,16 @@ const stylesheet = (ThemedColor: any) =>
             alignItems: "center",
             gap: 18,
         },
-        addButton: {
+        browseButton: {
             flexDirection: "row",
             alignItems: "center",
-            gap: 4,
+            justifyContent: "center",
+            gap: 6,
+            marginTop: 16,
+            paddingVertical: 14,
+            borderRadius: 14,
+            borderWidth: 1,
+            borderColor: ThemedColor.primary,
+            borderStyle: "dashed",
         },
     });

--- a/frontend/app/(logged-in)/(tabs)/(activity)/habits.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/habits.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from "react";
+import { View, ScrollView, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsRange } from "@/api/analytics";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import { RangeSwitcher } from "@/components/analytics/RangeSwitcher";
+import { HabitsWidget } from "@/components/analytics/HabitsWidget";
+
+export default function HabitsScreen() {
+    const ThemedColor = useThemeColor() as any;
+    const insets = useSafeAreaInsets();
+    const [range, setRange] = useState<AnalyticsRange>("week");
+    const { data, isLoading, isError } = useAnalyticsData({ range });
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title="Habits & Recurring" />
+            <View style={{ paddingHorizontal: 20 }}>
+                <RangeSwitcher range={range} onChange={setRange} />
+            </View>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 16, paddingBottom: insets.bottom + 110 }}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={{ marginTop: 60 }} />
+                ) : isError || !data ? (
+                    <ThemedText type="caption">Couldn't load habits.</ThemedText>
+                ) : (
+                    <HabitsWidget habits={data.habits} />
+                )}
+            </ScrollView>
+        </View>
+    );
+}

--- a/frontend/app/(logged-in)/(tabs)/(activity)/insight/[insightId].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/insight/[insightId].tsx
@@ -1,0 +1,90 @@
+import React, { useState } from "react";
+import { View, ScrollView, StyleSheet, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useLocalSearchParams } from "expo-router";
+import { format } from "date-fns";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsRange, AnalyticsHeatmap } from "@/api/analytics";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import { RangeSwitcher } from "@/components/analytics/RangeSwitcher";
+import { ActivityHeatmapWidget } from "@/components/analytics/ActivityHeatmapWidget";
+import { BestTimeWidget } from "@/components/analytics/BestTimeWidget";
+import { WidgetCard } from "@/components/analytics/WidgetCard";
+
+function parseLocalDate(iso: string): Date {
+    const [y, m, d] = iso.split("-").map((n) => parseInt(n, 10));
+    return new Date(y, (m || 1) - 1, d || 1);
+}
+
+export default function InsightDetail() {
+    const ThemedColor = useThemeColor() as any;
+    const insets = useSafeAreaInsets();
+    const params = useLocalSearchParams<{ insightId: string; category?: string; workspace?: string }>();
+    const [range, setRange] = useState<AnalyticsRange>("month");
+    const { data, isLoading, isError } = useAnalyticsData({
+        range,
+        category: params.category,
+        workspace: params.workspace,
+    });
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title="Insights" />
+            <View style={{ paddingHorizontal: 20 }}>
+                <RangeSwitcher range={range} onChange={setRange} />
+            </View>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 16, paddingBottom: insets.bottom + 110 }}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={{ marginTop: 60 }} />
+                ) : isError || !data ? (
+                    <ThemedText type="caption">Couldn't load insights.</ThemedText>
+                ) : (
+                    <>
+                        <ActivityHeatmapWidget heatmap={data.heatmap} />
+                        <BestTimeWidget bestTime={data.bestTime} />
+                        <TopActiveDays heatmap={data.heatmap} />
+                    </>
+                )}
+            </ScrollView>
+        </View>
+    );
+}
+
+function TopActiveDays({ heatmap }: { heatmap: AnalyticsHeatmap }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const top = (heatmap.days ?? [])
+        .filter((d) => d.count > 0)
+        .sort((a, b) => b.count - a.count)
+        .slice(0, 5);
+
+    if (top.length === 0) {
+        return null;
+    }
+
+    return (
+        <WidgetCard title="Top active days">
+            <View style={{ gap: 12 }}>
+                {top.map((d) => (
+                    <View key={d.date} style={styles.row}>
+                        <ThemedText type="default">{format(parseLocalDate(d.date), "EEE, MMM d")}</ThemedText>
+                        <ThemedText type="defaultSemiBold">{d.count} tasks</ThemedText>
+                    </View>
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+        },
+    });

--- a/frontend/app/(logged-in)/(tabs)/(activity)/weekly-review.tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/weekly-review.tsx
@@ -1,0 +1,127 @@
+import React from "react";
+import { View, ScrollView, StyleSheet, ActivityIndicator, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { router, type Href } from "expo-router";
+import { startOfWeek, endOfWeek, format } from "date-fns";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsSupporter } from "@/api/analytics";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import { StatCards } from "@/components/analytics/StatCards";
+import { WidgetCard } from "@/components/analytics/WidgetCard";
+import { WorkspaceHealthWidget } from "@/components/analytics/WorkspaceHealthWidget";
+import { CategoryHealthWidget } from "@/components/analytics/CategoryHealthWidget";
+import { KudosEffectWidget } from "@/components/analytics/KudosEffectWidget";
+import { SupportCoverageWidget } from "@/components/analytics/SupportCoverageWidget";
+
+export default function WeeklyReview() {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const insets = useSafeAreaInsets();
+    const { data, isLoading, isError } = useAnalyticsData({ range: "week" });
+
+    const now = new Date();
+    const rangeLabel = `${format(startOfWeek(now, { weekStartsOn: 1 }), "MMM d")} – ${format(endOfWeek(now, { weekStartsOn: 1 }), "MMM d")}`;
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title="Weekly Review" subtitle={rangeLabel} />
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 8, paddingBottom: insets.bottom + 110 }}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={{ marginTop: 60 }} />
+                ) : isError || !data ? (
+                    <ThemedText type="caption">Couldn't load your weekly review.</ThemedText>
+                ) : (
+                    <>
+                        <ThemedText type="fancyFrauncesHeading" style={styles.hero}>
+                            {data.progress.total > 0 ? "Nice week 🎉" : "A fresh start"}
+                        </ThemedText>
+                        <ThemedText type="caption" style={styles.heroSub}>
+                            {data.progress.total > 0
+                                ? "Here's how it came together — what moved and who showed up."
+                                : "Nothing logged yet this week. A small win is a great place to begin."}
+                        </ThemedText>
+
+                        <StatCards
+                            items={[
+                                { label: "Completed", value: String(data.progress.total) },
+                                { label: "On time", value: data.signals.timing.value },
+                                { label: "Workspaces", value: String((data.workspaceHealth.rows ?? []).length) },
+                                { label: "Kudos", value: String(Math.round(data.signals.support.rawValue)) },
+                            ]}
+                        />
+
+                        <WhoShowedUp supporters={data.topSupporters ?? []} />
+                        <WorkspaceHealthWidget workspaceHealth={data.workspaceHealth} />
+                        <CategoryHealthWidget categoryHealth={data.categoryHealth} />
+                        <KudosEffectWidget kudosEffect={data.kudosEffect} />
+                        <SupportCoverageWidget supportCoverage={data.supportCoverage} />
+
+                        <TouchableOpacity
+                            style={styles.planButton}
+                            activeOpacity={0.85}
+                            onPress={() => router.push("/(task)" as Href)}>
+                            <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.buttonText }}>
+                                Plan next week
+                            </ThemedText>
+                        </TouchableOpacity>
+                    </>
+                )}
+            </ScrollView>
+        </View>
+    );
+}
+
+function WhoShowedUp({ supporters }: { supporters: AnalyticsSupporter[] }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    if (supporters.length === 0) {
+        return (
+            <WidgetCard title="Who showed up">
+                <ThemedText type="caption">No Kudos yet this week — that's okay.</ThemedText>
+            </WidgetCard>
+        );
+    }
+    return (
+        <WidgetCard title="Who showed up">
+            <View style={{ gap: 12 }}>
+                {supporters.map((s) => (
+                    <View key={s.id} style={styles.supporterRow}>
+                        <ThemedText type="defaultSemiBold">{s.name || "A friend"}</ThemedText>
+                        <ThemedText type="caption">
+                            {s.count} {s.count === 1 ? "Kudos" : "Kudos"}
+                        </ThemedText>
+                    </View>
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        hero: {
+            fontSize: 28,
+            marginTop: 4,
+        },
+        heroSub: {
+            marginTop: 4,
+            marginBottom: 16,
+            lineHeight: 18,
+        },
+        supporterRow: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+        },
+        planButton: {
+            backgroundColor: ThemedColor.primary,
+            borderRadius: 14,
+            paddingVertical: 16,
+            alignItems: "center",
+            marginTop: 8,
+        },
+    });

--- a/frontend/app/(logged-in)/(tabs)/(activity)/workspace/[workspaceId].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(activity)/workspace/[workspaceId].tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+import { View, ScrollView, ActivityIndicator } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useLocalSearchParams, router, type Href } from "expo-router";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useAnalyticsData } from "@/hooks/useAnalyticsData";
+import { AnalyticsRange } from "@/api/analytics";
+import { DetailHeader } from "@/components/analytics/DetailHeader";
+import { RangeSwitcher } from "@/components/analytics/RangeSwitcher";
+import { StatCards } from "@/components/analytics/StatCards";
+import { CategoryHealthWidget } from "@/components/analytics/CategoryHealthWidget";
+import { CategoryShareWidget } from "@/components/analytics/CategoryShareWidget";
+import { TasksNeedingAttentionWidget } from "@/components/analytics/TasksNeedingAttentionWidget";
+
+export default function WorkspaceDetail() {
+    const ThemedColor = useThemeColor() as any;
+    const insets = useSafeAreaInsets();
+    const { workspaceId } = useLocalSearchParams<{ workspaceId: string }>();
+    const workspaceName = decodeURIComponent(String(workspaceId ?? ""));
+    const [range, setRange] = useState<AnalyticsRange>("week");
+    const { data, isLoading, isError } = useAnalyticsData({ range, workspace: workspaceName });
+
+    const goToCategory = (id: string) => router.push(`/(activity)/category/${id}` as Href);
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title={workspaceName} />
+            <View style={{ paddingHorizontal: 20 }}>
+                <RangeSwitcher range={range} onChange={setRange} />
+            </View>
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 16, paddingBottom: insets.bottom + 110 }}>
+                {isLoading ? (
+                    <ActivityIndicator size="large" color={ThemedColor.primary} style={{ marginTop: 60 }} />
+                ) : isError || !data ? (
+                    <ThemedText type="caption">Couldn't load this workspace.</ThemedText>
+                ) : (
+                    <>
+                        <StatCards
+                            items={[
+                                { label: "Done", value: String(data.progress.total) },
+                                { label: "On time", value: data.signals.timing.value },
+                                { label: "Kudos", value: String(Math.round(data.signals.support.rawValue)) },
+                            ]}
+                        />
+                        <CategoryShareWidget share={data.categoryShare} range={range} onSelectCategory={goToCategory} />
+                        <CategoryHealthWidget categoryHealth={data.categoryHealth} onSelectCategory={goToCategory} />
+                        <TasksNeedingAttentionWidget attention={data.attention} />
+                    </>
+                )}
+            </ScrollView>
+        </View>
+    );
+}

--- a/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
+++ b/frontend/app/(logged-in)/(tabs)/(feed,search,profile)/account/[id].tsx
@@ -32,6 +32,7 @@ import TaskList from "@/components/profile/TaskList";
 import ParallaxBanner from "@/components/ui/ParallaxBanner";
 import FollowButton from "@/components/inputs/FollowButton";
 import BlueprintSection from "@/components/profile/BlueprintSection";
+import SongPreviewPill from "@/components/profile/song/SongPreviewPill";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getProfile } from "@/api/profile";
 import { type Profile, type RelationshipStatus } from "@/api/types";
@@ -228,6 +229,10 @@ export default function Profile() {
                             onRelationshipChange={handleRelationshipChange}
                         />
                     </View>
+
+                    {profile?.song && (
+                        <SongPreviewPill key={profile.song.id} song={profile.song} />
+                    )}
 
                     {canViewPersonalContent && (
                         <View style={{ marginTop: 8 }}>

--- a/frontend/app/(logged-in)/posting/caption.tsx
+++ b/frontend/app/(logged-in)/posting/caption.tsx
@@ -71,6 +71,7 @@ export default function Caption() {
                     id: e.sender?.id,
                     handle: (e.sender as any)?.handle ?? "",
                     display_name: e.sender?.name,
+                    profile_picture: e.sender?.picture,
                 })).filter((u) => u.id);
                 const seen = new Set<string>();
                 setTaggedUsers(prefilled.filter((u) => {
@@ -317,7 +318,7 @@ export default function Caption() {
                             onMentionPicked={(c: MentionCandidate) => {
                                 setTaggedUsers((prev) => {
                                     if (prev.find((p) => p.id === c.id)) return prev;
-                                    return [...prev, { id: c.id, handle: c.handle, display_name: c.display_name }];
+                                    return [...prev, { id: c.id, handle: c.handle, display_name: c.display_name, profile_picture: c.profile_picture }];
                                 });
                             }}
                         />

--- a/frontend/components/analytics/ActivityHeatmapWidget.tsx
+++ b/frontend/components/analytics/ActivityHeatmapWidget.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { View, StyleSheet } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { ThemedText } from "@/components/ThemedText";
@@ -6,32 +6,62 @@ import { AnalyticsHeatmap } from "@/api/analytics";
 import { WidgetCard } from "./WidgetCard";
 import { MonthHeatmap } from "./charts/MonthHeatmap";
 import { heatmapLevelColor } from "./analyticsColors";
+import CompletedTasksBottomSheetModal from "@/components/modals/CompletedTasksBottomSheetModal";
 
-export function ActivityHeatmapWidget({ heatmap }: { heatmap: AnalyticsHeatmap }) {
+export function ActivityHeatmapWidget({
+    heatmap,
+    onOpenDetail,
+}: {
+    heatmap: AnalyticsHeatmap;
+    onOpenDetail?: () => void;
+}) {
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
+    const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+    const [modalVisible, setModalVisible] = useState(false);
+
+    const onSelectDay = (date: Date) => {
+        setSelectedDate(date);
+        setModalVisible(true);
+    };
 
     return (
-        <WidgetCard title="Activity heatmap" takeaway={heatmap.takeaway}>
-            <MonthHeatmap days={heatmap.days} />
-            <View style={styles.legend}>
-                <ThemedText type="caption">Less</ThemedText>
-                {[0, 1, 2, 3, 4].map((level) => (
-                    <View key={level} style={[styles.cell, { backgroundColor: heatmapLevelColor(level, ThemedColor) }]} />
-                ))}
-                <ThemedText type="caption">More</ThemedText>
+        <WidgetCard
+            title="Activity heatmap"
+            takeaway={heatmap.takeaway}
+            cta={onOpenDetail ? { label: "Best times & active days", onPress: onOpenDetail } : undefined}>
+            <MonthHeatmap days={heatmap.days} onSelectDay={onSelectDay} />
+
+            <View style={styles.footer}>
+                <ThemedText type="caption">Tap a day to see what you finished</ThemedText>
+                <View style={styles.legend}>
+                    <ThemedText type="caption">Less</ThemedText>
+                    {[0, 1, 2, 3, 4].map((level) => (
+                        <View key={level} style={[styles.cell, { backgroundColor: heatmapLevelColor(level, ThemedColor) }]} />
+                    ))}
+                    <ThemedText type="caption">More</ThemedText>
+                </View>
             </View>
+
+            <CompletedTasksBottomSheetModal visible={modalVisible} setVisible={setModalVisible} date={selectedDate} />
         </WidgetCard>
     );
 }
 
 const stylesheet = (ThemedColor: any) =>
     StyleSheet.create({
+        footer: {
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            marginTop: 12,
+            flexWrap: "wrap",
+            gap: 8,
+        },
         legend: {
             flexDirection: "row",
             alignItems: "center",
             gap: 4,
-            marginTop: 12,
         },
         cell: {
             width: 12,

--- a/frontend/components/analytics/AnalyticsHome.tsx
+++ b/frontend/components/analytics/AnalyticsHome.tsx
@@ -12,14 +12,17 @@ import { AnalyticsRange, AnalyticsResponse } from "@/api/analytics";
 import { WorkspaceSelector } from "./WorkspaceSelector";
 import { RangeSwitcher } from "./RangeSwitcher";
 import { FilterChips } from "./FilterChips";
-import { useAnalyticsLayout, WidgetId } from "./analyticsLayout";
-import { SignalStrip } from "./SignalStrip";
+import { WidgetId } from "./analyticsLayout";
+import { useAnalyticsLayout } from "@/hooks/useAnalyticsLayout";
 import { WeeklyProgressWidget } from "./WeeklyProgressWidget";
 import { CategoryShareWidget } from "./CategoryShareWidget";
 import { ActivityHeatmapWidget } from "./ActivityHeatmapWidget";
 import { HabitsWidget } from "./HabitsWidget";
 import { CategoryHealthWidget } from "./CategoryHealthWidget";
 import { WorkspaceHealthWidget } from "./WorkspaceHealthWidget";
+import { KudosEffectWidget } from "./KudosEffectWidget";
+import { SupportCoverageWidget } from "./SupportCoverageWidget";
+import { WeeklyReviewWidget } from "./WeeklyReviewWidget";
 
 const EDIT_HREF = "/(activity)/edit" as Href;
 
@@ -43,13 +46,20 @@ export function AnalyticsHome() {
         const source = workspace
             ? workspaces.find((w: any) => w.name === workspace)?.categories ?? []
             : workspaces.flatMap((w: any) => w.categories ?? []);
-        return source.map((c: any) => ({ id: c.id, name: c.name }));
+        // Drop sentinel "!-proxy-!" placeholder categories — they aren't real.
+        return source.filter((c: any) => c.name !== "!-proxy-!").map((c: any) => ({ id: c.id, name: c.name }));
     }, [workspaces, workspace]);
 
     const onSelectWorkspace = (ws?: string) => {
         setWorkspace(ws);
         setCategory(undefined);
     };
+
+    const goToCategory = (id: string) => router.push(`/(activity)/category/${id}` as Href);
+    const goToWorkspace = (ws: string) => router.push(`/(activity)/workspace/${encodeURIComponent(ws)}` as Href);
+    const goToHabits = () => router.push("/(activity)/habits" as Href);
+    const goToInsight = () => router.push("/(activity)/insight/activity" as Href);
+    const goToWeeklyReview = () => router.push("/(activity)/weekly-review" as Href);
 
     return (
         <View style={[styles.container, { paddingTop: insets.top + 8 }]}>
@@ -96,7 +106,11 @@ export function AnalyticsHome() {
                             id={id}
                             data={data}
                             range={range}
-                            onSelectCategory={setCategory}
+                            onOpenCategory={goToCategory}
+                            onOpenWorkspace={goToWorkspace}
+                            onOpenHabits={goToHabits}
+                            onOpenInsight={goToInsight}
+                            onOpenWeeklyReview={goToWeeklyReview}
                         />
                     ))
                 )}
@@ -109,26 +123,34 @@ interface WidgetRendererProps {
     id: WidgetId;
     data: AnalyticsResponse;
     range: AnalyticsRange;
-    onSelectCategory: (categoryId: string) => void;
+    onOpenCategory: (categoryId: string) => void;
+    onOpenWorkspace: (workspace: string) => void;
+    onOpenHabits: () => void;
+    onOpenInsight: () => void;
+    onOpenWeeklyReview: () => void;
 }
 
 /** Maps a widget id to its component — a proper component, not an inline helper. */
-function WidgetRenderer({ id, data, range, onSelectCategory }: WidgetRendererProps) {
+function WidgetRenderer({ id, data, range, onOpenCategory, onOpenWorkspace, onOpenHabits, onOpenInsight, onOpenWeeklyReview }: WidgetRendererProps) {
     switch (id) {
-        case "signals":
-            return <SignalStrip signals={data.signals} />;
         case "progress":
             return <WeeklyProgressWidget progress={data.progress} range={range} />;
         case "categoryShare":
-            return <CategoryShareWidget share={data.categoryShare} range={range} onSelectCategory={onSelectCategory} />;
+            return <CategoryShareWidget share={data.categoryShare} range={range} onSelectCategory={onOpenCategory} />;
         case "habits":
-            return <HabitsWidget habits={data.habits} />;
+            return <HabitsWidget habits={data.habits} onPress={onOpenHabits} />;
         case "heatmap":
-            return <ActivityHeatmapWidget heatmap={data.heatmap} />;
+            return <ActivityHeatmapWidget heatmap={data.heatmap} onOpenDetail={onOpenInsight} />;
         case "categoryHealth":
-            return <CategoryHealthWidget categoryHealth={data.categoryHealth} onSelectCategory={onSelectCategory} />;
+            return <CategoryHealthWidget categoryHealth={data.categoryHealth} onSelectCategory={onOpenCategory} />;
         case "workspaceHealth":
-            return <WorkspaceHealthWidget workspaceHealth={data.workspaceHealth} />;
+            return <WorkspaceHealthWidget workspaceHealth={data.workspaceHealth} onSelectWorkspace={onOpenWorkspace} />;
+        case "kudosEffect":
+            return <KudosEffectWidget kudosEffect={data.kudosEffect} />;
+        case "supportCoverage":
+            return <SupportCoverageWidget supportCoverage={data.supportCoverage} />;
+        case "weeklyReview":
+            return <WeeklyReviewWidget onOpen={onOpenWeeklyReview} />;
         default:
             return null;
     }

--- a/frontend/components/analytics/BestTimeWidget.tsx
+++ b/frontend/components/analytics/BestTimeWidget.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsBestTime } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { BestTimeHeatmap } from "./charts/BestTimeHeatmap";
+
+export function BestTimeWidget({ bestTime }: { bestTime: AnalyticsBestTime }) {
+    if (!bestTime || (bestTime.cells ?? []).length === 0) {
+        return (
+            <WidgetCard title="Best time of day">
+                <ThemedText type="caption">Not enough activity yet to find your peak time.</ThemedText>
+            </WidgetCard>
+        );
+    }
+    return (
+        <WidgetCard title="Best time of day" takeaway={bestTime.takeaway}>
+            <BestTimeHeatmap cells={bestTime.cells} />
+        </WidgetCard>
+    );
+}

--- a/frontend/components/analytics/CategoryHealthWidget.tsx
+++ b/frontend/components/analytics/CategoryHealthWidget.tsx
@@ -16,7 +16,8 @@ export function CategoryHealthWidget({ categoryHealth, onSelectCategory }: Props
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
 
-    if (categoryHealth.rows.length === 0) {
+    const rows = categoryHealth.rows ?? [];
+    if (rows.length === 0) {
         return (
             <WidgetCard title="Category health">
                 <ThemedText type="caption">No category activity in this period yet.</ThemedText>
@@ -27,7 +28,7 @@ export function CategoryHealthWidget({ categoryHealth, onSelectCategory }: Props
     return (
         <WidgetCard title="Category health">
             <View style={styles.list}>
-                {categoryHealth.rows.map((row) => (
+                {rows.map((row) => (
                     <CategoryHealthRowItem key={row.categoryId} row={row} onSelectCategory={onSelectCategory} />
                 ))}
             </View>
@@ -60,7 +61,7 @@ function CategoryHealthRowItem({
                 </View>
             </View>
             <View style={styles.right}>
-                <Sparkline data={row.sparkline} color={row.color} width={48} height={20} />
+                <Sparkline data={row.sparkline ?? []} color={row.color} width={48} height={20} />
                 <StatusPill status={row.status} />
             </View>
         </TouchableOpacity>

--- a/frontend/components/analytics/CategoryShareWidget.tsx
+++ b/frontend/components/analytics/CategoryShareWidget.tsx
@@ -18,18 +18,20 @@ export function CategoryShareWidget({ share, range, onSelectCategory }: Props) {
     const styles = stylesheet(ThemedColor);
 
     const title = range === "week" ? "Where your time went" : "Category share";
-    const total = share.slices.reduce((sum, s) => sum + s.count, 0);
-    const useBands = range !== "week" && share.overTime.length > 0;
+    const slices = share.slices ?? [];
+    const overTime = share.overTime ?? [];
+    const total = slices.reduce((sum, s) => sum + s.count, 0);
+    const useBands = range !== "week" && overTime.length > 0;
 
     return (
         <WidgetCard title={title} takeaway={share.takeaway}>
             {useBands ? (
-                <StackedBandChart bands={share.overTime} />
+                <StackedBandChart bands={overTime} />
             ) : (
                 <View style={styles.donutRow}>
-                    <DonutChart slices={share.slices} total={total} />
+                    <DonutChart slices={slices} total={total} />
                     <View style={styles.legend}>
-                        {share.slices.map((slice) => (
+                        {slices.map((slice) => (
                             <ShareLegendRow key={slice.categoryId} slice={slice} onSelectCategory={onSelectCategory} />
                         ))}
                     </View>

--- a/frontend/components/analytics/CompletionTrendWidget.tsx
+++ b/frontend/components/analytics/CompletionTrendWidget.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsProgress } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+import { LineChart } from "./charts/LineChart";
+
+/** Completion trend over the period — a line built from progress buckets. */
+export function CompletionTrendWidget({ progress }: { progress: AnalyticsProgress }) {
+    const buckets = progress.buckets ?? [];
+    if (buckets.length === 0) {
+        return (
+            <WidgetCard title="Completion trend">
+                <ThemedText type="caption">No completed tasks in this period yet.</ThemedText>
+            </WidgetCard>
+        );
+    }
+    return (
+        <WidgetCard title="Completion trend" takeaway={progress.takeaway}>
+            <LineChart data={buckets.map((b) => b.total ?? 0)} labels={buckets.map((b) => b.label)} />
+        </WidgetCard>
+    );
+}

--- a/frontend/components/analytics/DetailHeader.tsx
+++ b/frontend/components/analytics/DetailHeader.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
+import { router } from "expo-router";
+import { CaretLeft } from "phosphor-react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+interface DetailHeaderProps {
+    title: string;
+    subtitle?: string;
+    right?: React.ReactNode;
+}
+
+/** Back-chevron + title row for analytics drilldown screens. */
+export function DetailHeader({ title, subtitle, right }: DetailHeaderProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.container}>
+            <TouchableOpacity style={styles.back} activeOpacity={0.7} onPress={() => router.back()}>
+                <CaretLeft size={22} color={ThemedColor.text} weight="bold" />
+            </TouchableOpacity>
+            <View style={styles.titleCol}>
+                <ThemedText type="fancyFrauncesSubheading">{title}</ThemedText>
+                {subtitle ? <ThemedText type="caption">{subtitle}</ThemedText> : null}
+            </View>
+            {right ? <View style={styles.right}>{right}</View> : null}
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        container: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            paddingHorizontal: 16,
+            paddingBottom: 12,
+        },
+        back: {
+            padding: 4,
+        },
+        titleCol: {
+            flex: 1,
+        },
+        right: {
+            marginLeft: "auto",
+        },
+    });

--- a/frontend/components/analytics/FriendView.tsx
+++ b/frontend/components/analytics/FriendView.tsx
@@ -1,0 +1,107 @@
+import React, { useMemo, useState } from "react";
+import { View, ScrollView, StyleSheet, TouchableOpacity } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { useKudos } from "@/contexts/kudosContext";
+import { DetailHeader } from "./DetailHeader";
+import { WidgetCard } from "./WidgetCard";
+import { StatCards } from "./StatCards";
+import EncourageModal from "@/components/modals/EncourageModal";
+
+interface FriendViewProps {
+    userId: string;
+    displayName?: string;
+    handle?: string;
+}
+
+/**
+ * Privacy-safe minimal friend view: no analytics on the friend, just the Kudos
+ * exchanged between the two of you plus a way to cheer them on.
+ */
+export function FriendView({ userId, displayName, handle }: FriendViewProps) {
+    const ThemedColor = useThemeColor() as any;
+    const insets = useSafeAreaInsets();
+    const styles = stylesheet(ThemedColor);
+    const { encouragements, sentEncouragements } = useKudos();
+    const [encourageVisible, setEncourageVisible] = useState(false);
+
+    const fromThem = useMemo(
+        () => (encouragements ?? []).filter((e: any) => e.sender?.id === userId).length,
+        [encouragements, userId],
+    );
+    const toThem = useMemo(
+        () => (sentEncouragements ?? []).filter((e: any) => e.receiverInfo?.id === userId).length,
+        [sentEncouragements, userId],
+    );
+
+    const name = displayName || "This friend";
+    const initial = (name.trim()[0] ?? "?").toUpperCase();
+
+    return (
+        <View style={{ flex: 1, backgroundColor: ThemedColor.background, paddingTop: insets.top + 8 }}>
+            <DetailHeader title={name} />
+            <ScrollView
+                showsVerticalScrollIndicator={false}
+                contentContainerStyle={{ paddingHorizontal: 20, paddingTop: 8, paddingBottom: insets.bottom + 110 }}>
+                <View style={styles.profile}>
+                    <View style={styles.avatar}>
+                        <ThemedText type="fancyFrauncesSubheading" style={{ color: ThemedColor.buttonText }}>
+                            {initial}
+                        </ThemedText>
+                    </View>
+                    <ThemedText type="fancyFrauncesSubheading">{name}</ThemedText>
+                    {handle ? <ThemedText type="caption">{handle}</ThemedText> : null}
+                </View>
+
+                <StatCards
+                    items={[
+                        { label: "Kudos from them", value: String(fromThem) },
+                        { label: "Kudos to them", value: String(toThem) },
+                    ]}
+                />
+
+                <WidgetCard title="Cheer them on">
+                    <ThemedText type="caption">Send a little encouragement to keep them going.</ThemedText>
+                    <TouchableOpacity style={styles.button} activeOpacity={0.85} onPress={() => setEncourageVisible(true)}>
+                        <ThemedText type="defaultSemiBold" style={{ color: ThemedColor.buttonText }}>
+                            Send encouragement
+                        </ThemedText>
+                    </TouchableOpacity>
+                </WidgetCard>
+            </ScrollView>
+
+            <EncourageModal
+                visible={encourageVisible}
+                setVisible={setEncourageVisible}
+                isProfileLevel
+                encouragementConfig={{ receiverId: userId, categoryName: "", userHandle: handle }}
+            />
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        profile: {
+            alignItems: "center",
+            gap: 6,
+            marginVertical: 20,
+        },
+        avatar: {
+            width: 72,
+            height: 72,
+            borderRadius: 36,
+            backgroundColor: ThemedColor.primary,
+            alignItems: "center",
+            justifyContent: "center",
+            marginBottom: 4,
+        },
+        button: {
+            backgroundColor: ThemedColor.primary,
+            borderRadius: 14,
+            paddingVertical: 14,
+            alignItems: "center",
+            marginTop: 12,
+        },
+    });

--- a/frontend/components/analytics/HabitsWidget.tsx
+++ b/frontend/components/analytics/HabitsWidget.tsx
@@ -19,11 +19,11 @@ export function HabitsWidget({ habits, onPress }: Props) {
             title="Habits & recurring"
             takeaway={habits.takeaway}
             cta={onPress ? { label: "View habits", onPress } : undefined}>
-            {habits.rows.length === 0 ? (
+            {(habits.rows ?? []).length === 0 ? (
                 <ThemedText type="caption">No recurring tasks yet.</ThemedText>
             ) : (
                 <View style={styles.list}>
-                    {habits.rows.map((row) => (
+                    {(habits.rows ?? []).map((row) => (
                         <HabitRow key={row.templateId} row={row} />
                     ))}
                 </View>
@@ -44,7 +44,7 @@ function HabitRow({ row }: { row: AnalyticsHabitRow }) {
                 <ThemedText type="caption">{row.rhythmLabel}</ThemedText>
             </View>
             <View style={styles.dots}>
-                {row.dots.map((filled, i) => (
+                {(row.dots ?? []).map((filled, i) => (
                     <View
                         key={i}
                         style={[

--- a/frontend/components/analytics/KudosEffectWidget.tsx
+++ b/frontend/components/analytics/KudosEffectWidget.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsKudosEffect } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+
+function formatHours(h: number): string {
+    return h >= 24 ? `${(h / 24).toFixed(1)}d` : `${h}h`;
+}
+
+export function KudosEffectWidget({ kudosEffect }: { kudosEffect: AnalyticsKudosEffect }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    if (!kudosEffect?.hasComparison) {
+        return (
+            <WidgetCard title="Kudos effect">
+                <ThemedText type="caption">
+                    {kudosEffect?.takeaway ?? "Not enough completed tasks yet to compare with vs without Kudos."}
+                </ThemedText>
+            </WidgetCard>
+        );
+    }
+
+    const w = kudosEffect.withKudosMedianHours;
+    const wo = kudosEffect.withoutKudosMedianHours;
+    const max = Math.max(w, wo, 1);
+
+    return (
+        <WidgetCard title="Kudos effect" takeaway={kudosEffect.takeaway}>
+            <CompareRow label="With Kudos" value={formatHours(w)} ratio={w / max} color={ThemedColor.primary} />
+            <CompareRow label="Without" value={formatHours(wo)} ratio={wo / max} color={ThemedColor.tertiary} />
+        </WidgetCard>
+    );
+}
+
+function CompareRow({ label, value, ratio, color }: { label: string; value: string; ratio: number; color: string }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            <ThemedText type="caption" style={styles.label}>
+                {label}
+            </ThemedText>
+            <View style={styles.track}>
+                <View style={[styles.fill, { width: `${Math.max(6, ratio * 100)}%`, backgroundColor: color }]} />
+            </View>
+            <ThemedText type="defaultSemiBold" style={styles.value}>
+                {value}
+            </ThemedText>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: 10,
+            marginBottom: 10,
+        },
+        label: {
+            width: 80,
+        },
+        track: {
+            flex: 1,
+            height: 14,
+            borderRadius: 7,
+            backgroundColor: ThemedColor.lightened,
+            overflow: "hidden",
+        },
+        fill: {
+            height: "100%",
+            borderRadius: 7,
+        },
+        value: {
+            width: 44,
+            textAlign: "right",
+        },
+    });

--- a/frontend/components/analytics/StatCards.tsx
+++ b/frontend/components/analytics/StatCards.tsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+
+export interface StatItem {
+    label: string;
+    value: string;
+}
+
+/** Compact metric row for detail screens (Done / On-time / Kudos / Stale). */
+export function StatCards({ items }: { items: StatItem[] }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    return (
+        <View style={styles.row}>
+            {items.map((item) => (
+                <View key={item.label} style={styles.card}>
+                    <ThemedText type="fancyFrauncesSubheading" style={styles.value}>
+                        {item.value}
+                    </ThemedText>
+                    <ThemedText type="caption">{item.label}</ThemedText>
+                </View>
+            ))}
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            flexDirection: "row",
+            gap: 10,
+            marginBottom: 16,
+        },
+        card: {
+            flex: 1,
+            backgroundColor: ThemedColor.lightenedCard,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: ThemedColor.tertiary,
+            paddingVertical: 14,
+            paddingHorizontal: 10,
+            alignItems: "flex-start",
+            gap: 2,
+            boxShadow: ThemedColor.shadowSmall,
+        },
+        value: {
+            fontSize: 20,
+        },
+    });

--- a/frontend/components/analytics/SupportCoverageWidget.tsx
+++ b/frontend/components/analytics/SupportCoverageWidget.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsSupportCoverage } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+
+export function SupportCoverageWidget({ supportCoverage }: { supportCoverage: AnalyticsSupportCoverage }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const pct = supportCoverage?.pct ?? 0;
+
+    return (
+        <WidgetCard title="Support coverage" takeaway={supportCoverage?.takeaway}>
+            <ThemedText type="fancyFrauncesHeading" style={styles.stat}>
+                {pct}%
+            </ThemedText>
+            <View style={styles.track}>
+                <View style={[styles.fill, { width: `${pct}%`, backgroundColor: ThemedColor.primary }]} />
+            </View>
+            <ThemedText type="caption" style={styles.caption}>
+                {supportCoverage?.supported ?? 0} of {supportCoverage?.total ?? 0} finished tasks had support
+            </ThemedText>
+        </WidgetCard>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        stat: {
+            fontSize: 30,
+            marginBottom: 8,
+        },
+        track: {
+            height: 14,
+            borderRadius: 7,
+            backgroundColor: ThemedColor.lightened,
+            overflow: "hidden",
+        },
+        fill: {
+            height: "100%",
+            borderRadius: 7,
+        },
+        caption: {
+            marginTop: 8,
+        },
+    });

--- a/frontend/components/analytics/TasksNeedingAttentionWidget.tsx
+++ b/frontend/components/analytics/TasksNeedingAttentionWidget.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { format } from "date-fns";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsAttention, AnalyticsAttentionTask } from "@/api/analytics";
+import { WidgetCard } from "./WidgetCard";
+
+export function TasksNeedingAttentionWidget({ attention }: { attention: AnalyticsAttention }) {
+    const tasks = attention?.tasks ?? [];
+    if (tasks.length === 0) {
+        return (
+            <WidgetCard title="Tasks needing attention">
+                <ThemedText type="caption">Nothing needs attention right now. 🎉</ThemedText>
+            </WidgetCard>
+        );
+    }
+    return (
+        <WidgetCard title="Tasks needing attention">
+            <View style={{ gap: 14 }}>
+                {tasks.map((task) => (
+                    <AttentionRow key={task.id} task={task} />
+                ))}
+            </View>
+        </WidgetCard>
+    );
+}
+
+function AttentionRow({ task }: { task: AnalyticsAttentionTask }) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+    const meta = task.deadline ? `Due ${format(new Date(task.deadline), "MMM d")}` : `${task.daysOpen} days open`;
+    return (
+        <View style={styles.row}>
+            <ThemedText type="defaultSemiBold" style={styles.title} numberOfLines={1}>
+                {task.title}
+            </ThemedText>
+            <ThemedText type="caption">
+                {task.category} · {meta}
+            </ThemedText>
+            <View style={styles.reasons}>
+                {(task.reasons ?? []).map((reason) => (
+                    <View key={reason} style={styles.chip}>
+                        <ThemedText type="caption" style={{ color: ThemedColor.warning, fontSize: 11 }}>
+                            {reason}
+                        </ThemedText>
+                    </View>
+                ))}
+            </View>
+        </View>
+    );
+}
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            gap: 4,
+        },
+        title: {
+            fontSize: 15,
+        },
+        reasons: {
+            flexDirection: "row",
+            flexWrap: "wrap",
+            gap: 6,
+            marginTop: 2,
+        },
+        chip: {
+            paddingHorizontal: 8,
+            paddingVertical: 3,
+            borderRadius: 999,
+            borderWidth: 1,
+            borderColor: ThemedColor.warning + "55",
+            backgroundColor: ThemedColor.warning + "1A",
+        },
+    });

--- a/frontend/components/analytics/WeeklyProgressWidget.tsx
+++ b/frontend/components/analytics/WeeklyProgressWidget.tsx
@@ -48,7 +48,7 @@ export function WeeklyProgressWidget({ progress, range }: Props) {
             <StackedBarChart buckets={progress.buckets} />
 
             <View style={styles.legend}>
-                {progress.legend.map((item) => (
+                {(progress.legend ?? []).map((item) => (
                     <LegendChip key={item.categoryId} item={item} />
                 ))}
             </View>

--- a/frontend/components/analytics/WeeklyReviewWidget.tsx
+++ b/frontend/components/analytics/WeeklyReviewWidget.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { ThemedText } from "@/components/ThemedText";
+import { WidgetCard } from "./WidgetCard";
+
+/** Dashboard CTA card that opens the guided Weekly Review. */
+export function WeeklyReviewWidget({ onOpen }: { onOpen: () => void }) {
+    return (
+        <WidgetCard title="Weekly review" onPress={onOpen} cta={{ label: "Open weekly review", onPress: onOpen }}>
+            <ThemedText type="caption">See how your week came together — momentum, support, and what to focus on next.</ThemedText>
+        </WidgetCard>
+    );
+}

--- a/frontend/components/analytics/WidgetCard.tsx
+++ b/frontend/components/analytics/WidgetCard.tsx
@@ -67,6 +67,7 @@ const stylesheet = (ThemedColor: any) =>
             marginBottom: 16,
             borderWidth: 1,
             borderColor: ThemedColor.tertiary,
+            boxShadow: ThemedColor.shadowSmall,
         },
         header: {
             flexDirection: "row",

--- a/frontend/components/analytics/WorkspaceHealthWidget.tsx
+++ b/frontend/components/analytics/WorkspaceHealthWidget.tsx
@@ -15,7 +15,8 @@ export function WorkspaceHealthWidget({ workspaceHealth, onSelectWorkspace }: Pr
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
 
-    if (workspaceHealth.rows.length === 0) {
+    const rows = workspaceHealth.rows ?? [];
+    if (rows.length === 0) {
         return (
             <WidgetCard title="Workspace health">
                 <ThemedText type="caption">No workspace activity in this period yet.</ThemedText>
@@ -26,7 +27,7 @@ export function WorkspaceHealthWidget({ workspaceHealth, onSelectWorkspace }: Pr
     return (
         <WidgetCard title="Workspace health">
             <View style={styles.list}>
-                {workspaceHealth.rows.map((row) => (
+                {rows.map((row) => (
                     <WorkspaceHealthRowItem key={row.workspace} row={row} onSelectWorkspace={onSelectWorkspace} />
                 ))}
             </View>

--- a/frontend/components/analytics/analyticsLayout.ts
+++ b/frontend/components/analytics/analyticsLayout.ts
@@ -1,33 +1,62 @@
-import { useCallback, useEffect, useState } from "react";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+// Pure widget-layout helpers and metadata. No React / API imports here so this
+// stays trivially unit-testable; the data hook lives in hooks/useAnalyticsLayout.
 
 export type WidgetId =
-    | "signals"
-    | "progress"
     | "categoryShare"
+    | "progress"
     | "habits"
     | "heatmap"
     | "categoryHealth"
-    | "workspaceHealth";
+    | "workspaceHealth"
+    | "kudosEffect"
+    | "supportCoverage"
+    | "weeklyReview";
 
 export const DEFAULT_WIDGET_ORDER: WidgetId[] = [
-    "signals",
-    "progress",
     "categoryShare",
+    "progress",
     "habits",
     "heatmap",
     "categoryHealth",
     "workspaceHealth",
+    "kudosEffect",
+    "supportCoverage",
+    "weeklyReview",
 ];
 
 export const WIDGET_TITLES: Record<WidgetId, string> = {
-    signals: "Signal strip",
-    progress: "Weekly progress",
-    categoryShare: "Category share",
+    categoryShare: "Where your time went",
+    progress: "Progress",
     habits: "Habits & recurring",
     heatmap: "Activity heatmap",
     categoryHealth: "Category health",
     workspaceHealth: "Workspace health",
+    kudosEffect: "Kudos effect",
+    supportCoverage: "Support coverage",
+    weeklyReview: "Weekly review",
+};
+
+export type WidgetCategory = "Progress" | "Health" | "Social" | "Rhythms" | "Habits";
+
+export const WIDGET_CATEGORIES: WidgetCategory[] = ["Progress", "Health", "Rhythms", "Habits", "Social"];
+
+export interface WidgetMeta {
+    description: string;
+    category: WidgetCategory;
+    popular?: boolean;
+}
+
+// Gallery metadata for the Add Cards screen.
+export const WIDGET_META: Record<WidgetId, WidgetMeta> = {
+    categoryShare: { description: "Where your completed work went, by category.", category: "Progress", popular: true },
+    progress: { description: "Tasks completed over time, stacked by category.", category: "Progress", popular: true },
+    habits: { description: "Recurring tasks and how consistently you keep them up.", category: "Habits", popular: true },
+    heatmap: { description: "Your activity calendar — tap a day to see what you finished.", category: "Rhythms", popular: true },
+    categoryHealth: { description: "On-time rate, support, and status for each category.", category: "Health" },
+    workspaceHealth: { description: "A quick health read across your workspaces.", category: "Health" },
+    kudosEffect: { description: "How tasks with Kudos compare to those without.", category: "Social" },
+    supportCoverage: { description: "How much of your finished work had support.", category: "Social" },
+    weeklyReview: { description: "A guided recap of your week.", category: "Social" },
 };
 
 export function isWidgetId(value: unknown): value is WidgetId {
@@ -53,81 +82,4 @@ export function sanitizeOrder(order: unknown): WidgetId[] {
         if (!seen.has(id)) arr.push(id);
     }
     return arr;
-}
-
-const keyFor = (userId?: string) => (userId ? `analytics_layout_${userId}` : null);
-
-/**
- * Persisted, reorderable widget layout. Stored locally (AsyncStorage) for
- * Phase 1; server sync is a later phase.
- */
-export function useAnalyticsLayout(userId?: string) {
-    const [order, setOrder] = useState<WidgetId[]>(DEFAULT_WIDGET_ORDER);
-    const [hidden, setHidden] = useState<WidgetId[]>([]);
-    const [loaded, setLoaded] = useState(false);
-    const key = keyFor(userId);
-
-    useEffect(() => {
-        let active = true;
-        (async () => {
-            if (!key) {
-                setLoaded(true);
-                return;
-            }
-            try {
-                const raw = await AsyncStorage.getItem(key);
-                if (active && raw) {
-                    const parsed = JSON.parse(raw);
-                    setOrder(sanitizeOrder(parsed.order));
-                    setHidden(Array.isArray(parsed.hidden) ? parsed.hidden.filter(isWidgetId) : []);
-                }
-            } catch {
-                // fall back to defaults
-            } finally {
-                if (active) setLoaded(true);
-            }
-        })();
-        return () => {
-            active = false;
-        };
-    }, [key]);
-
-    const persist = useCallback(
-        (o: WidgetId[], h: WidgetId[]) => {
-            if (key) AsyncStorage.setItem(key, JSON.stringify({ order: o, hidden: h })).catch(() => {});
-        },
-        [key],
-    );
-
-    const moveWidget = useCallback(
-        (from: number, to: number) => {
-            setOrder((prev) => {
-                const next = moveItem(prev, from, to);
-                persist(next, hidden);
-                return next;
-            });
-        },
-        [hidden, persist],
-    );
-
-    const toggleHidden = useCallback(
-        (id: WidgetId) => {
-            setHidden((prev) => {
-                const next = prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id];
-                persist(order, next);
-                return next;
-            });
-        },
-        [order, persist],
-    );
-
-    const reset = useCallback(() => {
-        setOrder(DEFAULT_WIDGET_ORDER);
-        setHidden([]);
-        persist(DEFAULT_WIDGET_ORDER, []);
-    }, [persist]);
-
-    const visible = order.filter((id) => !hidden.includes(id));
-
-    return { order, hidden, visible, loaded, moveWidget, toggleHidden, reset };
 }

--- a/frontend/components/analytics/charts/BestTimeHeatmap.tsx
+++ b/frontend/components/analytics/charts/BestTimeHeatmap.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import { View, StyleSheet } from "react-native";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
+import { AnalyticsBestTimeCell } from "@/api/analytics";
+import { heatmapLevelColor } from "../analyticsColors";
+
+interface BestTimeHeatmapProps {
+    cells: AnalyticsBestTimeCell[];
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+const BLOCKS = 8; // 8 three-hour blocks
+const BLOCK_LABELS: Record<number, string> = { 0: "12a", 2: "6a", 4: "12p", 6: "6p" };
+
+/** Hour×weekday grid bucketed into eight 3-hour blocks. */
+export function BestTimeHeatmap({ cells }: BestTimeHeatmapProps) {
+    const ThemedColor = useThemeColor() as any;
+    const styles = stylesheet(ThemedColor);
+
+    // weekday(Mon=0) × block -> count
+    const matrix: number[][] = Array.from({ length: 7 }, () => Array(BLOCKS).fill(0));
+    let max = 0;
+    for (const c of cells ?? []) {
+        const block = Math.min(BLOCKS - 1, Math.floor(c.hour / 3));
+        if (c.weekday >= 0 && c.weekday < 7) {
+            matrix[c.weekday][block] += c.count;
+            if (matrix[c.weekday][block] > max) max = matrix[c.weekday][block];
+        }
+    }
+
+    const levelFor = (count: number) => {
+        if (count <= 0 || max <= 0) return 0;
+        return Math.max(1, Math.ceil((count / max) * 4));
+    };
+
+    return (
+        <View>
+            {WEEKDAYS.map((label, wd) => (
+                <View key={wd} style={styles.row}>
+                    <ThemedText type="caption" style={styles.rowLabel}>
+                        {label}
+                    </ThemedText>
+                    {matrix[wd].map((count, block) => (
+                        <View
+                            key={block}
+                            style={[styles.cell, { backgroundColor: heatmapLevelColor(levelFor(count), ThemedColor) }]}
+                        />
+                    ))}
+                </View>
+            ))}
+            <View style={styles.axis}>
+                <View style={styles.rowLabel} />
+                {Array.from({ length: BLOCKS }).map((_, block) => (
+                    <ThemedText key={block} type="caption" style={styles.axisLabel}>
+                        {BLOCK_LABELS[block] ?? ""}
+                    </ThemedText>
+                ))}
+            </View>
+        </View>
+    );
+}
+
+const CELL = 18;
+const GAP = 4;
+
+const stylesheet = (ThemedColor: any) =>
+    StyleSheet.create({
+        row: {
+            flexDirection: "row",
+            alignItems: "center",
+            gap: GAP,
+            marginBottom: GAP,
+        },
+        rowLabel: {
+            width: 32,
+            fontSize: 11,
+        },
+        cell: {
+            width: CELL,
+            height: CELL,
+            borderRadius: 4,
+        },
+        axis: {
+            flexDirection: "row",
+            gap: GAP,
+            marginTop: 2,
+        },
+        axisLabel: {
+            width: CELL,
+            fontSize: 9,
+            textAlign: "left",
+        },
+    });

--- a/frontend/components/analytics/charts/LineChart.tsx
+++ b/frontend/components/analytics/charts/LineChart.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { LineChart as GiftedLineChart } from "react-native-gifted-charts";
+import { useThemeColor } from "@/hooks/useThemeColor";
+
+interface LineChartProps {
+    data: number[];
+    labels?: string[];
+    color?: string;
+    height?: number;
+}
+
+/** Completion-trend line (area-filled) for detail screens. */
+export function LineChart({ data, labels, color, height = 140 }: LineChartProps) {
+    const ThemedColor = useThemeColor() as any;
+    const stroke = color ?? ThemedColor.primary;
+    const safe = data ?? [];
+    const points = safe.map((v, i) => ({ value: v, label: labels?.[i] }));
+    const peak = Math.max(1, ...safe);
+    const maxValue = peak <= 3 ? 3 : Math.ceil(peak / 3) * 3;
+
+    return (
+        <GiftedLineChart
+            data={points as any}
+            height={height}
+            color={stroke}
+            thickness={3}
+            curved
+            hideRules
+            hideYAxisText
+            yAxisThickness={0}
+            xAxisThickness={0}
+            noOfSections={3}
+            maxValue={maxValue}
+            initialSpacing={8}
+            endSpacing={8}
+            disableScroll
+            dataPointsColor={stroke}
+            areaChart
+            startFillColor={stroke}
+            startOpacity={0.18}
+            endFillColor={stroke}
+            endOpacity={0.02}
+            xAxisLabelTextStyle={{ color: ThemedColor.caption, fontSize: 11 }}
+        />
+    );
+}

--- a/frontend/components/analytics/charts/MonthHeatmap.tsx
+++ b/frontend/components/analytics/charts/MonthHeatmap.tsx
@@ -1,32 +1,63 @@
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, TouchableOpacity } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
+import { ThemedText } from "@/components/ThemedText";
 import { AnalyticsHeatmapDay } from "@/api/analytics";
 import { heatmapLevelColor } from "../analyticsColors";
 
 interface MonthHeatmapProps {
     days: AnalyticsHeatmapDay[];
+    onSelectDay?: (date: Date) => void;
+    weeks?: number;
 }
 
-/** Trailing-quarter activity grid: columns of 7 days, colored by intensity. */
-export function MonthHeatmap({ days }: MonthHeatmapProps) {
+const WEEKDAY_LABELS = ["M", "T", "W", "T", "F", "S", "S"];
+const CELL = 16;
+const GAP = 4;
+
+function parseLocalDate(iso: string): Date {
+    const [y, m, d] = iso.split("-").map((n) => parseInt(n, 10));
+    return new Date(y, (m || 1) - 1, d || 1);
+}
+
+// Mon=0 ... Sun=6
+function mondayIndex(date: Date): number {
+    return (date.getDay() + 6) % 7;
+}
+
+/** Monday-aligned calendar grid (weekday columns, week rows). Cells with
+ * activity are tappable to inspect that day. */
+export function MonthHeatmap({ days, onSelectDay, weeks = 10 }: MonthHeatmapProps) {
     const ThemedColor = useThemeColor() as any;
     const styles = stylesheet(ThemedColor);
+    const safeDays = days ?? [];
 
-    const columns: AnalyticsHeatmapDay[][] = [];
-    for (let i = 0; i < days.length; i += 7) {
-        columns.push(days.slice(i, i + 7));
+    if (safeDays.length === 0) {
+        return null;
     }
 
+    const firstMon = mondayIndex(parseLocalDate(safeDays[0].date));
+    const cells: (AnalyticsHeatmapDay | null)[] = [];
+    for (let i = 0; i < firstMon; i++) cells.push(null);
+    safeDays.forEach((d) => cells.push(d));
+
+    const rows: (AnalyticsHeatmapDay | null)[][] = [];
+    for (let i = 0; i < cells.length; i += 7) rows.push(cells.slice(i, i + 7));
+    const shown = rows.slice(-weeks);
+
     return (
-        <View style={styles.grid}>
-            {columns.map((col, ci) => (
-                <View key={ci} style={styles.column}>
-                    {col.map((d) => (
-                        <View
-                            key={d.date}
-                            style={[styles.cell, { backgroundColor: heatmapLevelColor(d.level, ThemedColor) }]}
-                        />
+        <View>
+            <View style={styles.headerRow}>
+                {WEEKDAY_LABELS.map((label, i) => (
+                    <ThemedText key={i} type="caption" style={styles.headerLabel}>
+                        {label}
+                    </ThemedText>
+                ))}
+            </View>
+            {shown.map((week, wi) => (
+                <View key={wi} style={styles.weekRow}>
+                    {Array.from({ length: 7 }).map((_, di) => (
+                        <HeatCell key={di} day={week[di] ?? null} onSelectDay={onSelectDay} ThemedColor={ThemedColor} />
                     ))}
                 </View>
             ))}
@@ -34,18 +65,54 @@ export function MonthHeatmap({ days }: MonthHeatmapProps) {
     );
 }
 
+function HeatCell({
+    day,
+    onSelectDay,
+    ThemedColor,
+}: {
+    day: AnalyticsHeatmapDay | null;
+    onSelectDay?: (date: Date) => void;
+    ThemedColor: any;
+}) {
+    if (!day) {
+        return <View style={{ width: CELL, height: CELL }} />;
+    }
+    const empty = day.level === 0;
+    const tappable = day.count > 0 && !!onSelectDay;
+    return (
+        <TouchableOpacity
+            disabled={!tappable}
+            activeOpacity={0.6}
+            onPress={() => onSelectDay?.(parseLocalDate(day.date))}>
+            <View
+                style={{
+                    width: CELL,
+                    height: CELL,
+                    borderRadius: 4,
+                    backgroundColor: heatmapLevelColor(day.level, ThemedColor),
+                    borderWidth: empty ? StyleSheet.hairlineWidth : 0,
+                    borderColor: ThemedColor.tertiary,
+                }}
+            />
+        </TouchableOpacity>
+    );
+}
+
 const stylesheet = (ThemedColor: any) =>
     StyleSheet.create({
-        grid: {
+        headerRow: {
             flexDirection: "row",
-            gap: 4,
+            gap: GAP,
+            marginBottom: GAP,
         },
-        column: {
-            gap: 4,
+        headerLabel: {
+            width: CELL,
+            textAlign: "center",
+            fontSize: 10,
         },
-        cell: {
-            width: 12,
-            height: 12,
-            borderRadius: 3,
+        weekRow: {
+            flexDirection: "row",
+            gap: GAP,
+            marginBottom: GAP,
         },
     });

--- a/frontend/components/analytics/charts/StackedBandChart.tsx
+++ b/frontend/components/analytics/charts/StackedBandChart.tsx
@@ -15,7 +15,7 @@ export function StackedBandChart({ bands }: StackedBandChartProps) {
 
     return (
         <View style={styles.container}>
-            {bands.map((band) => (
+            {(bands ?? []).map((band) => (
                 <BandRow key={band.label} band={band} ThemedColor={ThemedColor} />
             ))}
         </View>
@@ -24,7 +24,8 @@ export function StackedBandChart({ bands }: StackedBandChartProps) {
 
 function BandRow({ band, ThemedColor }: { band: AnalyticsShareBand; ThemedColor: any }) {
     const styles = stylesheet(ThemedColor);
-    const total = band.slices.reduce((sum, s) => sum + s.count, 0);
+    const slices = band.slices ?? [];
+    const total = slices.reduce((sum, s) => sum + s.count, 0);
 
     return (
         <View style={styles.row}>
@@ -35,7 +36,7 @@ function BandRow({ band, ThemedColor }: { band: AnalyticsShareBand; ThemedColor:
                 {total === 0 ? (
                     <View style={[styles.segment, { flex: 1, backgroundColor: ThemedColor.lightened }]} />
                 ) : (
-                    band.slices.map((s, i) => (
+                    slices.map((s, i) => (
                         <View
                             key={s.categoryId + i}
                             style={[styles.segment, { flex: Math.max(s.count, 0.0001), backgroundColor: s.color }]}

--- a/frontend/components/analytics/charts/StackedBarChart.tsx
+++ b/frontend/components/analytics/charts/StackedBarChart.tsx
@@ -13,15 +13,19 @@ interface StackedBarChartProps {
 export function StackedBarChart({ buckets, height = 160 }: StackedBarChartProps) {
     const ThemedColor = useThemeColor() as any;
 
-    const stackData = buckets.map((b) => ({
-        label: b.label,
-        stacks:
-            b.segments.length > 0
-                ? b.segments.map((s) => ({ value: s.count, color: s.color }))
-                : [{ value: 0, color: "transparent" }],
-    }));
+    const safeBuckets = buckets ?? [];
+    const stackData = safeBuckets.map((b) => {
+        const segments = b.segments ?? [];
+        return {
+            label: b.label,
+            stacks:
+                segments.length > 0
+                    ? segments.map((s) => ({ value: s.count, color: s.color }))
+                    : [{ value: 0, color: "transparent" }],
+        };
+    });
 
-    const peak = Math.max(1, ...buckets.map((b) => b.total));
+    const peak = Math.max(1, ...safeBuckets.map((b) => b.total ?? 0));
     const maxValue = peak <= 3 ? 3 : Math.ceil(peak / 3) * 3;
 
     return (

--- a/frontend/components/inputs/TaggedUsersChips.tsx
+++ b/frontend/components/inputs/TaggedUsersChips.tsx
@@ -1,15 +1,19 @@
 import React from "react";
-import { View, TouchableOpacity } from "react-native";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { Ionicons } from "@expo/vector-icons";
 import { formatHandle } from "@/utils/handle";
+import CachedImage from "@/components/CachedImage";
 
 export type TaggedUser = {
     id: string;
     handle: string;
     display_name?: string;
+    profile_picture?: string;
 };
+
+const AVATAR = 18;
 
 type Props = {
     users: TaggedUser[];
@@ -28,12 +32,23 @@ const TaggedUsersChips = ({ users, onRemove }: Props) => {
                     style={{
                         flexDirection: "row",
                         alignItems: "center",
-                        paddingHorizontal: 10,
+                        paddingLeft: 6,
+                        paddingRight: 10,
                         paddingVertical: 6,
                         backgroundColor: ThemedColor.lightened,
                         borderRadius: 16,
                         gap: 6,
                     }}>
+                    {u.profile_picture ? (
+                        <CachedImage
+                            source={{ uri: u.profile_picture }}
+                            style={styles.avatar}
+                            variant="thumbnail"
+                            cachePolicy="memory-disk"
+                        />
+                    ) : (
+                        <View style={[styles.avatar, { backgroundColor: ThemedColor.tertiary }]} />
+                    )}
                     <ThemedText type="caption">{formatHandle(u.handle)}</ThemedText>
                     <TouchableOpacity onPress={() => onRemove(u.id)} hitSlop={8}>
                         <Ionicons name="close-circle" size={16} color={ThemedColor.caption} />
@@ -43,5 +58,13 @@ const TaggedUsersChips = ({ users, onRemove }: Props) => {
         </View>
     );
 };
+
+const styles = StyleSheet.create({
+    avatar: {
+        width: AVATAR,
+        height: AVATAR,
+        borderRadius: AVATAR / 2,
+    },
+});
 
 export default TaggedUsersChips;

--- a/frontend/components/modals/DefaultModal.tsx
+++ b/frontend/components/modals/DefaultModal.tsx
@@ -14,6 +14,7 @@ type Props = {
     customPadding?: boolean;
     enableDynamicSizing?: boolean;
     enableContentPanningGesture?: boolean;
+    keyboardBehavior?: "interactive" | "extend" | "fillParent";
 };
 
 // Using memo to prevent unnecessary re-renders
@@ -78,7 +79,7 @@ const DefaultModal = memo((props: Props) => {
             backdropComponent={renderBackdrop}
             handleIndicatorStyle={{ backgroundColor: ThemedColor.text }}
             backgroundStyle={{ backgroundColor: ThemedColor.background }}
-            keyboardBehavior="interactive"
+            keyboardBehavior={props.keyboardBehavior ?? "interactive"}
             keyboardBlurBehavior="restore"
             android_keyboardInputMode="adjustResize"
             enableContentPanningGesture={props.enableContentPanningGesture}

--- a/frontend/components/modals/EndOfDayReviewSheet.tsx
+++ b/frontend/components/modals/EndOfDayReviewSheet.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { StyleSheet, TouchableOpacity, useWindowDimensions, View } from "react-native";
+import { StyleSheet, TouchableOpacity, View } from "react-native";
 import { BottomSheetScrollView, BottomSheetTextInput, type BottomSheetScrollViewMethods } from "@gorhom/bottom-sheet";
 import { CheckCircleIcon, CircleIcon, PlusCircleIcon, XCircleIcon } from "phosphor-react-native";
 import { useQueryClient } from "@tanstack/react-query";
@@ -76,7 +76,6 @@ export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, on
     const ThemedColor = useThemeColor();
     const queryClient = useQueryClient();
     const { workspaces, selected, removeFromCategory, fetchWorkspaces } = useTasks();
-    const { height: windowHeight } = useWindowDimensions();
     const scrollRef = useRef<BottomSheetScrollViewMethods>(null);
 
     const [checkedIds, setCheckedIds] = useState<Set<string>>(new Set());
@@ -157,14 +156,18 @@ export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, on
     };
 
     return (
-        <DefaultModal visible={visible} setVisible={setVisible} enableContentPanningGesture={false}>
+        <DefaultModal
+            visible={visible}
+            setVisible={setVisible}
+            enableContentPanningGesture={false}
+            keyboardBehavior="extend">
             <ThemedText type="fancyFrauncesSubheading" style={styles.heading}>
                 How did today go?
             </ThemedText>
 
             <BottomSheetScrollView
                 ref={scrollRef}
-                style={{ maxHeight: windowHeight * 0.42 }}
+                style={styles.scroll}
                 contentContainerStyle={styles.scrollContent}
                 showsVerticalScrollIndicator
                 keyboardShouldPersistTaps="handled"
@@ -195,9 +198,9 @@ export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, on
                 </View>
             </BottomSheetScrollView>
 
+            {/* Pinned footer; with keyboardBehavior="extend" the content region
+                shrinks for the keyboard so the whole footer stays above it. */}
             <View style={[styles.footer, { borderTopColor: ThemedColor.tertiary }]}>
-                {/* Button above the input: the keyboard only lifts enough to reveal
-                    the focused (bottom-most) input, so the button stays uncovered. */}
                 <PrimaryButton
                     title={submitting ? "Logging…" : "Log my day"}
                     onPress={handleSubmit}
@@ -226,6 +229,11 @@ export default function EndOfDayReviewSheet({ visible, setVisible, openTasks, on
 const styles = StyleSheet.create({
     heading: {
         marginBottom: 16,
+    },
+    // Flex so the list fills the space above the footer; the footer pins to the
+    // bottom and rides up with the keyboard (extend) instead of being covered.
+    scroll: {
+        flex: 1,
     },
     scrollContent: {
         paddingBottom: 8,

--- a/frontend/components/profile/BlueprintGallery.tsx
+++ b/frontend/components/profile/BlueprintGallery.tsx
@@ -10,8 +10,10 @@ import CachedImage from "../CachedImage";
 import { ThemedText } from "../ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import MaterialIcons from "@expo/vector-icons/MaterialIcons";
+import { Play } from "phosphor-react-native";
 import LoadingScreen from "../ui/LoadingScreen";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
+import { postCover, type PostCover } from "@/utils/postMedia";
 
 interface BlueprintGalleryProps {
     blueprintId: string;
@@ -19,6 +21,7 @@ interface BlueprintGalleryProps {
 
 interface PostImage {
     imageUrl: string;
+    isVideo: boolean;
     postId: string;
     postUserId: string;
 }
@@ -51,14 +54,16 @@ export default function BlueprintGallery({ blueprintId }: BlueprintGalleryProps)
             const posts = await getPostsByBlueprint(blueprintId);
 
             const postImageData: PostImage[] = posts
-                .filter((post) => post.images && post.images.length > 0)
+                .map((post) => ({ post, cover: postCover(post) }))
+                .filter((p): p is { post: (typeof posts)[number]; cover: PostCover } => p.cover !== null)
                 .sort((a, b) => {
-                    const dateA = new Date(a.metadata?.createdAt || 0);
-                    const dateB = new Date(b.metadata?.createdAt || 0);
+                    const dateA = new Date(a.post.metadata?.createdAt || 0);
+                    const dateB = new Date(b.post.metadata?.createdAt || 0);
                     return dateB.getTime() - dateA.getTime();
                 })
-                .map((post) => ({
-                    imageUrl: post.images[0],
+                .map(({ post, cover }) => ({
+                    imageUrl: cover.url,
+                    isVideo: cover.isVideo,
                     postId: post._id,
                     postUserId: post.user._id,
                 }));
@@ -172,6 +177,11 @@ export default function BlueprintGallery({ blueprintId }: BlueprintGalleryProps)
                     cachePolicy="disk"
                     transition={100}
                 />
+                {item.isVideo && (
+                    <View style={styles.videoBadge} pointerEvents="none">
+                        <Play size={12} color="#fff" weight="fill" />
+                    </View>
+                )}
             </TouchableOpacity>
         );
     }, [deletingPosts]);
@@ -264,6 +274,17 @@ const stylesheet = (ThemedColor: any) =>
         galleryImage: {
             width: "100%",
             height: "100%",
+        },
+        videoBadge: {
+            position: "absolute",
+            top: 6,
+            right: 6,
+            width: 22,
+            height: 22,
+            borderRadius: 11,
+            backgroundColor: "rgba(0,0,0,0.55)",
+            alignItems: "center",
+            justifyContent: "center",
         },
         galleryContainer: {
             paddingBottom: 20,

--- a/frontend/components/profile/ProfileGallery.tsx
+++ b/frontend/components/profile/ProfileGallery.tsx
@@ -8,6 +8,8 @@ import CachedImage from "../CachedImage";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import CustomAlert, { AlertButton } from "@/components/modals/CustomAlert";
+import { postCover, type PostCover } from "@/utils/postMedia";
+import { Play } from "phosphor-react-native";
 
 export interface ProfileGalleryHandle {
     loadMore: () => void;
@@ -21,6 +23,7 @@ interface ProfileGalleryProps {
 
 interface PostImage {
     imageUrl: string;
+    isVideo: boolean;
     postId: string;
     postUserId: string;
 }
@@ -96,7 +99,7 @@ const EmptyGallery = ({ ThemedColor }: { ThemedColor: any }) => {
                 No Posts Yet
             </ThemedText>
             <ThemedText type="default" style={[styles.emptyDescription, { color: ThemedColor.caption }]}>
-                Posts with photos will appear here
+                Your posts will appear here
             </ThemedText>
         </View>
     );
@@ -122,20 +125,19 @@ const ProfileGalleryComponent = forwardRef<ProfileGalleryHandle, ProfileGalleryP
 
     const mapPostsToImages = (posts: any[], fallbackUserId?: string): PostImage[] =>
         posts
-            .filter((post) => post.images && post.images.length > 0)
+            .map((post) => ({ post, cover: postCover(post) }))
+            .filter((p): p is { post: any; cover: PostCover } => p.cover !== null)
             .sort((a, b) => {
-                const dateA = new Date(a.metadata?.createdAt || 0);
-                const dateB = new Date(b.metadata?.createdAt || 0);
+                const dateA = new Date(a.post.metadata?.createdAt || 0);
+                const dateB = new Date(b.post.metadata?.createdAt || 0);
                 return dateB.getTime() - dateA.getTime();
             })
-            .map((post) => {
-                const postUserId = post.user?._id || fallbackUserId || "";
-                return {
-                    imageUrl: post.images[0],
-                    postId: post._id,
-                    postUserId,
-                };
-            });
+            .map(({ post, cover }) => ({
+                imageUrl: cover.url,
+                isVideo: cover.isVideo,
+                postId: post._id,
+                postUserId: post.user?._id || fallbackUserId || "",
+            }));
 
     useEffect(() => {
         const fetchImages = async () => {
@@ -146,6 +148,7 @@ const ProfileGalleryComponent = forwardRef<ProfileGalleryHandle, ProfileGalleryP
             if (images && images.length > 0) {
                 const legacyImages = images.map((imageUrl, index) => ({
                     imageUrl,
+                    isVideo: false,
                     postId: `legacy-${index}`,
                     postUserId: "",
                 }));
@@ -358,6 +361,11 @@ const ProfileGalleryComponent = forwardRef<ProfileGalleryHandle, ProfileGalleryP
                                         cachePolicy="disk"
                                         transition={100}
                                     />
+                                    {item.isVideo && (
+                                        <View style={styles.videoBadge} pointerEvents="none">
+                                            <Play size={12} color="#fff" weight="fill" />
+                                        </View>
+                                    )}
                                 </TouchableOpacity>
                             );
                         })}
@@ -400,6 +408,17 @@ const styles = StyleSheet.create({
     },
     galleryImage: {
         aspectRatio: 1,
+    },
+    videoBadge: {
+        position: "absolute",
+        top: 6,
+        right: 6,
+        width: 22,
+        height: 22,
+        borderRadius: 11,
+        backgroundColor: "rgba(0,0,0,0.55)",
+        alignItems: "center",
+        justifyContent: "center",
     },
     deletingItem: {
         opacity: 0.5,

--- a/frontend/components/profile/song/ProfileSongWidget.tsx
+++ b/frontend/components/profile/song/ProfileSongWidget.tsx
@@ -1,15 +1,13 @@
 import React, { useState } from "react";
 import { View, TouchableOpacity, StyleSheet } from "react-native";
-import { Image } from "expo-image";
-import { useVideoPlayer, VideoView } from "expo-video";
 import { ThemedText } from "@/components/ThemedText";
 import { useThemeColor } from "@/hooks/useThemeColor";
-import { MusicNote, Play, Pause, PencilSimple, X } from "phosphor-react-native";
+import { MusicNote } from "phosphor-react-native";
 import { type Song } from "@/api/itunes";
 import { useAuth } from "@/hooks/useAuth";
 import { updateProfile } from "@/api/profile";
 import SongPickerModal from "./SongPickerModal";
-import Equalizer from "./Equalizer";
+import SongPreviewPill from "./SongPreviewPill";
 
 export default function ProfileSongWidget() {
     const ThemedColor = useThemeColor();
@@ -43,59 +41,6 @@ export default function ProfileSongWidget() {
     );
 }
 
-function SongPreviewPill({ song, onChange, onRemove }: { song: Song; onChange: () => void; onRemove: () => void }) {
-    const ThemedColor = useThemeColor();
-    const [playing, setPlaying] = useState(false);
-    const player = useVideoPlayer(song.previewUrl, (p) => {
-        p.loop = true;
-    });
-
-    const toggle = () => {
-        setPlaying((prev) => {
-            const next = !prev;
-            next ? player.play() : player.pause();
-            return next;
-        });
-    };
-
-    return (
-        <View style={[styles.pill, { backgroundColor: ThemedColor.lightenedCard }]}>
-            <TouchableOpacity onPress={toggle} activeOpacity={0.7} style={styles.pillMain}>
-                <View style={[styles.artwork, { backgroundColor: ThemedColor.lightened }]}>
-                    {song.artworkUrl ? (
-                        <Image source={{ uri: song.artworkUrl }} style={StyleSheet.absoluteFill} contentFit="cover" />
-                    ) : (
-                        <MusicNote size={16} color={ThemedColor.caption} weight="fill" />
-                    )}
-                    <View style={styles.playOverlay}>
-                        {playing ? (
-                            <Pause size={14} color="#fff" weight="fill" />
-                        ) : (
-                            <Play size={14} color="#fff" weight="fill" />
-                        )}
-                    </View>
-                </View>
-                <View style={styles.pillText}>
-                    <ThemedText type="smallerDefault" numberOfLines={1}>
-                        {song.title}
-                    </ThemedText>
-                    <ThemedText type="caption" numberOfLines={1}>
-                        {song.artist}
-                    </ThemedText>
-                </View>
-                {playing && <Equalizer playing color={ThemedColor.primary} size={14} />}
-            </TouchableOpacity>
-            <TouchableOpacity onPress={onChange} hitSlop={8} style={styles.iconBtn}>
-                <PencilSimple size={16} color={ThemedColor.caption} />
-            </TouchableOpacity>
-            <TouchableOpacity onPress={onRemove} hitSlop={8} style={styles.iconBtn}>
-                <X size={16} color={ThemedColor.caption} />
-            </TouchableOpacity>
-            <VideoView player={player} style={styles.hiddenVideo} />
-        </View>
-    );
-}
-
 const styles = StyleSheet.create({
     wrapper: {
         width: "100%",
@@ -106,44 +51,5 @@ const styles = StyleSheet.create({
         alignItems: "center",
         gap: 6,
         paddingVertical: 4,
-    },
-    pill: {
-        flexDirection: "row",
-        alignItems: "center",
-        borderRadius: 12,
-        padding: 8,
-        gap: 8,
-    },
-    pillMain: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: 10,
-        flex: 1,
-    },
-    artwork: {
-        width: 40,
-        height: 40,
-        borderRadius: 8,
-        overflow: "hidden",
-        alignItems: "center",
-        justifyContent: "center",
-    },
-    playOverlay: {
-        ...StyleSheet.absoluteFillObject,
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "rgba(0,0,0,0.25)",
-    },
-    pillText: {
-        flex: 1,
-    },
-    iconBtn: {
-        padding: 4,
-    },
-    hiddenVideo: {
-        width: 1,
-        height: 1,
-        opacity: 0,
-        position: "absolute",
     },
 });

--- a/frontend/components/profile/song/SongPreviewPill.tsx
+++ b/frontend/components/profile/song/SongPreviewPill.tsx
@@ -1,0 +1,119 @@
+import React, { useState } from "react";
+import { View, TouchableOpacity, StyleSheet } from "react-native";
+import { Image } from "expo-image";
+import { useVideoPlayer, VideoView } from "expo-video";
+import { ThemedText } from "@/components/ThemedText";
+import { useThemeColor } from "@/hooks/useThemeColor";
+import { MusicNote, Play, Pause, PencilSimple, X } from "phosphor-react-native";
+import { type Song } from "@/api/itunes";
+import Equalizer from "./Equalizer";
+
+// Tappable song pill with a 30s preview. Edit/remove controls only render when
+// their handlers are passed, so the same pill serves the editable own-profile
+// widget and the read-only display on other users' profiles.
+export default function SongPreviewPill({
+    song,
+    onChange,
+    onRemove,
+}: {
+    song: Song;
+    onChange?: () => void;
+    onRemove?: () => void;
+}) {
+    const ThemedColor = useThemeColor();
+    const [playing, setPlaying] = useState(false);
+    const player = useVideoPlayer(song.previewUrl, (p) => {
+        p.loop = true;
+    });
+
+    const toggle = () => {
+        setPlaying((prev) => {
+            const next = !prev;
+            next ? player.play() : player.pause();
+            return next;
+        });
+    };
+
+    return (
+        <View style={[styles.pill, { backgroundColor: ThemedColor.lightenedCard }]}>
+            <TouchableOpacity onPress={toggle} activeOpacity={0.7} style={styles.pillMain}>
+                <View style={[styles.artwork, { backgroundColor: ThemedColor.lightened }]}>
+                    {song.artworkUrl ? (
+                        <Image source={{ uri: song.artworkUrl }} style={StyleSheet.absoluteFill} contentFit="cover" />
+                    ) : (
+                        <MusicNote size={16} color={ThemedColor.caption} weight="fill" />
+                    )}
+                    <View style={styles.playOverlay}>
+                        {playing ? (
+                            <Pause size={14} color="#fff" weight="fill" />
+                        ) : (
+                            <Play size={14} color="#fff" weight="fill" />
+                        )}
+                    </View>
+                </View>
+                <View style={styles.pillText}>
+                    <ThemedText type="smallerDefault" numberOfLines={1}>
+                        {song.title}
+                    </ThemedText>
+                    <ThemedText type="caption" numberOfLines={1}>
+                        {song.artist}
+                    </ThemedText>
+                </View>
+                {playing && <Equalizer playing color={ThemedColor.primary} size={14} />}
+            </TouchableOpacity>
+            {onChange && (
+                <TouchableOpacity onPress={onChange} hitSlop={8} style={styles.iconBtn}>
+                    <PencilSimple size={16} color={ThemedColor.caption} />
+                </TouchableOpacity>
+            )}
+            {onRemove && (
+                <TouchableOpacity onPress={onRemove} hitSlop={8} style={styles.iconBtn}>
+                    <X size={16} color={ThemedColor.caption} />
+                </TouchableOpacity>
+            )}
+            <VideoView player={player} style={styles.hiddenVideo} />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    pill: {
+        flexDirection: "row",
+        alignItems: "center",
+        borderRadius: 12,
+        padding: 8,
+        gap: 8,
+    },
+    pillMain: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: 10,
+        flex: 1,
+    },
+    artwork: {
+        width: 40,
+        height: 40,
+        borderRadius: 8,
+        overflow: "hidden",
+        alignItems: "center",
+        justifyContent: "center",
+    },
+    playOverlay: {
+        ...StyleSheet.absoluteFillObject,
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "rgba(0,0,0,0.25)",
+    },
+    pillText: {
+        flex: 1,
+    },
+    iconBtn: {
+        padding: 4,
+    },
+    hiddenVideo: {
+        width: 1,
+        height: 1,
+        opacity: 0,
+        position: "absolute",
+    },
+});

--- a/frontend/hooks/useAnalyticsLayout.ts
+++ b/frontend/hooks/useAnalyticsLayout.ts
@@ -1,0 +1,61 @@
+import { useCallback } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAnalyticsLayout, saveAnalyticsLayout, AnalyticsLayout } from "@/api/analytics";
+import { WidgetId, DEFAULT_WIDGET_ORDER, sanitizeOrder, isWidgetId, moveItem } from "@/components/analytics/analyticsLayout";
+
+const queryKeyFor = (userId?: string) => ["analytics", "layout", userId ?? "anon"];
+
+/**
+ * Server-synced, reorderable widget layout (TanStack Query over the typed
+ * openapi-fetch client). The layout is persisted on the user so it follows them
+ * across devices and is shared across screens through one query cache —
+ * reordering in Edit shows up on the dashboard immediately. Falls back to the
+ * default order when nothing is saved.
+ */
+export function useAnalyticsLayout(userId?: string) {
+    const qc = useQueryClient();
+    const queryKey = queryKeyFor(userId);
+
+    const { data, isLoading } = useQuery({
+        queryKey,
+        queryFn: getAnalyticsLayout,
+        enabled: !!userId,
+        staleTime: 60_000,
+        placeholderData: { order: DEFAULT_WIDGET_ORDER, hidden: [] } as AnalyticsLayout,
+    });
+
+    const order = sanitizeOrder(data?.order);
+    const hidden = ((data?.hidden ?? []) as string[]).filter(isWidgetId);
+
+    const save = useMutation({ mutationFn: saveAnalyticsLayout });
+
+    const apply = useCallback(
+        (nextOrder: WidgetId[], nextHidden: WidgetId[]) => {
+            qc.setQueryData(queryKeyFor(userId), { order: nextOrder, hidden: nextHidden });
+            save.mutate({ order: nextOrder, hidden: nextHidden });
+        },
+        [qc, save, userId],
+    );
+
+    const moveWidget = useCallback((from: number, to: number) => apply(moveItem(order, from, to), hidden), [apply, order, hidden]);
+
+    const toggleHidden = useCallback(
+        (id: WidgetId) => apply(order, hidden.includes(id) ? hidden.filter((x) => x !== id) : [...hidden, id]),
+        [apply, order, hidden],
+    );
+
+    const addWidget = useCallback(
+        (id: WidgetId) => {
+            const nextOrder = order.includes(id) ? order : [...order, id];
+            apply(nextOrder, hidden.filter((x) => x !== id));
+        },
+        [apply, order, hidden],
+    );
+
+    const reset = useCallback(() => apply(DEFAULT_WIDGET_ORDER, []), [apply]);
+
+    const visible = order.filter((id) => !hidden.includes(id));
+    const isVisible = (id: WidgetId) => order.includes(id) && !hidden.includes(id);
+
+    return { order, hidden, visible, loaded: !isLoading, moveWidget, toggleHidden, addWidget, reset, isVisible };
+}

--- a/frontend/hooks/useEndOfDayCard.ts
+++ b/frontend/hooks/useEndOfDayCard.ts
@@ -3,9 +3,9 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { endOfDayDismissKey, isEndOfDayWindow } from "@/utils/endOfDay";
 
 /**
- * Card is visible from END_OF_DAY_HOUR until local midnight, unless dismissed
- * (or the review was completed) today. Re-checks every minute so the card
- * appears if the app stays open across the trigger hour.
+ * Card is visible from END_OF_DAY_HOUR (8PM) through 6AM the next morning,
+ * unless dismissed (or the review was completed) for that night. Re-checks
+ * every minute so the card appears if the app stays open across the trigger hour.
  */
 export const useEndOfDayCard = () => {
     // Start hidden until storage answers, so the card never flashes.

--- a/frontend/utils/endOfDay.ts
+++ b/frontend/utils/endOfDay.ts
@@ -1,17 +1,23 @@
-import { isSameDay, startOfDay } from "date-fns";
+import { isSameDay, startOfDay, subDays } from "date-fns";
 import type { Task } from "@/api/types";
 import type { BulkCompleteResult, LogTasksResult } from "@/api/task";
 
 export const END_OF_DAY_HOUR = 20;
+export const END_OF_DAY_END_HOUR = 6;
 
+// Window runs from 8PM through 6AM the next morning (spans midnight).
 export function isEndOfDayWindow(now: Date): boolean {
-    return true; // TEMP: force EOD card on for testing — revert to `now.getHours() >= END_OF_DAY_HOUR`
+    const hour = now.getHours();
+    return hour >= END_OF_DAY_HOUR || hour < END_OF_DAY_END_HOUR;
 }
 
 export function endOfDayDismissKey(now: Date): string {
-    const month = String(now.getMonth() + 1).padStart(2, "0");
-    const day = String(now.getDate()).padStart(2, "0");
-    return `eod-dismissed-${now.getFullYear()}-${month}-${day}`;
+    // Anchor to the evening the window opened so a review done at night stays
+    // dismissed through the post-midnight hours of the same window.
+    const anchor = now.getHours() < END_OF_DAY_END_HOUR ? subDays(now, 1) : now;
+    const month = String(anchor.getMonth() + 1).padStart(2, "0");
+    const day = String(anchor.getDate()).padStart(2, "0");
+    return `eod-dismissed-${anchor.getFullYear()}-${month}-${day}`;
 }
 
 // Open tasks worth reviewing tonight: starting today, due today, or overdue.

--- a/frontend/utils/postMedia.ts
+++ b/frontend/utils/postMedia.ts
@@ -1,0 +1,30 @@
+import type { MediaItem } from "@/api/media";
+
+export interface PostCover {
+    url: string;
+    isVideo: boolean;
+}
+
+// A post-like shape from the posts API. media[] is the source of truth (the
+// backend backfills it from images[]); images[] is the legacy fallback.
+interface CoverablePost {
+    media?: MediaItem[] | null;
+    images?: string[] | null;
+}
+
+// The grid cover is the first media item we can show as a still: videos render
+// their uploaded poster (thumbnailUrl), images render directly. A posterless
+// video is skipped so a later image can still cover the post.
+export function postCover(post: CoverablePost): PostCover | null {
+    for (const m of post.media ?? []) {
+        if (m.type === "video") {
+            if (m.thumbnailUrl) return { url: m.thumbnailUrl, isVideo: true };
+        } else if (m.url) {
+            return { url: m.url, isVideo: false };
+        }
+    }
+    if (post.images && post.images.length > 0) {
+        return { url: post.images[0], isVideo: false };
+    }
+    return null;
+}


### PR DESCRIPTION
## What

Snapshots in-flight work that was sitting **uncommitted in the local working tree** (not in any PR) so it isn't lost. This is a mixed snapshot — happy to split into focused PRs if preferred.

## Contents
- **Analytics / activity dashboard** — new widgets (BestTime, CompletionTrend, KudosEffect, SupportCoverage, TasksNeedingAttention, WeeklyReview, StatCards, DetailHeader, FriendView), charts (LineChart, BestTimeHeatmap, MonthHeatmap/StackedBand/StackedBar updates), `useAnalyticsLayout` hook, `analyticsLayout` rework, and new activity screens (`add-cards`, `habits`, `weekly-review`, `workspace/`, `insight/`, `category/`)
- **Tagged users** — `TaggedUsersChips` updates + test
- **End-of-day review** — sheet/card tweaks (`useEndOfDayCard`, `utils/endOfDay`) + test
- **Songs** — `SongPreviewPill`, `ProfileSongWidget` slimming
- **Backend** — `xsentry` middleware changes + test
- **Media** — `postMedia` util + test

## Notes
- Does **not** include the bottom-sheet double-padding fix — that's in #439.
- Base is `bfd29394`, already in `main` (merged via #438), so the diff is just this WIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)