### PR TITLE
fix(posts): never fail a post on malformed tags + bump to 1.0.5

### DIFF
--- a/backend/internal/handlers/post/post.go
+++ b/backend/internal/handlers/post/post.go
@@ -106,9 +106,10 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 
 	doc.Metadata.IsPublic = input.Body.IsPublic
 
-	// Collect tag candidates: explicit + encourager auto-tag.
+	// Collect tag candidates: explicit + encourager auto-tag. coerceMentions
+	// drops any malformed tag so a bad "@" can't fail the post.
 	var tagCandidates []primitive.ObjectID
-	for _, m := range input.Body.TaggedUsers {
+	for _, m := range coerceMentions(input.Body.TaggedUsers) {
 		if objID, err := primitive.ObjectIDFromHex(m.ID); err == nil {
 			tagCandidates = append(tagCandidates, objID)
 		}
@@ -123,6 +124,9 @@ func (h *Handler) CreatePostHuma(ctx context.Context, input *CreatePostInput) (*
 				tagCandidates = append(tagCandidates, e.Sender.ID)
 			}
 		}
+	}
+	if len(tagCandidates) > maxTaggedUsers {
+		tagCandidates = tagCandidates[:maxTaggedUsers] // cap fanout; we dropped the validate=max guard
 	}
 	if len(tagCandidates) > 0 {
 		resolved, resolveErr := h.service.ResolveTaggedUsers(ctx, userObjID, tagCandidates)

--- a/backend/internal/handlers/post/service.go
+++ b/backend/internal/handlers/post/service.go
@@ -306,10 +306,13 @@ func (s *Service) UpdatePartialPost(ctx context.Context, id primitive.ObjectID, 
 		}
 
 		var candidates []primitive.ObjectID
-		for _, m := range *updated.TaggedUsers {
+		for _, m := range coerceMentions(*updated.TaggedUsers) {
 			if objID, err := primitive.ObjectIDFromHex(m.ID); err == nil {
 				candidates = append(candidates, objID)
 			}
+		}
+		if len(candidates) > maxTaggedUsers {
+			candidates = candidates[:maxTaggedUsers] // cap fanout; we dropped the validate=max guard
 		}
 
 		resolved, err := s.ResolveTaggedUsers(ctx, existing.User.ID, candidates)

--- a/backend/internal/handlers/post/service_test.go
+++ b/backend/internal/handlers/post/service_test.go
@@ -1671,9 +1671,9 @@ func (s *PostServiceTestSuite) TestUpdatePost_NotifiesOnlyNewlyAddedTags() {
 	})
 
 	// Update with both f1 and f2.
-	newTags := []Post.MentionInput{
-		{ID: f1.ID.Hex(), Handle: f1.Handle},
-		{ID: f2.ID.Hex(), Handle: f2.Handle},
+	newTags := []any{
+		map[string]any{"id": f1.ID.Hex(), "handle": f1.Handle},
+		map[string]any{"id": f2.ID.Hex(), "handle": f2.Handle},
 	}
 	params := Post.UpdatePostParams{TaggedUsers: &newTags}
 	err = s.service.UpdatePartialPost(s.Ctx, post.ID, params)

--- a/backend/internal/handlers/post/types.go
+++ b/backend/internal/handlers/post/types.go
@@ -1,12 +1,44 @@
 package Post
 
 import (
+	"encoding/json"
+
 	"github.com/abhikaboy/Kindred/internal/handlers/encouragement"
 	"github.com/abhikaboy/Kindred/internal/handlers/notifications"
 	"github.com/abhikaboy/Kindred/internal/handlers/rings"
 	"github.com/abhikaboy/Kindred/internal/handlers/types"
 	"go.mongodb.org/mongo-driver/mongo"
 )
+
+// maxTaggedUsers caps tag fanout now that the validate=max guard is gone.
+const maxTaggedUsers = 20
+
+// coerceMentions best-effort parses a permissive tagged-user / mention array.
+// The field is typed `any` so no validation layer (Huma schema or go-playground)
+// can reject it: a non-array value yields nil, and malformed elements are
+// dropped. A bad "@" tag can never fail the whole request — bad entries are
+// simply stripped (the handler then ObjectID- and friend-gates what's left).
+func coerceMentions(v any) []MentionInput {
+	if v == nil {
+		return nil
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	var raw []json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil // not an array → drop the whole thing
+	}
+	out := make([]MentionInput, 0, len(raw))
+	for _, r := range raw {
+		var mi MentionInput
+		if err := json.Unmarshal(r, &mi); err == nil {
+			out = append(out, mi)
+		}
+	}
+	return out
+}
 
 // Create Post
 type CreatePostInput struct {
@@ -46,8 +78,11 @@ type CreatePostParams struct {
 	BlueprintIsPublic *bool                            `json:"blueprintIsPublic,omitempty"`
 	Groups            []string                         `json:"groups,omitempty" validate:"omitempty,dive,len=24"`
 	IsPublic          bool                             `json:"isPublic"`
-	TaggedUsers       []MentionInput                   `json:"taggedUsers,omitempty" validate:"omitempty,max=20,dive"`
-	Song              *types.Song                      `json:"song,omitempty"`
+	// Permissive on purpose: malformed tags (a bare "@", missing fields, wrong
+	// types, a non-array) are dropped via coerceMentions instead of failing the
+	// post. Shape is [{id, handle}]; the handler ObjectID- and friend-gates.
+	TaggedUsers any         `json:"taggedUsers,omitempty" doc:"Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected"`
+	Song        *types.Song `json:"song,omitempty"`
 }
 
 // Get Posts (all)
@@ -166,10 +201,12 @@ type UpdatePostOutput struct {
 }
 
 type UpdatePostParams struct {
-	Caption     *string          `json:"caption,omitempty"`
-	IsPublic    *bool            `json:"isPublic,omitempty"`
-	Size        *types.ImageSize `json:"size,omitempty"`
-	TaggedUsers *[]MentionInput  `json:"taggedUsers,omitempty" validate:"omitempty,max=20,dive"`
+	Caption  *string          `json:"caption,omitempty"`
+	IsPublic *bool            `json:"isPublic,omitempty"`
+	Size     *types.ImageSize `json:"size,omitempty"`
+	// Pointer so absent vs. provided is distinguishable; element type is `any`
+	// so malformed tags are dropped (coerceMentions), never rejected.
+	TaggedUsers *[]any `json:"taggedUsers,omitempty" doc:"Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected"`
 }
 
 // Get User Groups (for posts)

--- a/backend/internal/handlers/post/validation_test.go
+++ b/backend/internal/handlers/post/validation_test.go
@@ -1,0 +1,40 @@
+package Post
+
+import "testing"
+
+// Malformed tagged-user input must be dropped, never error — a bad "@" (or any
+// garbage) can't be allowed to fail a post. coerceMentions keeps only the
+// object-shaped {id, handle} entries; the handler then ObjectID/friend-gates.
+func TestCoerceMentions_DropsMalformed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   any
+		want int
+	}{
+		{"nil", nil, 0},
+		{"not an array (string)", "@", 0},
+		{"not an array (number)", 42, 0},
+		{"empty array", []any{}, 0},
+		{
+			"mixed garbage + one valid",
+			[]any{
+				map[string]any{"id": "", "handle": ""},   // bare "@" with nothing picked
+				map[string]any{"id": "@", "handle": "@"}, // garbage strings (kept; handler drops bad ObjectID)
+				map[string]any{"id": float64(123)},       // wrong type → dropped
+				"loose string",                           // not an object → dropped
+				42,                                       // not an object → dropped
+				map[string]any{"id": "507f1f77bcf86cd799439011", "handle": "real"},
+			},
+			3, // the two string-shaped objects + the valid one survive coercion
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := coerceMentions(c.in)
+			if len(got) != c.want {
+				t.Fatalf("coerceMentions(%v) kept %d, want %d (%v)", c.in, len(got), c.want, got)
+			}
+		})
+	}
+}

--- a/frontend/api/api-spec.yaml
+++ b/frontend/api/api-spec.yaml
@@ -9520,9 +9520,7 @@ components:
                 song:
                     $ref: '#/components/schemas/Song'
                 taggedUsers:
-                    type: array
-                    items:
-                        $ref: '#/components/schemas/MentionInput'
+                    description: Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected
                 task:
                     $ref: '#/components/schemas/PostTaskExtendedReference'
             required:
@@ -14597,8 +14595,8 @@ components:
                     $ref: '#/components/schemas/ImageSize'
                 taggedUsers:
                     type: array
-                    items:
-                        $ref: '#/components/schemas/MentionInput'
+                    description: Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected
+                    items: {}
         UpdateProfileDocument:
             type: object
             additionalProperties: false

--- a/frontend/api/generated/types.ts
+++ b/frontend/api/generated/types.ts
@@ -4895,7 +4895,8 @@ export interface components {
             media?: components["schemas"]["MediaItemInput"][];
             size?: components["schemas"]["ImageSize"];
             song?: components["schemas"]["Song"];
-            taggedUsers?: components["schemas"]["MentionInput"][];
+            /** @description Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected */
+            taggedUsers?: unknown;
             task?: components["schemas"]["PostTaskExtendedReference"];
         };
         CreateTaskNaturalLanguageInputBody: {
@@ -7732,7 +7733,8 @@ export interface components {
             caption?: string;
             isPublic?: boolean;
             size?: components["schemas"]["ImageSize"];
-            taggedUsers?: components["schemas"]["MentionInput"][];
+            /** @description Tagged user references as [{id, handle}]; malformed entries are dropped, never rejected */
+            taggedUsers?: unknown[];
         };
         UpdateProfileDocument: {
             /**

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Kindred",
     "slug": "Kindred",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "kindred",

--- a/frontend/ios/Kindred/Info.plist
+++ b/frontend/ios/Kindred/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>1.0.4</string>
+    <string>1.0.5</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>
@@ -36,7 +36,7 @@
       </dict>
     </array>
     <key>CFBundleVersion</key>
-    <string>120</string>
+    <string>121</string>
     <key>ExpoWidgetsAppGroupIdentifier</key>
     <string>group.com.kindred.kindredtsl</string>
     <key>ExpoWidgets_EnablePushNotifications</key>


### PR DESCRIPTION
## Bug
Typing a bare `@` (or any empty/garbage tagged user) **400'd post creation**. `CreatePostHuma` runs go-playground validation, and `TaggedUsers` used `validate:"...,dive"` into `MentionInput`'s required `id`/`handle` — so a single malformed entry rejected the entire post.

## Fix
Make the tagged-user arrays **permissive** (`any` / `*[]any`) on create and update so *no* validation layer (Huma schema **or** go-playground) can reject them, then parse best-effort via `coerceMentions`:
- a non-array value → dropped whole
- malformed elements (missing/empty/wrong-type fields, non-objects) → dropped individually

The handler was already fully resilient — it skips non-ObjectID IDs, friend-gates, and **re-fetches canonical handles from the DB** (the input handle is never trusted). Added a `maxTaggedUsers` (20) cap to bound notification fanout now that the `validate=max` guard is gone. Comment mentions were already lenient (no validate gate + skip invalid IDs).

Net: improper tags are silently stripped, never fatal.

## Also
- Bumps app version **1.0.4 → 1.0.5** (`app.json`), iOS `CFBundleShortVersionString` 1.0.5 / `CFBundleVersion` **120 → 121**.
- Regenerated `api-spec.yaml` + `types.ts` (`taggedUsers` → permissive).

## Tests
- New `TestCoerceMentions_DropsMalformed`: nil, non-array, empty, and a mixed garbage+valid array all coerce correctly.
- `go test -short -race ./internal/handlers/post/` passes; frontend `tsc` unchanged (14 pre-existing DatePager errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)