### PR TITLE
feat(tasks): @-mention autocomplete in the task-create name field

### DIFF
--- a/frontend/components/inputs/LongTextInput.tsx
+++ b/frontend/components/inputs/LongTextInput.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, TextInput, View, NativeSyntheticEvent, TextInputSelectionChangeEventData } from "react-native";
+import { StyleSheet, TextInput, View, NativeSyntheticEvent, TextInputSelectionChangeEventData, TextStyle } from "react-native";
 import { useThemeColor } from "@/hooks/useThemeColor";
 
 type Props = {
@@ -9,6 +9,8 @@ type Props = {
     onBlur?: () => void;
     minHeight?: number;
     fontSize?: number;
+    fontWeight?: TextStyle["fontWeight"];
+    autoFocus?: boolean;
     onSelectionChange?: (e: NativeSyntheticEvent<TextInputSelectionChangeEventData>) => void;
 };
 
@@ -19,6 +21,8 @@ const LongTextInput = ({
     onBlur,
     minHeight = 100,
     fontSize = 16,
+    fontWeight = "400",
+    autoFocus,
     onSelectionChange,
 }: Props) => {
     const ThemedColor = useThemeColor();
@@ -30,6 +34,7 @@ const LongTextInput = ({
                 placeholderTextColor={ThemedColor.ghost}
                 multiline={true}
                 numberOfLines={6}
+                autoFocus={autoFocus}
                 value={value}
                 onChangeText={setValue}
                 onBlur={onBlur}
@@ -39,7 +44,7 @@ const LongTextInput = ({
                     color: ThemedColor.text,
                     fontSize: fontSize,
                     fontFamily: "Outfit",
-                    fontWeight: "400",
+                    fontWeight: fontWeight,
                     lineHeight: fontSize * 1.5,
                     padding: 0,
                     margin: 0,

--- a/frontend/components/inputs/MentionTextInput.tsx
+++ b/frontend/components/inputs/MentionTextInput.tsx
@@ -12,6 +12,8 @@ type Props = {
     placeholder?: string;
     fontSize?: number;
     minHeight?: number;
+    fontWeight?: import("react-native").TextStyle["fontWeight"];
+    autoFocus?: boolean;
 };
 
 const GAP = 4;
@@ -23,6 +25,8 @@ const MentionTextInput = ({
     placeholder,
     fontSize = 16,
     minHeight,
+    fontWeight = "400",
+    autoFocus,
 }: Props) => {
     const { query, caret, onChange, onSelection, onPick } = useMentionTrigger(value, setValue);
     const { height: windowHeight } = useWindowDimensions();
@@ -68,6 +72,8 @@ const MentionTextInput = ({
                 placeholder={placeholder}
                 fontSize={fontSize}
                 minHeight={minHeight}
+                fontWeight={fontWeight}
+                autoFocus={autoFocus}
                 onSelectionChange={onSelection}
             />
             {/* Hidden mirror: matches the input's text layout so its height = bottom Y of the caret's line. */}
@@ -84,7 +90,7 @@ const MentionTextInput = ({
                     zIndex: -1,
                     fontSize,
                     fontFamily: "Outfit",
-                    fontWeight: "400",
+                    fontWeight,
                     lineHeight,
                 }}>
                 {value.slice(0, caret) || " "}

--- a/frontend/components/modals/create/Standard.tsx
+++ b/frontend/components/modals/create/Standard.tsx
@@ -1,6 +1,7 @@
-import { Dimensions, Keyboard, ScrollView, StyleSheet, TextInput, TouchableOpacity, View } from "react-native";
+import { Dimensions, ScrollView, StyleSheet, TouchableOpacity, View } from "react-native";
 import React, { useState, useEffect, useMemo } from "react";
-import ThemedInput from "../../inputs/ThemedInput";
+import MentionTextInput from "../../inputs/MentionTextInput";
+import type { MentionCandidate } from "@/hooks/useFriendsForMention";
 import Dropdown from "../../inputs/Dropdown";
 import { useRequest } from "@/hooks/useRequest";
 import { useTasks } from "@/contexts/tasksContext";
@@ -15,7 +16,6 @@ import AdvancedOption from "./AdvancedOption";
 import { useThemeColor } from "@/hooks/useThemeColor";
 import { CaretUp, CaretDown, Eye, EyeSlash, Flag, Barbell, WarningCircle, Plugs } from "phosphor-react-native";
 import Popover from "react-native-popover-view";
-import { BottomSheetTextInput } from "@gorhom/bottom-sheet";
 import type { components } from "@/api/generated/types";
 import { updateTaskAPI, updateTemplateAPI, respondToTaskTagAPI } from "@/api/task";
 import { ObjectId } from "bson";
@@ -41,7 +41,6 @@ type Props = {
 };
 
 const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = false }: Props) => {
-    const nameRef = React.useRef<TextInput>(null);
     const { request } = useRequest();
     const { categories, addToCategory, updateTask, removeFromCategory, selectedCategory, setCreateCategory, task } = useTasks();
     const { addTaskToBlueprintCategory, blueprintCategories } = useBlueprints();
@@ -77,6 +76,7 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
         isBlueprint: isBlueprintState,
         setIsBlueprint,
         taggedUsers,
+        setTaggedUsers,
         notes,
         checklist,
         copySourceTaskId,
@@ -493,32 +493,20 @@ const Standard = ({ hide, goTo, edit = false, categoryId, screen, isBlueprint = 
                     <ThemedText type="lightBody">{edit ? "Update" : "Create"}</ThemedText>
                 </TouchableOpacity>
             </View>
-            <View onStartShouldSetResponder={() => true}>
-                <ThemedInput
-                    ghost
-                    autofocus={taskName.length === 0}
-                    ref={nameRef as React.Ref<React.ElementRef<typeof BottomSheetTextInput>>}
-                    placeHolder="Enter the Task Name"
-                    textArea
-                    onSubmit={() => {
-                        if (!selectedCategory?.id) return;
-                        createPost();
-                        hide();
-                    }}
-                    onBlur={() => {
-                        nameRef.current?.blur();
-                        Keyboard.dismiss();
-                    }}
-                    onChangeText={(text) => {
-                        setTaskName(text);
-                    }}
+            <View onStartShouldSetResponder={() => true} style={{ zIndex: 1000 }}>
+                <MentionTextInput
+                    placeholder="Enter the Task Name"
                     value={taskName}
                     setValue={setTaskName}
-                    textStyle={{
-                        fontSize: 24,
-                        fontFamily: "Outfit",
-                        fontWeight: 500,
-                        letterSpacing: -0.2,
+                    fontSize={24}
+                    fontWeight={500}
+                    autoFocus={taskName.length === 0}
+                    onMentionPicked={(c: MentionCandidate) => {
+                        if (taggedUsers.find((u) => u.id === c.id)) return;
+                        setTaggedUsers([
+                            ...taggedUsers,
+                            { id: c.id, handle: c.handle, display_name: c.display_name, profile_picture: c.profile_picture },
+                        ]);
                     }}
                 />
             </View>


### PR DESCRIPTION
## What
Brings `@`-mention tagging into the **task creation/edit** name field. Typing `@` in the task name now surfaces the friend autocomplete and adds the picked user to `taggedUsers`.

- `create/Standard.tsx`: replace `ThemedInput` with `MentionTextInput` for the name field; wire `onMentionPicked` → `setTaggedUsers` (deduped).
- `MentionTextInput.tsx` / `LongTextInput.tsx`: add optional `fontWeight` and `autoFocus` props so the name field keeps its large (24px / weight 500) styling and autofocus-on-empty behavior.

## Note
This is the remaining un-merged work from the working tree — the tagged-`@` backend fix + version bump (#441) and the bottom-sheet padding fix (#439) already merged to main, so this PR contains only the mention-input/create-modal changes.

⚠️ The swap drops the old name field's `onSubmit` (submit-to-create) and `onBlur` (dismiss keyboard) handlers, since `MentionTextInput` doesn't expose them. Worth confirming that's intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)